### PR TITLE
Add a SLF4J logging provider for tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,13 @@
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.25</version>
+      <scope>test</scope>
+    </dependency>
+
 
     <!-- TODO: this is a test dependency for now. Should project ID discovery be part of the driver itself? -->
     <dependency>


### PR DESCRIPTION
Provides a SLF4J binder for tests. Fixes #67.

**Note:** the dep must be test-scoped because "embedded components" like libraries or drivers should not specify a logging provider and leave the decision to the client: http://www.slf4j.org/codes.html#StaticLoggerBinder