### PR TITLE
Enable our SpannerConnectionFactory for driver name 'spanner'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <r2dbc.version>1.0.0.M7</r2dbc.version>
+    <reactor.version>Californium-SR6</reactor.version>
   </properties>
 
 
@@ -23,6 +24,11 @@
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-spi</artifactId>
       <version>${r2dbc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
     </dependency>
 
     <!-- test dependencies -->
@@ -40,6 +46,18 @@
     </dependency>
 
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-bom</artifactId>
+        <version>${reactor.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+
+import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
@@ -28,6 +31,9 @@ import io.r2dbc.spi.ConnectionFactoryProvider;
  */
 public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvider {
 
+  /** R2DBC driver name for Google Cloud Spanner. */
+  public static final String DRIVER_NAME = "spanner";
+
   @Override
   public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
     return new SpannerConnectionFactory();
@@ -35,6 +41,9 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
   @Override
   public boolean supports(ConnectionFactoryOptions connectionFactoryOptions) {
-    return false;
+    Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
+    String driver = connectionFactoryOptions.getValue(DRIVER);
+
+    return DRIVER_NAME.equals(driver);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/Assert.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/Assert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.util;
+
+import javax.annotation.Nullable;
+
+/**
+ * Lightweight assertion support.
+ */
+public class Assert {
+
+  // static methods only; no instantiation.
+  private Assert() {}
+
+  /**
+   * Checks that a specified object reference is not {@code null} and throws a customized
+   * {@link IllegalArgumentException} if it is.
+   *
+   * @param o       the object reference to check for nullity
+   * @param message informative message to be used in the event that an
+   * {@link IllegalArgumentException} is thrown
+   * @throws IllegalArgumentException if {@code o} is {@code null}
+   */
+  public static void requireNonNull(@Nullable Object o, String message) {
+    if (o == null) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+}

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/Assert.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/Assert.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc.util;
 
-import javax.annotation.Nullable;
+import reactor.util.annotation.Nullable;
 
 /**
  * Lightweight assertion support.

--- a/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
+++ b/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
@@ -1,0 +1,1 @@
+com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -16,8 +16,13 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import io.r2dbc.spi.ConnectionFactory;
-import org.assertj.core.api.Assertions;
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.Test;
 
 /**
@@ -32,6 +37,44 @@ public class SpannerConnectionFactoryProviderTest {
     ConnectionFactory spannerConnectionFactory = spannerConnectionFactoryProvider
         .create(null);
 
-    Assertions.assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isNotNull();
+  }
+
+  @Test
+  public void testSupportsThrowsExceptionOnNullOptions() {
+    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
+        new SpannerConnectionFactoryProvider();
+    assertThatThrownBy(() -> {
+      spannerConnectionFactoryProvider.supports(null);
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("connectionFactoryOptions must not be null");
+  }
+
+  @Test
+  public void testSupportsReturnsFalseWhenNoDriverInOptions() {
+    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
+        new SpannerConnectionFactoryProvider();
+    assertFalse(spannerConnectionFactoryProvider.supports(
+        ConnectionFactoryOptions.builder().build()));
+  }
+
+  @Test
+  public void testSupportsReturnsFalseWhenWrongDriverInOptions() {
+    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
+        new SpannerConnectionFactoryProvider();
+    assertFalse(spannerConnectionFactoryProvider.supports(buildOptions("not spanner")));
+  }
+
+  @Test
+  public void testSupportsReturnsTrueWhenCorrectDriverInOptions() {
+    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
+        new SpannerConnectionFactoryProvider();
+    assertTrue(spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
+  }
+
+  private static ConnectionFactoryOptions buildOptions(String driverName) {
+    return ConnectionFactoryOptions.builder()
+        .option(ConnectionFactoryOptions.DRIVER, driverName)
+        .build();
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.Test;
@@ -70,6 +72,16 @@ public class SpannerConnectionFactoryProviderTest {
     SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
         new SpannerConnectionFactoryProvider();
     assertTrue(spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
+  }
+
+  @Test
+  public void testR2dbcFindsSpannerConnectionFactoryProvider() {
+    ConnectionFactory connectionFactory =
+        ConnectionFactories.get(ConnectionFactoryOptions.builder()
+            .option(DRIVER, "spanner")
+            .build());
+
+    assertThat(connectionFactory).isInstanceOf(SpannerConnectionFactory.class);
   }
 
   private static ConnectionFactoryOptions buildOptions(String driverName) {

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Assert}.
+ */
+public class AssertTest {
+
+  @Test
+  public void assertNotNullThrowsExceptionWhenNull() {
+    assertThatThrownBy(() -> {
+      Assert.requireNonNull(null, "oh no");
+    }).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("oh no");
+  }
+
+  @Test
+  public void assertNotNullNoopWhenNotNull() {
+    Assert.requireNonNull("definitely not null", "oh no");
+  }
+
+}


### PR DESCRIPTION
Nothing else would work unless factory discovery file is in META-INF, and `SpannerConnectionFactoryProvider` returns true, so this was the first step. The remaining boilerplate from the WIP will follow.

Also:
* added dependency on Project Reactor.
* added Assert class for very basic argument checking. Would be nice to not duplicate this in every driver, but Spring is too heavy of a required dependency. Guava may be appropriate if we need anything more complex.