### PR TITLE
Add Rollbacks to Spanner Connection

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -70,6 +70,15 @@ public class SpannerConnection implements Connection {
   }
 
   @Override
+  public Publisher<Void> rollbackTransaction() {
+    return currentTransaction
+        .flatMap(transaction -> client.rollbackTransaction(session, transaction))
+        .switchIfEmpty(Mono.fromRunnable(() ->
+            logger.warn("rollbackTransaction() is a no-op; called with no transaction active.")))
+        .then();
+  }
+
+  @Override
   public Publisher<Void> close() {
     return client.deleteSession(session);
   }
@@ -91,11 +100,6 @@ public class SpannerConnection implements Connection {
 
   @Override
   public Publisher<Void> releaseSavepoint(String s) {
-    return null;
-  }
-
-  @Override
-  public Publisher<Void> rollbackTransaction() {
     return null;
   }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -58,6 +58,15 @@ public interface Client {
    */
   Mono<CommitResponse> commitTransaction(Session session, Transaction transaction);
 
+
+  /**
+   * Performs a rollback on a Spanner {@link Transaction} within the provided {@link Session}.
+   * @param session The session object with which requests are made to the Spanner API.
+   * @param transaction The transaction that you want to rollback.
+   * @return {@link Mono} indicating completion of the rollback.
+   */
+  Mono<Void> rollbackTransaction(Session session, Transaction transaction);
+
   /**
    * Execute a streaming query and get partial results.
    */

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -26,6 +26,7 @@ import com.google.spanner.v1.CreateSessionRequest;
 import com.google.spanner.v1.DeleteSessionRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
 import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.SpannerGrpc;
 import com.google.spanner.v1.SpannerGrpc.SpannerStub;
@@ -100,6 +101,21 @@ public class GrpcClient implements Client {
 
       return ObservableReactiveUtil.unaryCall(
           (obs) -> this.spanner.commit(commitRequest, obs));
+    });
+  }
+
+  @Override
+  public Mono<Void> rollbackTransaction(Session session, Transaction transaction) {
+    return Mono.defer(() -> {
+      RollbackRequest rollbackRequest =
+          RollbackRequest.newBuilder()
+              .setSession(session.getName())
+              .setTransactionId(transaction.getId())
+              .build();
+
+      return ObservableReactiveUtil.<Empty>unaryCall(
+          (obs) -> this.spanner.rollback(rollbackRequest, obs))
+          .then();
     });
   }
 

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
+import com.google.protobuf.Empty;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
@@ -53,6 +54,8 @@ public class SpannerConnectionTest {
         .thenReturn(Mono.just(Transaction.getDefaultInstance()));
     when(this.mockClient.commitTransaction(any(), any()))
         .thenReturn(Mono.just(CommitResponse.getDefaultInstance()));
+    when(this.mockClient.rollbackTransaction(any(), any()))
+        .thenReturn(Mono.empty());
   }
 
   @Test
@@ -82,5 +85,20 @@ public class SpannerConnectionTest {
         .beginTransaction(TEST_SESSION);
     verify(this.mockClient, times(1))
         .commitTransaction(TEST_SESSION, Transaction.getDefaultInstance());
+  }
+
+  @Test
+  public void rollbackTransactions() {
+    SpannerConnection connection = new SpannerConnection(mockClient, TEST_SESSION);
+
+    Mono.from(connection.rollbackTransaction()).block();
+    verify(this.mockClient, never()).rollbackTransaction(any(), any());
+
+    Mono.from(connection.beginTransaction()).block();
+    Mono.from(connection.rollbackTransaction()).block();
+    verify(this.mockClient, times(1))
+        .beginTransaction(TEST_SESSION);
+    verify(this.mockClient, times(1))
+        .rollbackTransaction(TEST_SESSION, Transaction.getDefaultInstance());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
-import com.google.protobuf.Empty;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;


### PR DESCRIPTION
This adds `rollback()` to the SpannerConnection implementation.

Contributes to #35.