### PR TITLE
Change ExecuteStreamingSql style to use Flux.create

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -29,7 +29,7 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import java.io.IOException;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -67,42 +67,30 @@ public class GrpcClient implements Client {
 
   @Override
   public Publisher<PartialResultSet> executeStreamingSql(ExecuteSqlRequest request) {
-    return subscriber -> spanner.executeStreamingSql(request,
-        new ClientResponseObserver<ExecuteSqlRequest, PartialResultSet>() {
-          @Override
-          public void beforeStart(
-              ClientCallStreamObserver<ExecuteSqlRequest> clientCallStreamObserver) {
+    return Flux.create(sink -> {
+      ClientResponseObserver<ExecuteSqlRequest, PartialResultSet> clientResponseObserver =
+          new ClientResponseObserver<ExecuteSqlRequest, PartialResultSet>() {
+            @Override
+            public void onNext(PartialResultSet value) {
+              sink.next(value);
+            }
 
-            clientCallStreamObserver.disableAutoInboundFlowControl();
+            @Override
+            public void onError(Throwable t) {
+              sink.error(t);
+            }
 
-            subscriber.onSubscribe(new Subscription() {
-              @Override
-              public void request(long l) {
-                clientCallStreamObserver.request((int) l);
-              }
+            @Override
+            public void onCompleted() {
+              sink.complete();
+            }
 
-              @Override
-              public void cancel() {
-                clientCallStreamObserver.cancel(null, null);
-              }
-            });
-          }
-
-          @Override
-          public void onNext(PartialResultSet partialResultSet) {
-            subscriber.onNext(partialResultSet);
-          }
-
-          @Override
-          public void onError(Throwable throwable) {
-            subscriber.onError(throwable);
-          }
-
-          @Override
-          public void onCompleted() {
-            subscriber.onComplete();
-          }
-        });
-
+            @Override
+            public void beforeStart(ClientCallStreamObserver<ExecuteSqlRequest> requestStream) {
+              requestStream.disableAutoInboundFlowControl();
+            }
+          };
+      this.spanner.executeStreamingSql(request, clientResponseObserver);
+    });
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -88,6 +88,8 @@ public class GrpcClient implements Client {
             @Override
             public void beforeStart(ClientCallStreamObserver<ExecuteSqlRequest> requestStream) {
               requestStream.disableAutoInboundFlowControl();
+              sink.onRequest(demand -> requestStream.request((int) demand));
+              sink.onCancel(() -> requestStream.cancel(null, null));
             }
           };
       this.spanner.executeStreamingSql(request, clientResponseObserver);


### PR DESCRIPTION
As per [Mark's comment](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/pull/23#discussion_r281350638), modifies the executeStreamingSql method to use `Flux.create` instead of creating Publisher manually.