### PR TITLE
Set Transaction as Volatile Variable in Connection

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -39,7 +39,7 @@ public class SpannerConnection implements Connection {
 
   private final Session session;
 
-  private Mono<Transaction> currentTransaction;
+  private volatile Transaction currentTransaction;
 
   /**
    * Instantiates a Spanner session with given configuration.
@@ -49,33 +49,38 @@ public class SpannerConnection implements Connection {
   public SpannerConnection(Client client, Session session) {
     this.client = client;
     this.session = session;
-    this.currentTransaction = Mono.empty();
+    this.currentTransaction = null;
   }
 
   @Override
   public Publisher<Void> beginTransaction() {
-    return Mono.defer(() -> {
-      this.currentTransaction = this.client.beginTransaction(this.session).cache();
-      return this.currentTransaction.then();
-    });
+    return this.client.beginTransaction(this.session)
+        .doOnNext(transaction -> this.currentTransaction = transaction)
+        .then();
   }
 
   @Override
   public Publisher<Void> commitTransaction() {
-    return this.currentTransaction
-        .flatMap(transaction -> this.client.commitTransaction(this.session, transaction))
-        .switchIfEmpty(Mono.fromRunnable(() ->
-          this.logger.warn("commitTransaction() is a no-op; called with no transaction active.")))
-        .then();
+    return Mono.defer(() -> {
+      if (this.currentTransaction == null) {
+        this.logger.warn("commitTransaction() is a no-op; called with no transaction active.");
+        return Mono.empty();
+      } else {
+        return this.client.commitTransaction(this.session, this.currentTransaction).then();
+      }
+    });
   }
 
   @Override
   public Publisher<Void> rollbackTransaction() {
-    return this.currentTransaction
-        .flatMap(transaction -> this.client.rollbackTransaction(this.session, transaction))
-        .switchIfEmpty(Mono.fromRunnable(() ->
-          this.logger.warn("rollbackTransaction() is a no-op; called with no transaction active.")))
-        .then();
+    return Mono.defer(() -> {
+      if (this.currentTransaction == null) {
+        this.logger.warn("commitTransaction() is a no-op; called with no transaction active.");
+        return Mono.empty();
+      } else {
+        return this.client.rollbackTransaction(this.session, this.currentTransaction);
+      }
+    });
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -75,7 +75,7 @@ public class SpannerConnection implements Connection {
   public Publisher<Void> rollbackTransaction() {
     return Mono.defer(() -> {
       if (this.currentTransaction == null) {
-        this.logger.warn("commitTransaction() is a no-op; called with no transaction active.");
+        this.logger.warn("rollbackTransaction() is a no-op; called with no transaction active.");
         return Mono.empty();
       } else {
         return this.client.rollbackTransaction(this.session, this.currentTransaction);

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
@@ -23,6 +23,7 @@ import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
+import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -36,7 +37,7 @@ public class SpannerStatement implements Statement {
 
   private Session session;
 
-  private Mono<Transaction> transaction;
+  private Transaction transaction;
 
   private String sql;
 
@@ -52,7 +53,11 @@ public class SpannerStatement implements Statement {
    * @param sql the query to execute
    */
   public SpannerStatement(
-      Client client, Session session, Mono<Transaction> transaction, String sql) {
+      Client client,
+      Session session,
+      @Nullable Transaction transaction,
+      String sql) {
+
     this.client = client;
     this.session = session;
     this.transaction = transaction;

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -20,6 +20,7 @@ import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
+import javax.annotation.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -70,7 +71,7 @@ public interface Client {
    * Execute a streaming query and get partial results.
    */
   Flux<PartialResultSet> executeStreamingSql(
-      Session session, Mono<Transaction> transaction, String sql);
+      Session session, @Nullable Transaction transaction, String sql);
 
   /**
    * Release any resources held by the {@link Client}.

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -78,7 +78,7 @@ public class SpannerConnectionTest {
         .addValues(Value.newBuilder().setStringValue("Odyssey"))
         .build();
 
-    when(this.mockClient.executeStreamingSql(TEST_SESSION, Mono.empty(), sql))
+    when(this.mockClient.executeStreamingSql(TEST_SESSION, null, sql))
         .thenReturn(Flux.just(partialResultSet));
 
     Statement statement = connection.createStatement(sql);
@@ -86,7 +86,7 @@ public class SpannerConnectionTest {
     Mono<SpannerResult> result = (Mono<SpannerResult>)statement.execute();
     result.block().map((r, m) -> (String)r.get(0)).blockFirst().equals("Odyssey");
 
-    verify(this.mockClient).executeStreamingSql(TEST_SESSION, Mono.empty(), sql);
+    verify(this.mockClient).executeStreamingSql(TEST_SESSION, null, sql);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -73,11 +73,11 @@ public class SpannerStatementTest {
                     .setType(Type.newBuilder().setCode(TypeCode.STRING)))))
         .addValues(Value.newBuilder().setStringValue("Odyssey"))
         .build();
-    when(mockClient.executeStreamingSql(TEST_SESSION, Mono.empty(), sql))
+    when(mockClient.executeStreamingSql(TEST_SESSION, null, sql))
         .thenReturn(Flux.just(partialResultSet));
 
     SpannerStatement statement
-        = new SpannerStatement(mockClient, TEST_SESSION, Mono.empty(),sql);
+        = new SpannerStatement(mockClient, TEST_SESSION, null,sql);
 
     Mono<SpannerResult> result = (Mono<SpannerResult>)statement.execute();
 
@@ -85,7 +85,7 @@ public class SpannerStatementTest {
 
     result.block().map((r, m) -> (String)r.get(0)).blockFirst().equals("Odyssey");
 
-    verify(mockClient).executeStreamingSql(TEST_SESSION, Mono.empty(), sql);
+    verify(mockClient).executeStreamingSql(TEST_SESSION, null, sql);
   }
 
   @Test
@@ -149,11 +149,11 @@ public class SpannerStatementTest {
         .setMetadata(ResultSetMetadata.getDefaultInstance())
         .setStats(ResultSetStats.getDefaultInstance())
         .build();
-    when(mockClient.executeStreamingSql(TEST_SESSION, Mono.empty(), sql))
+    when(mockClient.executeStreamingSql(TEST_SESSION, null, sql))
         .thenReturn(Flux.just(partialResultSet));
 
     SpannerStatement statement
-        = new SpannerStatement(mockClient, TEST_SESSION, Mono.empty(),sql);
+        = new SpannerStatement(mockClient, TEST_SESSION, null,sql);
 
     SpannerResult result = ((Mono<SpannerResult>) statement.execute()).block();
 
@@ -163,6 +163,6 @@ public class SpannerStatementTest {
     int rowsUpdated = Mono.from(result.getRowsUpdated()).block();
     assertThat(rowsUpdated).isEqualTo(0);
 
-    verify(mockClient, times(1)).executeStreamingSql(TEST_SESSION, Mono.empty(), sql);
+    verify(mockClient, times(1)).executeStreamingSql(TEST_SESSION, null, sql);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -43,7 +43,6 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import reactor.core.publisher.Mono;
 
 /**
  * Test for {@link GrpcClient}.
@@ -91,10 +90,9 @@ public class GrpcClientTest {
           }
         },
         // call the method under test
-        grpcClient -> grpcClient.executeStreamingSql(session,
-            Mono.just(Transaction.newBuilder().setId(
-            transId).build()), sql).blockFirst()
-        );
+        grpcClient ->
+            grpcClient.executeStreamingSql(
+                session, Transaction.newBuilder().setId(transId).build(), sql).blockFirst());
 
     // verify the service was called correctly
     ArgumentCaptor<ExecuteSqlRequest> requestCaptor = ArgumentCaptor


### PR DESCRIPTION
As per discussion today with R2DBC folks, this PR modifies `SpannerConnection` to set the transaction as a volatile property of the connection class.