### PR TITLE
Upgrade to SPI 0.8, add missing interface methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <r2dbc.version>1.0.0.M7</r2dbc.version>
+    <r2dbc.version>0.8.0.M8</r2dbc.version>
     <reactor.version>Californium-SR6</reactor.version>
     <google-auth.version>0.15.0</google-auth.version>
     <grpc.version>1.20.0</grpc.version>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -82,6 +82,11 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
     return DRIVER_NAME.equals(driver);
   }
 
+  @Override
+  public String getDriver() {
+    return DRIVER_NAME;
+  }
+
   @VisibleForTesting
   void setClient(Client client) {
     this.client = client;

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
@@ -38,14 +38,17 @@ public class SpannerRowMetadata implements RowMetadata {
   /**
    * Mapping of column names to its integer index position in the row.
    */
-  private final HashMap<String, Integer> columnNameIndex = new HashMap<>();
+  private final HashMap<String, Integer> columnNameIndex;
 
   /**
-   * Constructor.
+   * Extracts column metadata and initializes lookup data structures from the passed-in
+   * {@link ResultSetMetadata}.
    *
    * @param resultSetMetadata the row from Cloud Spanner.
    */
   public SpannerRowMetadata(ResultSetMetadata resultSetMetadata) {
+
+    this.columnNameIndex = new HashMap<>();
     List<ColumnMetadata> tmpColumnMetadata = new ArrayList<>();
     List<String> tmpColumnNames = new ArrayList<>();
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
@@ -20,10 +20,11 @@ import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.StructType.Field;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.RowMetadata;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * {@link RowMetadata} implementation for Cloud Spanner.
@@ -32,10 +33,12 @@ public class SpannerRowMetadata implements RowMetadata {
 
   private final List<ColumnMetadata> columnMetadatas;
 
+  private final List<String> columnNames;
+
   /**
    * Mapping of column names to its integer index position in the row.
    */
-  private final HashMap<String, Integer> columnNameIndex;
+  private final HashMap<String, Integer> columnNameIndex = new HashMap<>();
 
   /**
    * Constructor.
@@ -43,16 +46,19 @@ public class SpannerRowMetadata implements RowMetadata {
    * @param resultSetMetadata the row from Cloud Spanner.
    */
   public SpannerRowMetadata(ResultSetMetadata resultSetMetadata) {
-    this.columnMetadatas = resultSetMetadata.getRowType().getFieldsList()
-        .stream()
-        .map(SpannerColumnMetadata::new)
-        .collect(Collectors.toList());
+    List<ColumnMetadata> tmpColumnMetadata = new ArrayList<>();
+    List<String> tmpColumnNames = new ArrayList<>();
 
-    this.columnNameIndex = new HashMap<>();
     for (int i = 0; i < resultSetMetadata.getRowType().getFieldsCount(); i++) {
-      Field currField = resultSetMetadata.getRowType().getFields(i);
-      this.columnNameIndex.put(currField.getName(), i);
+      Field field = resultSetMetadata.getRowType().getFields(i);
+      SpannerColumnMetadata metadata = new SpannerColumnMetadata(field);
+      tmpColumnMetadata.add(metadata);
+      tmpColumnNames.add(field.getName());
+      this.columnNameIndex.put(field.getName(), i);
     }
+
+    this.columnMetadatas = Collections.unmodifiableList(tmpColumnMetadata);
+    this.columnNames = Collections.unmodifiableList(tmpColumnNames);
   }
 
   @Override
@@ -64,6 +70,11 @@ public class SpannerRowMetadata implements RowMetadata {
   @Override
   public Iterable<? extends ColumnMetadata> getColumnMetadatas() {
     return Collections.unmodifiableList(this.columnMetadatas);
+  }
+
+  @Override
+  public Collection<String> getColumnNames() {
+    return this.columnNames;
   }
 
   /**

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -90,6 +90,11 @@ public class SpannerConnectionFactoryProviderTest {
     assertTrue(this.spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
   }
 
+  @Test
+  public void getDriverReturnsSpanner() {
+    assertThat(this.spannerConnectionFactoryProvider.getDriver()).isEqualTo(DRIVER_NAME);
+  }
+
   private static ConnectionFactoryOptions buildOptions(String driverName) {
     return ConnectionFactoryOptions.builder()
         .option(ConnectionFactoryOptions.DRIVER, driverName)

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
@@ -51,6 +51,7 @@ public class SpannerRowMetadataTest {
   public void testEmptyResultSetMetadata() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.newBuilder().build());
     assertThat(metadata.getColumnMetadatas()).isEmpty();
+    assertThat(metadata.getColumnNames()).isEmpty();
   }
 
   @Test
@@ -70,6 +71,22 @@ public class SpannerRowMetadataTest {
     assertThat(column0.getName()).isEqualTo("column_0");
     assertThat(column0.getNativeTypeMetadata()).isEqualTo(
         Type.newBuilder().setCode(TypeCode.INT64).build());
+  }
+
+  @Test
+  public void getColumnNamesReturnsCorrectNamesWhenColumnsPresent() {
+    ResultSetMetadata resultSetMetadata
+        = buildResultSetMetadata(TypeCode.INT64, TypeCode.STRING, TypeCode.BOOL);
+    SpannerRowMetadata metadata = new SpannerRowMetadata(resultSetMetadata);
+
+    assertThat(metadata.getColumnNames()).containsExactly("column_0", "column_1", "column_2");
+  }
+
+  @Test
+  public void getColumnNamesReturnsEmptyCollectionWhenNoColumns() {
+    SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance());
+
+    assertThat(metadata.getColumnNames()).isEmpty();
   }
 
   private static ResultSetMetadata buildResultSetMetadata(TypeCode... types) {


### PR DESCRIPTION
The upgrade added a couple of trivial interface methods.

While I was there, I folded everything under a single for-loop in `SpannerRowMetadata`. It already had a for-loop and two stream pipeline. Since now there are three different pieces of data we need to keep track of, a single for-loop is simpler.

Fixes #58 .