### PR TITLE
Switch to gRPC client for Cloud Spanner

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring
+-DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <r2dbc.version>1.0.0.M7</r2dbc.version>
     <reactor.version>Californium-SR6</reactor.version>
-    <spanner-client.version>1.11.0</spanner-client.version>
+    <google-cloud-java.version>0.90.0-alpha</google-cloud-java.version>
+    <google-auth.version>0.11.0</google-auth.version>
+    <grpc.version>1.20.0</grpc.version>
   </properties>
 
 
@@ -34,9 +36,20 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner</artifactId>
-      <version>${spanner-client.version}</version>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-spanner-v1</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>${google-auth.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -61,6 +74,13 @@
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-bom</artifactId>
         <version>${reactor.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>${google-cloud-java.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.client;
+
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.PartialResultSet;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+/**
+ * An abstraction that wraps interaction with the Cloud Spanner Database APIs.
+ */
+public interface Client {
+
+  /**
+   * Release any resources held by the {@link Client}.
+   *
+   * @return a {@link Mono} that indicates that a client has been closed
+   */
+  Mono<Void> close();
+
+  /**
+   * Execute a streaming query and get partial results.
+   */
+  Publisher<PartialResultSet> executeStreamingSql(ExecuteSqlRequest request);
+
+}

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -37,6 +37,7 @@ import reactor.core.publisher.Mono;
  */
 public class GrpcClient implements Client {
 
+  public static final String HOST = "spanner.googleapis.com";
   public static final int PORT = 443;
 
   private final SpannerStub spanner;
@@ -47,7 +48,7 @@ public class GrpcClient implements Client {
   public GrpcClient() throws IOException {
     // Create a channel
     ManagedChannel channel = ManagedChannelBuilder
-        .forAddress("spanner.googleapis.com", PORT)
+        .forAddress(HOST, PORT)
         .build();
 
     // Create blocking and async stubs using the channel

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.client;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.SpannerGrpc;
+import com.google.spanner.v1.SpannerGrpc.SpannerStub;
+import io.grpc.CallCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.auth.MoreCallCredentials;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import java.io.IOException;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Mono;
+
+/**
+ * gRPC-based {@link Client} implementation.
+ */
+public class GrpcClient implements Client {
+
+  public static final int PORT = 443;
+
+  private final SpannerStub spanner;
+
+  /**
+   * Initializes the Cloud Spanner gRPC async stub.
+   */
+  public GrpcClient() throws IOException {
+    // Create a channel
+    ManagedChannel channel = ManagedChannelBuilder
+        .forAddress("spanner.googleapis.com", PORT)
+        .build();
+
+    // Create blocking and async stubs using the channel
+    CallCredentials callCredentials = MoreCallCredentials
+        .from(GoogleCredentials.getApplicationDefault());
+
+    // Create the asynchronous stub for Cloud Spanner
+    this.spanner = SpannerGrpc.newStub(channel)
+        .withCallCredentials(callCredentials);
+  }
+
+  @Override
+  public Mono<Void> close() {
+    return null;
+  }
+
+  @Override
+  public Publisher<PartialResultSet> executeStreamingSql(ExecuteSqlRequest request) {
+    return subscriber -> spanner.executeStreamingSql(request,
+        new ClientResponseObserver<ExecuteSqlRequest, PartialResultSet>() {
+          @Override
+          public void beforeStart(
+              ClientCallStreamObserver<ExecuteSqlRequest> clientCallStreamObserver) {
+
+            clientCallStreamObserver.disableAutoInboundFlowControl();
+
+            subscriber.onSubscribe(new Subscription() {
+              @Override
+              public void request(long l) {
+                clientCallStreamObserver.request((int) l);
+              }
+
+              @Override
+              public void cancel() {
+                clientCallStreamObserver.cancel(null, null);
+              }
+            });
+          }
+
+          @Override
+          public void onNext(PartialResultSet partialResultSet) {
+            subscriber.onNext(partialResultSet);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            subscriber.onError(throwable);
+          }
+
+          @Override
+          public void onCompleted() {
+            subscriber.onComplete();
+          }
+        });
+
+  }
+}


### PR DESCRIPTION
Also introduces the Client abstraction to hide interactions with the
gRPC Spanner service, and implements the basic executeStreamingSql
method wrapping the result into a Reactive Streams
Publisher<PartialResultSet>.