### PR TITLE
Add a test for GrpcClient.executeStreamingSql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -40,9 +40,9 @@ import io.grpc.auth.MoreCallCredentials;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 /**
@@ -81,6 +81,7 @@ public class GrpcClient implements Client {
    */
   public GrpcClient(SpannerStub spanner) throws IOException {
     this.spanner = spanner;
+    this.channel = null;
   }
 
   @Override
@@ -205,10 +206,12 @@ public class GrpcClient implements Client {
     }
   }
 
-}
-
   @Override
   public Mono<Void> close() {
-    return Mono.fromRunnable(() -> this.channel.shutdownNow());
+    return Mono.fromRunnable(() -> {
+      if (this.channel != null) {
+        this.channel.shutdownNow();
+      }
+    });
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -39,6 +39,8 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -69,6 +71,16 @@ public class GrpcClient implements Client {
     // Create the asynchronous stub for Cloud Spanner
     this.spanner = SpannerGrpc.newStub(this.channel)
         .withCallCredentials(callCredentials);
+  }
+
+
+  /**
+   * Constructor that builds the client from a user-specified {@code SpannerStub}.
+   *
+   * @param spanner The asynchronous gRPC Spanner client stub.
+   */
+  public GrpcClient(SpannerStub spanner) throws IOException {
+    this.spanner = spanner;
   }
 
   @Override
@@ -168,6 +180,7 @@ public class GrpcClient implements Client {
               sink.onRequest(demand -> requestStream.request((int) demand));
               sink.onCancel(() -> requestStream.cancel(null, null));
             }
+
           };
       this.spanner.executeStreamingSql(request, clientResponseObserver);
     });

--- a/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2018 original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.google.spanner.v1.CreateSessionRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.Session;
+import com.google.spanner.v1.SpannerGrpc;
+import com.google.spanner.v1.SpannerGrpc.SpannerImplBase;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.function.Consumer;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
+
+/**
+ * Test for {@link GrpcClient}.
+ */
+public class GrpcClientTest {
+
+
+  @Test
+  public void testCreateSession() throws IOException {
+
+    SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
+                                          @Override
+                                          public void createSession(CreateSessionRequest request,
+                                              StreamObserver<Session> responseObserver) {
+                                            responseObserver.onNext(Session.newBuilder().build());
+                                            responseObserver.onCompleted();
+                                          }
+                                        },
+        // call the method under test
+        grpcClient -> grpcClient.createSession("testDb").block()
+    );
+
+    // verify the service was called correctly
+    ArgumentCaptor<CreateSessionRequest> requestCaptor = ArgumentCaptor
+        .forClass(CreateSessionRequest.class);
+    verify(spannerSpy).createSession(requestCaptor.capture(), any());
+    assertEquals("testDb", requestCaptor.getValue().getDatabase());
+  }
+
+  @Test
+  public void testExecuteStreamingSql() throws IOException {
+
+    ExecuteSqlRequest request = ExecuteSqlRequest.newBuilder().build();
+
+    SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
+                                          @Override
+                                          public void executeStreamingSql(ExecuteSqlRequest request,
+                                              StreamObserver<PartialResultSet> responseObserver) {
+                                            responseObserver.onNext(PartialResultSet.newBuilder().build());
+                                            responseObserver.onCompleted();
+                                          }
+                                        },
+        // call the method under test
+        grpcClient -> Flux.from( grpcClient.executeStreamingSql(request)).blockFirst()
+    );
+
+    // verify the service was called correctly
+    ArgumentCaptor<ExecuteSqlRequest> requestCaptor = ArgumentCaptor
+        .forClass(ExecuteSqlRequest.class);
+    verify(spannerSpy).executeStreamingSql(requestCaptor.capture(), any());
+    assertSame(request, requestCaptor.getValue());
+  }
+
+  /**
+   * Starts and shuts down an in-process gRPC service based on the {@code serviceImpl} provided,
+   * while allowing a test to execute using the {@link GrpcClient}.
+   *
+   * @param serviceImpl implementation of the Spanner service. Typically, just the methods needed to
+   * execute the test.
+   * @param clientConsumer consumer of the {@link GrpcClient} - the class under test.
+   * @return a Mockito spy for the gRPC service for verification.
+   */
+  private SpannerImplBase doTest(SpannerGrpc.SpannerImplBase serviceImpl,
+      Consumer<GrpcClient> clientConsumer)
+      throws IOException {
+    SpannerGrpc.SpannerImplBase serviceImplSpy = spy(serviceImpl);
+
+    String serverName = InProcessServerBuilder.generateName();
+
+    Server server = InProcessServerBuilder
+        .forName(serverName).directExecutor().addService(serviceImplSpy).build().start();
+
+    ManagedChannel channel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().build();
+
+    clientConsumer.accept(new GrpcClient(SpannerGrpc.newStub(channel)));
+
+    channel.shutdown();
+    server.shutdown();
+
+    return serviceImplSpy;
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -1,17 +1,17 @@
 /*
- *  Copyright 2018 original author or authors.
+ * Copyright 2019 Google LLC
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.google.cloud.spanner.r2dbc.client;
@@ -49,13 +49,13 @@ public class GrpcClientTest {
   public void testCreateSession() throws IOException {
 
     SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
-                                          @Override
-                                          public void createSession(CreateSessionRequest request,
-                                              StreamObserver<Session> responseObserver) {
-                                            responseObserver.onNext(Session.newBuilder().build());
-                                            responseObserver.onCompleted();
-                                          }
-                                        },
+          @Override
+          public void createSession(CreateSessionRequest request,
+              StreamObserver<Session> responseObserver) {
+            responseObserver.onNext(Session.newBuilder().build());
+            responseObserver.onCompleted();
+          }
+        },
         // call the method under test
         grpcClient -> grpcClient.createSession("testDb").block()
     );
@@ -73,15 +73,15 @@ public class GrpcClientTest {
     ExecuteSqlRequest request = ExecuteSqlRequest.newBuilder().build();
 
     SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
-                                          @Override
-                                          public void executeStreamingSql(ExecuteSqlRequest request,
-                                              StreamObserver<PartialResultSet> responseObserver) {
-                                            responseObserver.onNext(PartialResultSet.newBuilder().build());
-                                            responseObserver.onCompleted();
-                                          }
-                                        },
+          @Override
+          public void executeStreamingSql(ExecuteSqlRequest request,
+              StreamObserver<PartialResultSet> responseObserver) {
+            responseObserver.onNext(PartialResultSet.newBuilder().build());
+            responseObserver.onCompleted();
+          }
+        },
         // call the method under test
-        grpcClient -> Flux.from( grpcClient.executeStreamingSql(request)).blockFirst()
+        grpcClient -> Flux.from(grpcClient.executeStreamingSql(request)).blockFirst()
     );
 
     // verify the service was called correctly
@@ -96,7 +96,7 @@ public class GrpcClientTest {
    * while allowing a test to execute using the {@link GrpcClient}.
    *
    * @param serviceImpl implementation of the Spanner service. Typically, just the methods needed to
-   * execute the test.
+   *     execute the test.
    * @param clientConsumer consumer of the {@link GrpcClient} - the class under test.
    * @return a Mockito spy for the gRPC service for verification.
    */


### PR DESCRIPTION
This test involes starting an embedded gRPC server because there is no
way to mock `SpannerStub`, which a final class.

Fixes #24.