### PR TITLE
Implement Spanner Row and Column Metadata

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadata.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
 import io.r2dbc.spi.ColumnMetadata;
 
 /**
@@ -23,9 +25,19 @@ import io.r2dbc.spi.ColumnMetadata;
  */
 public class SpannerColumnMetadata implements ColumnMetadata {
 
-  @Override
-  public String getName() {
-    return null;
+  private final Field columnField;
+
+  public SpannerColumnMetadata(Field columnField) {
+    this.columnField = columnField;
   }
 
+  @Override
+  public String getName() {
+    return columnField.getName();
+  }
+
+  @Override
+  public Type getNativeTypeMetadata() {
+    return columnField.getType();
+  }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
@@ -16,17 +16,26 @@
 
 package com.google.cloud.spanner.r2dbc;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType.Field;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.RowMetadata;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * {@link RowMetadata} implementation for Cloud Spanner.
  */
 public class SpannerRowMetadata implements RowMetadata {
 
-  private final ResultSetMetadata rowMetadata;
+  private final List<ColumnMetadata> columnMetadatas;
+
+  /**
+   * Mapping of column names to its integer index position in the row.
+   */
+  private final HashMap<String, Integer> columnNameIndex;
 
   /**
    * Constructor.
@@ -34,23 +43,51 @@ public class SpannerRowMetadata implements RowMetadata {
    * @param resultSetMetadata the row from Cloud Spanner.
    */
   public SpannerRowMetadata(ResultSetMetadata resultSetMetadata) {
-    this.rowMetadata = resultSetMetadata;
-  }
+    this.columnMetadatas = resultSetMetadata.getRowType().getFieldsList()
+        .stream()
+        .map(SpannerColumnMetadata::new)
+        .collect(Collectors.toList());
 
-  @VisibleForTesting
-  ResultSetMetadata getRowMetadata() {
-    return this.rowMetadata;
+    this.columnNameIndex = new HashMap<>();
+    for (int i = 0; i < resultSetMetadata.getRowType().getFieldsCount(); i++) {
+      Field currField = resultSetMetadata.getRowType().getFields(i);
+      this.columnNameIndex.put(currField.getName(), i);
+    }
   }
 
   @Override
   public ColumnMetadata getColumnMetadata(Object identifier) {
-    // TODO
-    return new SpannerColumnMetadata();
+    int columnIndex = getColumnIndex(identifier);
+    return columnMetadatas.get(columnIndex);
   }
 
   @Override
   public Iterable<? extends ColumnMetadata> getColumnMetadatas() {
-    // TODO
-    return null;
+    return Collections.unmodifiableList(columnMetadatas);
+  }
+
+  /**
+   * Returns the column index of the value in a row for the given {@code identifier}.
+   */
+  int getColumnIndex(Object identifier) {
+    if (identifier instanceof Integer) {
+      return (Integer) identifier;
+    } else if (identifier instanceof String) {
+      return getColumnIndexByName((String) identifier);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Identifier '%s' is not a valid identifier. "
+              + "Should either be an Integer index or a String column name.", identifier));
+    }
+  }
+
+  private int getColumnIndexByName(String name) {
+    if (!columnNameIndex.containsKey(name)) {
+      throw new IllegalArgumentException(
+          "The column name " + name + " does not exist for the Spanner row. "
+              + "Available columns: " + columnNameIndex.keySet());
+    }
+
+    return columnNameIndex.get(name);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.spanner.v1.StructType.Field;
 import org.junit.Test;
 
 /**
@@ -27,8 +28,7 @@ public class SpannerColumnMetadataTest {
 
   @Test
   public void getNameDummyImplementation() {
-    SpannerColumnMetadata metadata = new SpannerColumnMetadata();
-    assertThat(metadata.getName()).isNull();
+    SpannerColumnMetadata metadata = new SpannerColumnMetadata(Field.getDefaultInstance());
+    assertThat(metadata.getName()).isEmpty();
   }
-
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
@@ -19,6 +19,8 @@ package com.google.cloud.spanner.r2dbc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
 import org.junit.Test;
 
 /**
@@ -27,8 +29,21 @@ import org.junit.Test;
 public class SpannerColumnMetadataTest {
 
   @Test
-  public void getNameDummyImplementation() {
+  public void testEmptyFieldName() {
     SpannerColumnMetadata metadata = new SpannerColumnMetadata(Field.getDefaultInstance());
     assertThat(metadata.getName()).isEmpty();
+  }
+
+  @Test
+  public void testSpannerColumnCorrectMetadata() {
+    Field rawColumnInfo =
+        Field.newBuilder()
+            .setName("firstColumn")
+            .setType(Type.newBuilder().setCode(TypeCode.STRING))
+            .build();
+
+    SpannerColumnMetadata metadata = new SpannerColumnMetadata(rawColumnInfo);
+    assertThat(metadata.getName()).isEqualTo("firstColumn");
+    assertThat(metadata.getNativeTypeMetadata()).isEqualTo(rawColumnInfo.getType());
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.cloud.spanner.r2dbc.codecs.Codecs;
 import com.google.cloud.spanner.r2dbc.codecs.DefaultCodecs;
 import com.google.protobuf.Value;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
@@ -39,7 +40,10 @@ public class SpannerRowTest {
 
   @Test
   public void testInvalidIdentifier() {
-    SpannerRow row = new SpannerRow(new ArrayList<>(), StructType.getDefaultInstance());
+    SpannerRow row = new SpannerRow(
+        new ArrayList<>(),
+        new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance()));
+
     assertThatThrownBy(() -> row.get(true, String.class))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Identifier 'true' is not a valid identifier.");
@@ -47,14 +51,20 @@ public class SpannerRowTest {
 
   @Test
   public void testOutOfBoundsIndex() {
-    SpannerRow row = new SpannerRow(new ArrayList<>(), StructType.getDefaultInstance());
+    SpannerRow row = new SpannerRow(
+        new ArrayList<>(),
+        new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance()));
+
     assertThatThrownBy(() -> row.get(4, String.class))
         .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test
   public void testInvalidColumnLabel() {
-    SpannerRow row = new SpannerRow(new ArrayList<>(), StructType.getDefaultInstance());
+    SpannerRow row = new SpannerRow(
+        new ArrayList<>(),
+        new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance()));
+
     assertThatThrownBy(() -> row.get("foobar", String.class))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("The column name foobar does not exist for the Spanner row.");
@@ -62,7 +72,8 @@ public class SpannerRowTest {
 
   @Test
   public void testIndexingIntoColumns() {
-    StructType rowMetadata = createRowMetadata(TypeCode.STRING, TypeCode.INT64, TypeCode.BOOL);
+    SpannerRowMetadata rowMetadata =
+        createRowMetadata(TypeCode.STRING, TypeCode.INT64, TypeCode.BOOL);
     List<Value> rawSpannerRow = createRawSpannerRow("Hello", 25L, true);
     SpannerRow row = new SpannerRow(rawSpannerRow, rowMetadata);
 
@@ -80,7 +91,7 @@ public class SpannerRowTest {
     return listValues;
   }
 
-  private static StructType createRowMetadata(TypeCode... types) {
+  private static SpannerRowMetadata createRowMetadata(TypeCode... types) {
     StructType.Builder structType = StructType.newBuilder();
 
     for (int i = 0; i < types.length; i++) {
@@ -92,6 +103,11 @@ public class SpannerRowTest {
       structType.addFields(field);
     }
 
-    return structType.build();
+    ResultSetMetadata resultSetMetadata =
+        ResultSetMetadata.newBuilder()
+            .setRowType(structType)
+            .build();
+
+    return new SpannerRowMetadata(resultSetMetadata);
   }
 }


### PR DESCRIPTION
This implements the `SpannerRowMetadata` and `SpannerColumnMetadata` objects. Integrates them with `SpannerRow`.

Fixes #34.
Fixes #50.