### PR TITLE
create R2DBC connection as a Spanner session created over gRPC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,11 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <r2dbc.version>1.0.0.M7</r2dbc.version>
     <reactor.version>Californium-SR6</reactor.version>
-    <google-cloud-java.version>0.90.0-alpha</google-cloud-java.version>
-    <google-auth.version>0.11.0</google-auth.version>
+    <google-auth.version>0.15.0</google-auth.version>
     <grpc.version>1.20.0</grpc.version>
+    <mockito.version>2.23.0</mockito.version>
+    <grpc-spanner.version>1.17.0</grpc-spanner.version>
+    <google-cloud-core.version>1.72.0</google-cloud-core.version>
   </properties>
 
 
@@ -38,6 +40,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-spanner-v1</artifactId>
+      <version>${grpc-spanner.version}</version>
     </dependency>
 
     <dependency>
@@ -49,7 +52,11 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-auth</artifactId>
-      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
     </dependency>
 
     <!-- test dependencies -->
@@ -65,22 +72,38 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- TODO: this is a test dependency for now. Should project ID discovery be part of the driver itself? -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <version>${google-cloud-core.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-bom</artifactId>
         <version>${reactor.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bom</artifactId>
-        <version>${google-cloud-java.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -23,14 +23,13 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Mono;
 
 /**
  * {@link Connection} implementation for Cloud Spanner.
  */
 public class SpannerConnection implements Connection {
 
-  private Mono<Session> session;
+  private Session session;
 
   private Client client;
 
@@ -39,7 +38,7 @@ public class SpannerConnection implements Connection {
    * @param client client controlling low-level Spanner operations
    * @param session Spanner session to use for all interactions on this connection.
    */
-  public SpannerConnection(Client client, Mono<Session> session) {
+  public SpannerConnection(Client client, Session session) {
 
     this.client = client;
 
@@ -86,7 +85,12 @@ public class SpannerConnection implements Connection {
     return null;
   }
 
-  public Mono<String> getSessionName() {
-    return this.session.map(s -> s.getName());
+  /**
+   * Returns the Spanner session associated with the current {@link Connection}.
+   * @return spanner session proto
+   */
+  public Session getSession() {
+    return this.session;
   }
+
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -16,16 +16,38 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import com.google.cloud.spanner.r2dbc.client.Client;
+import com.google.spanner.v1.Session;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 /**
  * {@link Connection} implementation for Cloud Spanner.
  */
 public class SpannerConnection implements Connection {
+
+  private SpannerConnectionConfiguration config;
+
+  private Mono<Session> session;
+
+  private Client client;
+
+  /**
+   * Instantiates a Spanner session with given configuration.
+   * @param client client controlling low-level Spanner operations
+   * @param config database connection settings
+   */
+  public SpannerConnection(Client client, SpannerConnectionConfiguration config) {
+    this.config = config;
+
+    this.client = client;
+
+    this.session = this.client.createSession(config.getFullyQualifiedDatabaseName());
+  }
 
   public Publisher<Void> beginTransaction() {
     return null;
@@ -65,5 +87,9 @@ public class SpannerConnection implements Connection {
 
   public Publisher<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
     return null;
+  }
+
+  public Mono<String> getSessionName() {
+    return this.session.map(s -> s.getName());
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -30,8 +30,6 @@ import reactor.core.publisher.Mono;
  */
 public class SpannerConnection implements Connection {
 
-  private SpannerConnectionConfiguration config;
-
   private Mono<Session> session;
 
   private Client client;
@@ -39,14 +37,13 @@ public class SpannerConnection implements Connection {
   /**
    * Instantiates a Spanner session with given configuration.
    * @param client client controlling low-level Spanner operations
-   * @param config database connection settings
+   * @param session Spanner session to use for all interactions on this connection.
    */
-  public SpannerConnection(Client client, SpannerConnectionConfiguration config) {
-    this.config = config;
+  public SpannerConnection(Client client, Mono<Session> session) {
 
     this.client = client;
 
-    this.session = this.client.createSession(config.getFullyQualifiedDatabaseName());
+    this.session = session;
   }
 
   public Publisher<Void> beginTransaction() {

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -23,20 +23,25 @@ import com.google.cloud.spanner.r2dbc.util.Assert;
  */
 public class SpannerConnectionConfiguration {
 
-  private String projectId;
+  private static final String FULLY_QUALIFIED_DB_NAME_PATTERN
+      = "projects/%s/instances/%s/databases/%s";
 
-  private String instanceName;
+  private final String projectId;
 
-  private String databaseName;
+  private final String instanceName;
+
+  private final String databaseName;
+
+  private final String fullyQualifiedDbName;
 
   /**
    * Basic property initializing constructor.
    *
+   * @param projectId GCP project that contains the database.
    * @param instanceName instance to connect to
    * @param databaseName database to connect to.
    */
-  // TODO: set up builder.
-  public SpannerConnectionConfiguration(
+  private SpannerConnectionConfiguration(
       String projectId, String instanceName, String databaseName) {
     this.projectId
         = Assert.requireNonNull(projectId, "projectId must not be null");
@@ -44,6 +49,9 @@ public class SpannerConnectionConfiguration {
         = Assert.requireNonNull(instanceName, "instanceName must not be null");
     this.databaseName
         = Assert.requireNonNull(databaseName, "databaseName must not be null");
+
+    this.fullyQualifiedDbName = String.format(
+        FULLY_QUALIFIED_DB_NAME_PATTERN, this.projectId, this.instanceName, this.databaseName);
   }
 
   public String getInstanceName() {
@@ -59,16 +67,41 @@ public class SpannerConnectionConfiguration {
   }
 
   /**
-   * Formats configuration properties into a fully qualified database name.
+   * Turns configuration properties into a fully qualified database name.
    * @return fully qualified database name
    */
   public String getFullyQualifiedDatabaseName() {
-    return "projects/"
-        + this.projectId
-        + "/instances/"
-        + this.instanceName
-        + "/databases/"
-        + this.databaseName;
+    return this.fullyQualifiedDbName;
+  }
+
+  public static class Builder {
+
+    private String projectId;
+
+    private String instanceName;
+
+    private String databaseName;
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder setInstanceName(String instanceName) {
+      this.instanceName = instanceName;
+      return this;
+    }
+
+    public Builder setDatabaseName(String databaseName) {
+      this.databaseName = databaseName;
+      return this;
+    }
+
+    public SpannerConnectionConfiguration build() {
+      return new SpannerConnectionConfiguration(
+          this.projectId, this.instanceName, this.databaseName);
+    }
+
   }
 
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -26,12 +26,6 @@ public class SpannerConnectionConfiguration {
   private static final String FULLY_QUALIFIED_DB_NAME_PATTERN
       = "projects/%s/instances/%s/databases/%s";
 
-  private final String projectId;
-
-  private final String instanceName;
-
-  private final String databaseName;
-
   private final String fullyQualifiedDbName;
 
   /**
@@ -43,27 +37,13 @@ public class SpannerConnectionConfiguration {
    */
   private SpannerConnectionConfiguration(
       String projectId, String instanceName, String databaseName) {
-    this.projectId
-        = Assert.requireNonNull(projectId, "projectId must not be null");
-    this.instanceName
-        = Assert.requireNonNull(instanceName, "instanceName must not be null");
-    this.databaseName
-        = Assert.requireNonNull(databaseName, "databaseName must not be null");
+
+    Assert.requireNonNull(projectId, "projectId must not be null");
+    Assert.requireNonNull(instanceName, "instanceName must not be null");
+    Assert.requireNonNull(databaseName, "databaseName must not be null");
 
     this.fullyQualifiedDbName = String.format(
-        FULLY_QUALIFIED_DB_NAME_PATTERN, this.projectId, this.instanceName, this.databaseName);
-  }
-
-  public String getInstanceName() {
-    return instanceName;
-  }
-
-  public String getDatabaseName() {
-    return databaseName;
-  }
-
-  public String getProjectId() {
-    return projectId;
+        FULLY_QUALIFIED_DB_NAME_PATTERN, projectId, instanceName, databaseName);
   }
 
   /**

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -23,6 +23,8 @@ import com.google.cloud.spanner.r2dbc.util.Assert;
  */
 public class SpannerConnectionConfiguration {
 
+  private String projectId;
+
   private String instanceName;
 
   private String databaseName;
@@ -33,12 +35,15 @@ public class SpannerConnectionConfiguration {
    * @param instanceName instance to connect to
    * @param databaseName database to connect to.
    */
-  public SpannerConnectionConfiguration(String instanceName, String databaseName) {
-    Assert.requireNonNull(instanceName, "instanceName must not be null");
-    Assert.requireNonNull(databaseName, "databaseName must not be null");
-
-    this.instanceName = instanceName;
-    this.databaseName = databaseName;
+  // TODO: set up builder.
+  public SpannerConnectionConfiguration(
+      String projectId, String instanceName, String databaseName) {
+    this.projectId
+        = Assert.requireNonNull(projectId, "projectId must not be null");
+    this.instanceName
+        = Assert.requireNonNull(instanceName, "instanceName must not be null");
+    this.databaseName
+        = Assert.requireNonNull(databaseName, "databaseName must not be null");
   }
 
   public String getInstanceName() {
@@ -47,6 +52,23 @@ public class SpannerConnectionConfiguration {
 
   public String getDatabaseName() {
     return databaseName;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  /**
+   * Formats configuration properties into a fully qualified database name.
+   * @return fully qualified database name
+   */
+  public String getFullyQualifiedDatabaseName() {
+    return "projects/"
+        + this.projectId
+        + "/instances/"
+        + this.instanceName
+        + "/databases/"
+        + this.databaseName;
   }
 
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactory.java
@@ -18,11 +18,9 @@ package com.google.cloud.spanner.r2dbc;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
 import com.google.cloud.spanner.r2dbc.util.Assert;
-import com.google.spanner.v1.Session;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Mono;
 
 /**
  * An implementation of {@link ConnectionFactory} for creating connections to Cloud Spanner
@@ -42,10 +40,8 @@ public class SpannerConnectionFactory implements ConnectionFactory {
   @Override
   public Publisher<SpannerConnection> create() {
 
-    return Mono.fromSupplier(() -> {
-      Mono<Session> session = this.client.createSession(config.getFullyQualifiedDatabaseName());
-      return new SpannerConnection(this.client, session);
-    });
+    return this.client.createSession(config.getFullyQualifiedDatabaseName())
+      .map(session -> new SpannerConnection(this.client, session));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
 import com.google.cloud.spanner.r2dbc.client.GrpcClient;
+import com.google.spanner.v1.Session;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import java.io.IOException;
@@ -44,7 +45,8 @@ public class SpannerConnectionFactory implements ConnectionFactory {
     return Mono.defer(() -> {
       try {
         this.client.initialize();
-        return Mono.just(new SpannerConnection(this.client, this.config));
+        Mono<Session> session = this.client.createSession(config.getFullyQualifiedDatabaseName());
+        return Mono.just(new SpannerConnection(this.client, session));
       } catch (IOException e) {
         return Mono.error(e);
       }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -19,11 +19,13 @@ package com.google.cloud.spanner.r2dbc;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
+import com.google.cloud.spanner.r2dbc.client.GrpcClient;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
+import java.io.IOException;
 
 /**
  * An implementation of {@link ConnectionFactoryProvider} for creating {@link
@@ -49,7 +51,12 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
         .setInstanceName(connectionFactoryOptions.getValue(OPTION_INSTANCE))
         .setDatabaseName(connectionFactoryOptions.getValue(DATABASE))
         .build();
-    return new SpannerConnectionFactory(config);
+    try {
+      return new SpannerConnectionFactory(new GrpcClient(), config);
+    } catch (IOException e) {
+      // TODO: log and return null instead?
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -44,11 +44,11 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
   @Override
   public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration(
-        connectionFactoryOptions.getValue(OPTION_PROJECT),
-        connectionFactoryOptions.getValue(OPTION_INSTANCE),
-        connectionFactoryOptions.getValue(DATABASE)
-    );
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+        .setProjectId(connectionFactoryOptions.getValue(OPTION_PROJECT))
+        .setInstanceName(connectionFactoryOptions.getValue(OPTION_INSTANCE))
+        .setDatabaseName(connectionFactoryOptions.getValue(DATABASE))
+        .build();
     return new SpannerConnectionFactory(config);
   }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -16,12 +16,14 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
+import io.r2dbc.spi.Option;
 
 /**
  * An implementation of {@link ConnectionFactoryProvider} for creating {@link
@@ -34,9 +36,20 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   /** R2DBC driver name for Google Cloud Spanner. */
   public static final String DRIVER_NAME = "spanner";
 
+  /** Option name for GCP Project. */
+  public static final Option<String> OPTION_PROJECT = Option.valueOf("project");
+
+  /** Option name for GCP Spanner instance. */
+  public static final Option<String> OPTION_INSTANCE = Option.valueOf("instance");
+
   @Override
   public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
-    return new SpannerConnectionFactory(null);
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration(
+        connectionFactoryOptions.getValue(OPTION_PROJECT),
+        connectionFactoryOptions.getValue(OPTION_INSTANCE),
+        connectionFactoryOptions.getValue(DATABASE)
+    );
+    return new SpannerConnectionFactory(config);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -18,6 +18,8 @@ package com.google.cloud.spanner.r2dbc.client;
 
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.Session;
+import java.io.IOException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -25,6 +27,13 @@ import reactor.core.publisher.Mono;
  * An abstraction that wraps interaction with the Cloud Spanner Database APIs.
  */
 public interface Client {
+
+  /**
+   * Prepares the client for performing Spanner operations.
+   * @throws IOException if credentials could not be acquired
+   */
+  public void initialize() throws IOException;
+
 
   /**
    * Release any resources held by the {@link Client}.
@@ -37,5 +46,10 @@ public interface Client {
    * Execute a streaming query and get partial results.
    */
   Publisher<PartialResultSet> executeStreamingSql(ExecuteSqlRequest request);
+
+  /**
+   * Create a Spanner session.
+   */
+  Mono<Session> createSession(String databaseName);
 
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.r2dbc.client;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.Session;
-import java.io.IOException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -27,13 +26,6 @@ import reactor.core.publisher.Mono;
  * An abstraction that wraps interaction with the Cloud Spanner Database APIs.
  */
 public interface Client {
-
-  /**
-   * Prepares the client for performing Spanner operations.
-   * @throws IOException if credentials could not be acquired
-   */
-  public void initialize() throws IOException;
-
 
   /**
    * Release any resources held by the {@link Client}.
@@ -48,7 +40,10 @@ public interface Client {
   Publisher<PartialResultSet> executeStreamingSql(ExecuteSqlRequest request);
 
   /**
-   * Create a Spanner session.
+   * Create a Spanner session to be used in subsequent interactions with the database.
+   * @param databaseName Fully qualified Spanner database name in the format
+   * {@code projects/[PROJECT_ID]/instances/[INSTANCE]/databases/[DATABASE]}
+   * @returns {@link Mono} of the generated session.
    */
   Mono<Session> createSession(String databaseName);
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -43,32 +43,27 @@ public class GrpcClient implements Client {
   public static final String HOST = "spanner.googleapis.com";
   public static final int PORT = 443;
 
-  private SpannerStub spanner;
+  private final SpannerStub spanner;
 
   /**
-   * Creates the gRPC stub with authentication.
-   * @throws IOException if credentials could not be acquired
+   * Initializes the Cloud Spanner gRPC async stub.
    */
-  public void initialize() throws IOException {
-    // Create blocking and async stubs using the channel
-    CallCredentials callCredentials = MoreCallCredentials
-        .from(GoogleCredentials.getApplicationDefault());
-
+  public GrpcClient() throws IOException {
     // Create a channel
     ManagedChannel channel = ManagedChannelBuilder
         .forAddress(HOST, PORT)
         .build();
+
+    // Create blocking and async stubs using the channel
+    CallCredentials callCredentials = MoreCallCredentials
+        .from(GoogleCredentials.getApplicationDefault());
 
     // Create the asynchronous stub for Cloud Spanner
     this.spanner = SpannerGrpc.newStub(channel)
         .withCallCredentials(callCredentials);
   }
 
-  /**
-   * Creates a Spanner session to be used for any future operations.
-   * @param databaseName Fully qualified database name in {@code project/instance/database} format.
-   * @return {@link Mono} of the created session.
-   */
+  @Override
   public Mono<Session> createSession(String databaseName) {
     CreateSessionRequest request = CreateSessionRequest.newBuilder()
         .setDatabase(databaseName)

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.r2dbc.util;
 import io.grpc.stub.StreamObserver;
 import java.util.function.Consumer;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
 
 /**
  * Converter from a gRPC async calls to Reactor primitives ({@link Mono}).
@@ -36,22 +37,46 @@ public class ObservableReactiveUtil {
   public static <ResponseT> Mono<ResponseT> unaryCall(
       Consumer<StreamObserver<ResponseT>> remoteCall) {
     return Mono.create(sink -> {
-      remoteCall.accept(new StreamObserver<ResponseT>() {
-        @Override
-        public void onNext(ResponseT response) {
-          sink.success(response);
-        }
-
-        @Override
-        public void onError(Throwable throwable) {
-          sink.error(throwable);
-        }
-
-        @Override
-        public void onCompleted() {
-          // do nothing; Mono will already be completed by onNext/onError.
-        }
-      });
+      remoteCall.accept(new UnaryStreamObserver(sink));
     });
+  }
+
+  /**
+   * Forwards the result of a unary gRPC call to a {@link MonoSink}.
+   *
+   * <p>Unary gRPC calls expect a single response or an error, so completion of the call without an
+   * emitted value is an error condition.
+   *
+   * @param <ResponseT> type of expected gRPC call response value.
+   */
+  private static class UnaryStreamObserver<ResponseT> implements StreamObserver<ResponseT> {
+
+    private boolean terminalEventReceived;
+
+    private final MonoSink sink;
+
+    public UnaryStreamObserver(MonoSink sink) {
+      this.sink = sink;
+    }
+
+    @Override
+    public void onNext(ResponseT response) {
+      this.terminalEventReceived = true;
+      this.sink.success(response);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      this.terminalEventReceived = true;
+      this.sink.error(throwable);
+    }
+
+    @Override
+    public void onCompleted() {
+      if (!terminalEventReceived) {
+        this.sink.error(
+            new RuntimeException("Unary gRPC call completed without yielding a value or an error"));
+      }
+    }
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.util;
+
+import io.grpc.stub.StreamObserver;
+import java.util.function.Consumer;
+import reactor.core.publisher.Mono;
+
+/**
+ * Converter from a gRPC async calls to Reactor primitives ({@link Mono}).
+ */
+public class ObservableReactiveUtil {
+
+  /**
+   * Invokes a lambda that in turn issues a remote call, directing the response to a {@link Mono}
+   * stream.
+   * @param remoteCall lambda capable of invoking the correct remote call, making use of the
+   * {@link Mono}-converting {@link StreamObserver} implementation.
+   * @param <ResponseT> type of remote call response
+   * @return
+   */
+  public static <ResponseT> Mono<ResponseT> unaryCall(
+      Consumer<StreamObserver<ResponseT>> remoteCall) {
+    return Mono.create(sink -> {
+      remoteCall.accept(new StreamObserver<ResponseT>() {
+        @Override
+        public void onNext(ResponseT response) {
+          sink.success(response);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+          sink.error(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+          // do nothing; Mono will already be completed by onNext/onError.
+        }
+      });
+    });
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class SpannerConnectionConfigurationTest {
 
   @Test
-  public void nullInstanceNameTriggersException() {
+  public void missingInstanceNameTriggersException() {
     assertThatThrownBy(
         () -> {
           new SpannerConnectionConfiguration.Builder()
@@ -40,7 +40,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void nullDatabaseNameTriggersException() {
+  public void missingDatabaseNameTriggersException() {
     assertThatThrownBy(
         () -> {
           new SpannerConnectionConfiguration.Builder()
@@ -53,6 +53,19 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
+  public void missingProjectIdTriggersException() {
+    assertThatThrownBy(
+        () -> {
+          new SpannerConnectionConfiguration.Builder()
+              .setInstanceName("an-instance")
+              .setDatabaseName("db")
+              .build();
+        })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("projectId must not be null");
+  }
+
+  @Test
   public void nonNullConstructorParametersPassPreconditions() {
     SpannerConnectionConfiguration config
         = new SpannerConnectionConfiguration.Builder()
@@ -60,9 +73,8 @@ public class SpannerConnectionConfigurationTest {
         .setInstanceName("an-instance")
         .setDatabaseName("db")
         .build();
-    assertThat(config.getProjectId()).isEqualTo("project1");
-    assertThat(config.getInstanceName()).isEqualTo("an-instance");
-    assertThat(config.getDatabaseName()).isEqualTo("db");
+    assertThat(config.getFullyQualifiedDatabaseName())
+        .isEqualTo("projects/project1/instances/an-instance/databases/db");
   }
 
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -30,7 +30,10 @@ public class SpannerConnectionConfigurationTest {
   public void nullInstanceNameTriggersException() {
     assertThatThrownBy(
         () -> {
-          new SpannerConnectionConfiguration("project1", null, "db");
+          new SpannerConnectionConfiguration.Builder()
+              .setProjectId("project1")
+              .setDatabaseName("db")
+              .build();
         })
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("instanceName must not be null");
@@ -40,7 +43,10 @@ public class SpannerConnectionConfigurationTest {
   public void nullDatabaseNameTriggersException() {
     assertThatThrownBy(
         () -> {
-          new SpannerConnectionConfiguration("project1", "an-instance", null);
+          new SpannerConnectionConfiguration.Builder()
+              .setProjectId("project1")
+              .setInstanceName("an-instance")
+              .build();
         })
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("databaseName must not be null");
@@ -49,7 +55,12 @@ public class SpannerConnectionConfigurationTest {
   @Test
   public void nonNullConstructorParametersPassPreconditions() {
     SpannerConnectionConfiguration config
-        = new SpannerConnectionConfiguration("project1", "an-instance", "db");
+        = new SpannerConnectionConfiguration.Builder()
+        .setProjectId("project1")
+        .setInstanceName("an-instance")
+        .setDatabaseName("db")
+        .build();
+    assertThat(config.getProjectId()).isEqualTo("project1");
     assertThat(config.getInstanceName()).isEqualTo("an-instance");
     assertThat(config.getDatabaseName()).isEqualTo("db");
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -30,7 +30,7 @@ public class SpannerConnectionConfigurationTest {
   public void nullInstanceNameTriggersException() {
     assertThatThrownBy(
         () -> {
-          new SpannerConnectionConfiguration(null, "db");
+          new SpannerConnectionConfiguration("project1", null, "db");
         })
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("instanceName must not be null");
@@ -40,7 +40,7 @@ public class SpannerConnectionConfigurationTest {
   public void nullDatabaseNameTriggersException() {
     assertThatThrownBy(
         () -> {
-          new SpannerConnectionConfiguration("an-instance", null);
+          new SpannerConnectionConfiguration("project1", "an-instance", null);
         })
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("databaseName must not be null");
@@ -48,7 +48,8 @@ public class SpannerConnectionConfigurationTest {
 
   @Test
   public void nonNullConstructorParametersPassPreconditions() {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration("an-instance", "db");
+    SpannerConnectionConfiguration config
+        = new SpannerConnectionConfiguration("project1", "an-instance", "db");
     assertThat(config.getInstanceName()).isEqualTo("an-instance");
     assertThat(config.getDatabaseName()).isEqualTo("db");
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -17,8 +17,8 @@
 package com.google.cloud.spanner.r2dbc;
 
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
-import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_INSTANCE;
-import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_PROJECT;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PROJECT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,70 +26,72 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import io.r2dbc.spi.ConnectionFactories;
+import com.google.cloud.spanner.r2dbc.client.Client;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Unit test for {@link SpannerConnectionFactoryProvider}.
  */
 public class SpannerConnectionFactoryProviderTest {
 
-  public static final ConnectionFactoryOptions SPANNER_CONFIG = ConnectionFactoryOptions.builder()
+  public static final ConnectionFactoryOptions SPANNER_OPTIONS = ConnectionFactoryOptions.builder()
       .option(DRIVER, DRIVER_NAME)
-      .option(OPTION_PROJECT, "project-id")
-      .option(OPTION_INSTANCE, "an-instance")
+      .option(PROJECT, "project-id")
+      .option(INSTANCE, "an-instance")
       .option(DATABASE, "db")
       .build();
 
+  SpannerConnectionFactoryProvider spannerConnectionFactoryProvider;
+
+  /**
+   * Initializes unit under test with a mock {@link Client}.
+   */
+  @Before
+  public void setUp() {
+    this.spannerConnectionFactoryProvider = new SpannerConnectionFactoryProvider();
+    Client mockClient = Mockito.mock(Client.class);
+    spannerConnectionFactoryProvider.setClient(mockClient);
+  }
+
   @Test
   public void testCreate() {
-    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
-        new SpannerConnectionFactoryProvider();
     ConnectionFactory spannerConnectionFactory
-        = spannerConnectionFactoryProvider.create(SPANNER_CONFIG);
+        = this.spannerConnectionFactoryProvider.create(SPANNER_OPTIONS);
 
     assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
   }
 
   @Test
   public void testSupportsThrowsExceptionOnNullOptions() {
-    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
-        new SpannerConnectionFactoryProvider();
+
     assertThatThrownBy(() -> {
-      spannerConnectionFactoryProvider.supports(null);
+      this.spannerConnectionFactoryProvider.supports(null);
     }).isInstanceOf(IllegalArgumentException.class)
         .hasMessage("connectionFactoryOptions must not be null");
   }
 
   @Test
   public void testSupportsReturnsFalseWhenNoDriverInOptions() {
-    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
-        new SpannerConnectionFactoryProvider();
-    assertFalse(spannerConnectionFactoryProvider.supports(
+
+    assertFalse(this.spannerConnectionFactoryProvider.supports(
         ConnectionFactoryOptions.builder().build()));
   }
 
   @Test
   public void testSupportsReturnsFalseWhenWrongDriverInOptions() {
-    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
-        new SpannerConnectionFactoryProvider();
-    assertFalse(spannerConnectionFactoryProvider.supports(buildOptions("not spanner")));
+
+    assertFalse(this.spannerConnectionFactoryProvider.supports(buildOptions("not spanner")));
   }
 
   @Test
   public void testSupportsReturnsTrueWhenCorrectDriverInOptions() {
-    SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
-        new SpannerConnectionFactoryProvider();
-    assertTrue(spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
-  }
 
-  @Test
-  public void testR2dbcFindsSpannerConnectionFactoryProvider() {
-    ConnectionFactory connectionFactory = ConnectionFactories.get(SPANNER_CONFIG);
-
-    assertThat(connectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+    assertTrue(this.spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
   }
 
   private static ConnectionFactoryOptions buildOptions(String driverName) {

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -16,6 +16,10 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_INSTANCE;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_PROJECT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,12 +36,19 @@ import org.junit.Test;
  */
 public class SpannerConnectionFactoryProviderTest {
 
+  public static final ConnectionFactoryOptions SPANNER_CONFIG = ConnectionFactoryOptions.builder()
+      .option(DRIVER, DRIVER_NAME)
+      .option(OPTION_PROJECT, "project-id")
+      .option(OPTION_INSTANCE, "an-instance")
+      .option(DATABASE, "db")
+      .build();
+
   @Test
   public void testCreate() {
     SpannerConnectionFactoryProvider spannerConnectionFactoryProvider =
         new SpannerConnectionFactoryProvider();
-    ConnectionFactory spannerConnectionFactory = spannerConnectionFactoryProvider
-        .create(null);
+    ConnectionFactory spannerConnectionFactory
+        = spannerConnectionFactoryProvider.create(SPANNER_CONFIG);
 
     assertThat(spannerConnectionFactory).isNotNull();
   }
@@ -76,10 +87,7 @@ public class SpannerConnectionFactoryProviderTest {
 
   @Test
   public void testR2dbcFindsSpannerConnectionFactoryProvider() {
-    ConnectionFactory connectionFactory =
-        ConnectionFactories.get(ConnectionFactoryOptions.builder()
-            .option(DRIVER, "spanner")
-            .build());
+    ConnectionFactory connectionFactory = ConnectionFactories.get(SPANNER_CONFIG);
 
     assertThat(connectionFactory).isInstanceOf(SpannerConnectionFactory.class);
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -39,8 +39,11 @@ public class SpannerConnectionFactoryTest {
 
   @Test
   public void createReturnsNewSpannerConnection() {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration(
-        "a-project", "an-instance", "db");
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+        .setProjectId("a-project")
+        .setInstanceName("an-instance")
+        .setDatabaseName("db")
+        .build();
     SpannerConnectionFactory factory = new SpannerConnectionFactory(config);
 
     Client mockClient = Mockito.mock(Client.class);

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -55,7 +55,7 @@ public class SpannerConnectionFactoryTest {
     SpannerConnectionFactory factory = new SpannerConnectionFactory(mockClient, this.config);
     SpannerConnection connection = Mono.from(factory.create()).block();
 
-    assertThat(connection.getSessionName().block()).isEqualTo("jam session");
+    assertThat(connection.getSession().getName()).isEqualTo("jam session");
 
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -30,29 +30,29 @@ import reactor.core.publisher.Mono;
  */
 public class SpannerConnectionFactoryTest {
 
+  SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+      .setProjectId("a-project")
+      .setInstanceName("an-instance")
+      .setDatabaseName("db")
+      .build();
+
   @Test
   public void getMetadataReturnsSingleton() {
-    SpannerConnectionFactory factory = new SpannerConnectionFactory(null);
+    Client mockClient = Mockito.mock(Client.class);
+    SpannerConnectionFactory factory = new SpannerConnectionFactory(mockClient, config);
 
     assertThat(factory.getMetadata()).isSameAs(SpannerConnectionFactoryMetadata.INSTANCE);
   }
 
   @Test
   public void createReturnsNewSpannerConnection() {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
-        .setProjectId("a-project")
-        .setInstanceName("an-instance")
-        .setDatabaseName("db")
-        .build();
-    SpannerConnectionFactory factory = new SpannerConnectionFactory(config);
 
     Client mockClient = Mockito.mock(Client.class);
-    factory.setClient(mockClient);
-
     Session session = Session.newBuilder().setName("jam session").build();
     when(mockClient.createSession("projects/a-project/instances/an-instance/databases/db"))
         .thenReturn(Mono.just(session));
 
+    SpannerConnectionFactory factory = new SpannerConnectionFactory(mockClient, this.config);
     SpannerConnection connection = Mono.from(factory.create()).block();
 
     assertThat(connection.getSessionName().block()).isEqualTo("jam session");

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -19,9 +19,11 @@ package com.google.cloud.spanner.r2dbc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
+import com.google.spanner.v1.Session;
 import io.r2dbc.spi.Statement;
 import org.junit.Test;
 import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
 
 /**
  * Test for {@link SpannerConnection}.
@@ -37,7 +39,8 @@ public class SpannerConnectionTest {
         .setInstanceName("an-instance")
         .setDatabaseName("db")
         .build();
-    SpannerConnection connection = new SpannerConnection(mockClient, config);
+    Session session = Session.newBuilder().setName("project/session/1234").build();
+    SpannerConnection connection = new SpannerConnection(mockClient, Mono.just(session));
     Statement statement = connection.createStatement("not actual sql");
     assertThat(statement).isInstanceOf(SpannerStatement.class);
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -23,7 +23,6 @@ import com.google.spanner.v1.Session;
 import io.r2dbc.spi.Statement;
 import org.junit.Test;
 import org.mockito.Mockito;
-import reactor.core.publisher.Mono;
 
 /**
  * Test for {@link SpannerConnection}.
@@ -40,7 +39,7 @@ public class SpannerConnectionTest {
         .setDatabaseName("db")
         .build();
     Session session = Session.newBuilder().setName("project/session/1234").build();
-    SpannerConnection connection = new SpannerConnection(mockClient, Mono.just(session));
+    SpannerConnection connection = new SpannerConnection(mockClient, session);
     Statement statement = connection.createStatement("not actual sql");
     assertThat(statement).isInstanceOf(SpannerStatement.class);
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -18,8 +18,10 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.cloud.spanner.r2dbc.client.Client;
 import io.r2dbc.spi.Statement;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Test for {@link SpannerConnection}.
@@ -28,7 +30,10 @@ public class SpannerConnectionTest {
 
   @Test
   public void createStatementDummyImplementation() {
-    SpannerConnection connection = new SpannerConnection();
+    Client mockClient = Mockito.mock(Client.class);
+    SpannerConnectionConfiguration config
+        = new SpannerConnectionConfiguration("a-project", "an-instance", "db");
+    SpannerConnection connection = new SpannerConnection(mockClient, config);
     Statement statement = connection.createStatement("not actual sql");
     assertThat(statement).isInstanceOf(SpannerStatement.class);
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -32,7 +32,11 @@ public class SpannerConnectionTest {
   public void createStatementDummyImplementation() {
     Client mockClient = Mockito.mock(Client.class);
     SpannerConnectionConfiguration config
-        = new SpannerConnectionConfiguration("a-project", "an-instance", "db");
+        = new SpannerConnectionConfiguration.Builder()
+        .setProjectId("a-project")
+        .setInstanceName("an-instance")
+        .setDatabaseName("db")
+        .build();
     SpannerConnection connection = new SpannerConnection(mockClient, config);
     Statement statement = connection.createStatement("not actual sql");
     assertThat(statement).isInstanceOf(SpannerStatement.class);

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
@@ -46,8 +46,6 @@ public class SpannerIntegrationTest {
 
   @Test
   public void testCreatingSession() {
-
-
     ConnectionFactory connectionFactory =
         ConnectionFactories.get(ConnectionFactoryOptions.builder()
             // TODO: consider whether to bring autodiscovery of project ID

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc;
 
-import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_INSTANCE;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,12 +51,15 @@ public class SpannerIntegrationTest {
             // TODO: consider whether to bring autodiscovery of project ID
             .option(Option.valueOf("project"), ServiceOptions.getDefaultProjectId())
             .option(DRIVER, "spanner")
-            .option(OPTION_INSTANCE, "reactivetest")
+            .option(INSTANCE, "reactivetest")
             .option(DATABASE, "testdb")
             .build());
 
+    assertThat(connectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+
     Mono<Connection> connection = (Mono<Connection>) connectionFactory.create();
     SpannerConnection spannerConnection = (SpannerConnection)connection.block();
-    assertThat(spannerConnection.getSessionName().block()).contains("/sessions/");
+    assertThat(spannerConnection.getSession().getName()).contains("/sessions/");
   }
+
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc;
+
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTION_INSTANCE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.assumeThat;
+
+import com.google.cloud.ServiceOptions;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+/**
+ * Integration test for connecting to a real Spanner instance.
+ */
+public class SpannerIntegrationTest {
+
+  @Before
+  public void enableIntegrationTest() {
+    assumeThat("Enable integration tests with -Dit.spanner=true.",
+        System.getProperty("it.spanner"), is("true"));
+  }
+
+  @Test
+  public void testCreatingSession() {
+
+
+    ConnectionFactory connectionFactory =
+        ConnectionFactories.get(ConnectionFactoryOptions.builder()
+            // TODO: consider whether to bring autodiscovery of project ID
+            .option(Option.valueOf("project"), ServiceOptions.getDefaultProjectId())
+            .option(DRIVER, "spanner")
+            .option(OPTION_INSTANCE, "reactivetest")
+            .option(DATABASE, "testdb")
+            .build());
+
+    Mono<Connection> connection = (Mono<Connection>) connectionFactory.create();
+    SpannerConnection spannerConnection = (SpannerConnection)connection.block();
+    assertThat(spannerConnection.getSessionName().block()).contains("/sessions/");
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+/**
+ * Test for {@link ObservableReactiveUtil}.
+ */
+public class ObservableReactiveUtilTest {
+
+  @Test
+  public void unaryCallReturnsSingleValue() {
+    Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
+      observer.onNext(42);
+      observer.onCompleted();
+    });
+    assertThat(mono.block()).isEqualTo(42);
+  }
+
+  @Test
+  public void unaryCallForwardsError() {
+    Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
+      observer.onError(new IllegalArgumentException("oh no"));
+    });
+    assertThatThrownBy(() -> mono.block())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("oh no");
+  }
+
+  @Test
+  public void unaryCallThrowsExceptionIfCompletedWithNoValue() {
+    Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
+      observer.onCompleted();
+    });
+    assertThatThrownBy(() -> mono.block())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Unary gRPC call completed without yielding a value or an error");
+  }
+
+}


### PR DESCRIPTION
This change:
* Creates a real `Connection` object with minimum necessary settings.
* When a new Connection is created, it creates a new Spanner session and keeps its name. The session name is necessary for most future operations.
* Added a utility `ObservableReactiveUtil` that takes care of the boilerplate of converting from `StreamObservable` into a `Mono`.
* There is a new integration test, gated with `it.spanner`. You'll have to create a new instance "reactivetest" and a new database "testdb" to run it with no errors. The proper integration setup will be done in #14 .
* I added a _test-only_ dependency on `com.google.cloud:google-cloud-core` to take advantage of `ServiceOptions` project ID autodiscovery. Edit: decided to keep it as is for now; possibly remove completely in the future.