### PR TITLE
Modify Retry Approach to Propagate Errors

### DIFF
--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -47,6 +47,7 @@ public class ObservableReactiveUtilTest {
       observer.onError(new IllegalArgumentException("oh no"));
     });
     assertThatThrownBy(() -> mono.block())
+        .hasCauseInstanceOf(IllegalArgumentException.class)
         .isInstanceOf(R2dbcNonTransientException.class)
         .hasMessage("oh no");
   }
@@ -69,6 +70,7 @@ public class ObservableReactiveUtilTest {
         ObservableReactiveUtil.unaryCall(observer -> observer.onError(retryableException));
 
     assertThatThrownBy(() -> result.block())
+        .hasCauseInstanceOf(StatusRuntimeException.class)
         .isInstanceOf(R2dbcTransientResourceException.class);
   }
 
@@ -79,6 +81,7 @@ public class ObservableReactiveUtilTest {
             observer -> observer.onError(new IllegalArgumentException()));
 
     assertThatThrownBy(() -> result.block())
+        .hasCauseInstanceOf(IllegalArgumentException.class)
         .isInstanceOf(R2dbcNonTransientException.class);
   }
 
@@ -92,6 +95,7 @@ public class ObservableReactiveUtilTest {
         ObservableReactiveUtil.streamingCall(observer -> observer.onError(retryableException));
 
     assertThatThrownBy(() -> result.blockFirst())
+        .hasCauseInstanceOf(StatusRuntimeException.class)
         .isInstanceOf(R2dbcTransientResourceException.class);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.r2dbc.spi.R2dbcNonTransientException;
 import io.r2dbc.spi.R2dbcTransientResourceException;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -46,7 +47,7 @@ public class ObservableReactiveUtilTest {
       observer.onError(new IllegalArgumentException("oh no"));
     });
     assertThatThrownBy(() -> mono.block())
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(R2dbcNonTransientException.class)
         .hasMessage("oh no");
   }
 
@@ -78,7 +79,7 @@ public class ObservableReactiveUtilTest {
             observer -> observer.onError(new IllegalArgumentException()));
 
     assertThatThrownBy(() -> result.block())
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(R2dbcNonTransientException.class);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -21,8 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.util.concurrent.atomic.AtomicInteger;
+import io.r2dbc.spi.R2dbcTransientResourceException;
 import org.junit.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -51,51 +52,45 @@ public class ObservableReactiveUtilTest {
 
   @Test
   public void unaryCallThrowsExceptionIfCompletedWithNoValue() {
-    Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
-      observer.onCompleted();
-    });
+    Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> observer.onCompleted());
     assertThatThrownBy(() -> mono.block())
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Unary gRPC call completed without yielding a value or an error");
   }
 
   @Test
-  public void unaryCallRetries() {
-    StatusRuntimeException retryableError = new StatusRuntimeException(
-        Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"), null);
+  public void propagateTransientErrorUnaryCall() {
+    StatusRuntimeException retryableException =
+        new StatusRuntimeException(
+            Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"));
 
-    AtomicInteger timesRetried = new AtomicInteger(0);
+    Mono<Void> result =
+        ObservableReactiveUtil.unaryCall(observer -> observer.onError(retryableException));
 
-    Mono<Integer> resultMono = ObservableReactiveUtil.unaryCall(
-        obs -> {
-          // Test must retry twice before success.
-          if (timesRetried.get() < 3) {
-            obs.onError(retryableError);
-            timesRetried.addAndGet(1);
-          } else {
-            obs.onNext(100);
-          }
-        });
-
-    int result = resultMono.block();
-    assertThat(timesRetried.get()).isEqualTo(3);
-    assertThat(result).isEqualTo(100);
+    assertThatThrownBy(() -> result.block())
+        .isInstanceOf(R2dbcTransientResourceException.class);
   }
 
   @Test
-  public void unaryCallUnretryableError() {
-    AtomicInteger timesTried = new AtomicInteger(0);
-    Mono<Integer> resultMono = ObservableReactiveUtil.unaryCall(
-        obs -> {
-          if (timesTried.get() < 3) {
-            obs.onError(new IllegalArgumentException());
-            timesTried.addAndGet(1);
-          } else {
-            obs.onNext(100);
-          }
-        });
+  public void propagateNonRetryableError() {
+    Mono<Void> result =
+        ObservableReactiveUtil.unaryCall(
+            observer -> observer.onError(new IllegalArgumentException()));
 
-    assertThatThrownBy(() -> resultMono.block()).isInstanceOf(IllegalArgumentException.class);
-    assertThat(timesTried.get()).isEqualTo(1);
+    assertThatThrownBy(() -> result.block())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void propagateTransientErrorStreamingCall() {
+    StatusRuntimeException retryableException =
+        new StatusRuntimeException(
+            Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"));
+
+    Flux<Void> result =
+        ObservableReactiveUtil.streamingCall(observer -> observer.onError(retryableException));
+
+    assertThatThrownBy(() -> result.blockFirst())
+        .isInstanceOf(R2dbcTransientResourceException.class);
   }
 }


### PR DESCRIPTION
This modifies the retry logic of the driver to propagate `R2dbcTransientExceptions` if a call fails instead of attempting to retry on the driver-side.