### PR TITLE
Implement basic get() functionality for Spanner rows

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
@@ -52,7 +52,7 @@ public class SpannerRow implements Row {
     this.rowMetadata = rowMetadata;
 
     this.columnNameIndex = new HashMap<>();
-    for (int i = 0; i < rowMetadata.getFieldsList().size(); i++) {
+    for (int i = 0; i < rowMetadata.getFieldsCount(); i++) {
       Field currField = rowMetadata.getFields(i);
       this.columnNameIndex.put(currField.getName(), i);
     }
@@ -66,26 +66,26 @@ public class SpannerRow implements Row {
   @Override
   public <T> T get(Object identifier, Class<T> type) {
 
-    int rowIndex;
+    int colIndex;
 
     if (identifier instanceof Integer) {
-      rowIndex = (Integer) identifier;
+      colIndex = (Integer) identifier;
     } else if (identifier instanceof String) {
-      rowIndex = getRowIndexByName((String) identifier);
+      colIndex = getColIndexByName((String) identifier);
     } else {
       throw new IllegalArgumentException(
           String.format("Identifier '%s' is not a valid identifier. "
               + "Should either be an Integer index or a String column name.", identifier));
     }
 
-    Value spannerValue = values.get(rowIndex);
-    Field spannerValueMetadata = rowMetadata.getFields(rowIndex);
+    Value spannerValue = values.get(colIndex);
+    Field spannerValueMetadata = rowMetadata.getFields(colIndex);
 
     T decodedValue = this.codecs.decode(spannerValue, spannerValueMetadata.getType(), type);
     return decodedValue;
   }
 
-  private int getRowIndexByName(String name) {
+  private int getColIndexByName(String name) {
     if (!columnNameIndex.containsKey(name)) {
       throw new IllegalArgumentException(
           "The column name " + name + " does not exist for the Spanner row. "

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
@@ -66,26 +66,28 @@ public class SpannerRow implements Row {
   @Override
   public <T> T get(Object identifier, Class<T> type) {
 
-    int colIndex;
+    int columnIndex = getColumnIndex(identifier);
 
-    if (identifier instanceof Integer) {
-      colIndex = (Integer) identifier;
-    } else if (identifier instanceof String) {
-      colIndex = getColIndexByName((String) identifier);
-    } else {
-      throw new IllegalArgumentException(
-          String.format("Identifier '%s' is not a valid identifier. "
-              + "Should either be an Integer index or a String column name.", identifier));
-    }
-
-    Value spannerValue = values.get(colIndex);
-    Field spannerValueMetadata = rowMetadata.getFields(colIndex);
+    Value spannerValue = values.get(columnIndex);
+    Field spannerValueMetadata = rowMetadata.getFields(columnIndex);
 
     T decodedValue = this.codecs.decode(spannerValue, spannerValueMetadata.getType(), type);
     return decodedValue;
   }
 
-  private int getColIndexByName(String name) {
+  private int getColumnIndex(Object identifier) {
+    if (identifier instanceof Integer) {
+      return (Integer) identifier;
+    } else if (identifier instanceof String) {
+      return getColumnIndexByName((String) identifier);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Identifier '%s' is not a valid identifier. "
+              + "Should either be an Integer index or a String column name.", identifier));
+    }
+  }
+
+  private int getColumnIndexByName(String name) {
     if (!columnNameIndex.containsKey(name)) {
       throw new IllegalArgumentException(
           "The column name " + name + " does not exist for the Spanner row. "

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
@@ -16,10 +16,14 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import com.google.cloud.spanner.r2dbc.codecs.Codecs;
+import com.google.cloud.spanner.r2dbc.codecs.DefaultCodecs;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
 import io.r2dbc.spi.Row;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -28,12 +32,17 @@ import java.util.List;
  */
 public class SpannerRow implements Row {
 
+  private static final Codecs codecs = new DefaultCodecs();
+
   private final List<Value> values;
 
   private final StructType rowMetadata;
 
+  /** Mapping of column names to its integer index position in the row. */
+  private final HashMap<String, Integer> columnNameIndex;
+
   /**
-   * Constructor.
+   * Builds a new Spanner row.
    *
    * @param values the list of values in each column.
    * @param rowMetadata the type information for each column.
@@ -41,6 +50,12 @@ public class SpannerRow implements Row {
   public SpannerRow(List<Value> values, StructType rowMetadata) {
     this.values = values;
     this.rowMetadata = rowMetadata;
+
+    this.columnNameIndex = new HashMap<>();
+    for (int i = 0; i < rowMetadata.getFieldsList().size(); i++) {
+      Field currField = rowMetadata.getFields(i);
+      this.columnNameIndex.put(currField.getName(), i);
+    }
   }
 
   @VisibleForTesting
@@ -50,7 +65,33 @@ public class SpannerRow implements Row {
 
   @Override
   public <T> T get(Object identifier, Class<T> type) {
-    // TODO
-    return null;
+
+    int rowIndex;
+
+    if (identifier instanceof Integer) {
+      rowIndex = (Integer) identifier;
+    } else if (identifier instanceof String) {
+      rowIndex = getRowIndexByName((String) identifier);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Identifier '%s' is not a valid identifier. "
+              + "Should either be an Integer index or a String column name.", identifier));
+    }
+
+    Value spannerValue = values.get(rowIndex);
+    Field spannerValueMetadata = rowMetadata.getFields(rowIndex);
+
+    T decodedValue = this.codecs.decode(spannerValue, spannerValueMetadata.getType(), type);
+    return decodedValue;
+  }
+
+  private int getRowIndexByName(String name) {
+    if (!columnNameIndex.containsKey(name)) {
+      throw new IllegalArgumentException(
+          "The column name " + name + " does not exist for the Spanner row. "
+              + "Available columns: " + columnNameIndex.keySet());
+    }
+
+    return columnNameIndex.get(name);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecs.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecs.java
@@ -36,7 +36,10 @@ public final class DefaultCodecs implements Codecs {
 
   private final List<Codec<?>> codecs;
 
-  DefaultCodecs() {
+  /**
+   * Constructs the {@link DefaultCodecs} used for type conversions.
+   */
+  public DefaultCodecs() {
     this.codecs = Arrays.asList(
         new ArrayCodec(this, Boolean[].class),
         new ArrayCodec(this, byte[][].class),

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -37,7 +37,7 @@ public class SpannerRowTest {
   private static final Codecs codecs = new DefaultCodecs();
 
   @Test
-  public void getDummyImplementation() {
+  public void testIndexingIntoColumns() {
     StructType rowMetadata = createRowMetadata(TypeCode.STRING, TypeCode.INT64, TypeCode.BOOL);
     List<Value> rawSpannerRow = createRawSpannerRow("Hello", 25L, true);
 

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -18,6 +18,15 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.cloud.spanner.r2dbc.codecs.Codecs;
+import com.google.cloud.spanner.r2dbc.codecs.DefaultCodecs;
+import com.google.protobuf.Value;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 
 /**
@@ -25,9 +34,42 @@ import org.junit.Test;
  */
 public class SpannerRowTest {
 
+  private static final Codecs codecs = new DefaultCodecs();
+
   @Test
   public void getDummyImplementation() {
-    SpannerRow row = new SpannerRow(null, null);
-    assertThat(row.get("columnName", String.class)).isNull();
+    StructType rowMetadata = createRowMetadata(TypeCode.STRING, TypeCode.INT64, TypeCode.BOOL);
+    List<Value> rawSpannerRow = createRawSpannerRow("Hello", 25L, true);
+
+    SpannerRow row = new SpannerRow(rawSpannerRow, rowMetadata);
+
+    assertThat(row.get("column_2", Boolean.class)).isEqualTo(true);
+    assertThat(row.get("column_0", String.class)).isEqualTo("Hello");
+
+    assertThat(row.get(1, Long.class)).isEqualTo(25L);
+  }
+
+  private static List<Value> createRawSpannerRow(Object... rowItems) {
+    List<Value> listValues = new ArrayList<>();
+
+    for (int i = 0; i < rowItems.length; i++) {
+      listValues.add(codecs.encode(rowItems[i]));
+    }
+    return listValues;
+  }
+
+  private static StructType createRowMetadata(TypeCode... types) {
+    StructType.Builder structType = StructType.newBuilder();
+
+    for (int i = 0; i < types.length; i++) {
+      Field field =
+          Field.newBuilder()
+              .setName("column_" + i)
+              .setType(Type.newBuilder().setCode(types[i]).build())
+              .build();
+      structType.addFields(field);
+    }
+
+    return structType.build();
   }
 }


### PR DESCRIPTION
This implements the get() method for Spanner rows.

Contributes to #34.