### PR TITLE
Add Helper Classes to Parse Statement Types

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
@@ -166,7 +166,7 @@ public class SpannerStatement implements Statement {
       return resultSetFlux
           .last()
           .map(partialResultSet -> Math.toIntExact(partialResultSet.getStats().getRowCountExact()))
-          .transform(rowCount -> Mono.just(new SpannerResult(Flux.empty(), rowCount)));
+          .map(rowCount -> new SpannerResult(Flux.empty(), Mono.just(rowCount)));
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
@@ -149,8 +149,8 @@ public class SpannerStatement implements Statement {
     PartialResultRowExtractor partialResultRowExtractor = new PartialResultRowExtractor();
     StatementType statementType = StatementParser.getStatementType(this.sql);
 
-    Flux<PartialResultSet> resultSetFlux
-        = this.client.executeStreamingSql(
+    Flux<PartialResultSet> resultSetFlux =
+        this.client.executeStreamingSql(
             this.session, this.transaction, this.sql, params, this.types);
 
     if (statementType == StatementType.SELECT) {

--- a/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementParser.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementParser.java
@@ -24,6 +24,9 @@ import java.util.List;
  */
 public class StatementParser {
 
+  /** Matches on the Spanner SQL hints in the form @{hintName...} */
+  private static final String SQL_OPTIONS_REGEX = "(?m)@\\{.*\\}";
+
   private static final List<String> SELECT_STATEMENTS = Arrays.asList("select");
   private static final List<String> DDL_STATEMENTS = Arrays.asList("create", "drop", "alter");
   private static final List<String> DML_STATEMENTS = Arrays.asList("insert", "update", "delete");
@@ -34,29 +37,24 @@ public class StatementParser {
    * Returns the statement type of a given SQL string.
    */
   public static StatementType getStatementType(String sql) {
-    String processedSql = sql.trim().toLowerCase();
+    String processedSql = processSql(sql);
 
-    if (isSelectQuery(processedSql)) {
+    if (statementStartsWith(processedSql, SELECT_STATEMENTS)) {
       return StatementType.SELECT;
-    } else if (isDdl(processedSql)) {
+    } else if (statementStartsWith(processedSql, DDL_STATEMENTS)) {
       return StatementType.DDL;
-    } else if (isDml(processedSql)) {
+    } else if (statementStartsWith(processedSql, DML_STATEMENTS)) {
       return StatementType.DML;
     } else {
       return StatementType.UNKNOWN;
     }
   }
 
-  private static boolean isSelectQuery(String sql) {
-    return statementStartsWith(sql, SELECT_STATEMENTS);
-  }
-
-  private static boolean isDdl(String sql) {
-    return statementStartsWith(sql, DDL_STATEMENTS);
-  }
-
-  private static boolean isDml(String sql) {
-    return statementStartsWith(sql, DML_STATEMENTS);
+  private static String processSql(String rawSql) {
+    return rawSql
+        .replaceAll(SQL_OPTIONS_REGEX, "")
+        .trim()
+        .toLowerCase();
   }
 
   private static boolean statementStartsWith(String sqlStatement, List<String> prefixes) {

--- a/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementParser.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementParser.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Parses SQL statements to determine what type of statement it is.
+ */
+public class StatementParser {
+
+  private static final List<String> SELECT_STATEMENTS = Arrays.asList("select");
+  private static final List<String> DDL_STATEMENTS = Arrays.asList("create", "drop", "alter");
+  private static final List<String> DML_STATEMENTS = Arrays.asList("insert", "update", "delete");
+
+  private StatementParser() {}
+
+  /**
+   * Returns the statement type of a given SQL string.
+   */
+  public static StatementType getStatementType(String sql) {
+    String processedSql = sql.trim().toLowerCase();
+
+    if (isSelectQuery(processedSql)) {
+      return StatementType.SELECT;
+    } else if (isDdl(processedSql)) {
+      return StatementType.DDL;
+    } else if (isDml(processedSql)) {
+      return StatementType.DML;
+    } else {
+      return StatementType.UNKNOWN;
+    }
+  }
+
+  private static boolean isSelectQuery(String sql) {
+    return statementStartsWith(sql, SELECT_STATEMENTS);
+  }
+
+  private static boolean isDdl(String sql) {
+    return statementStartsWith(sql, DDL_STATEMENTS);
+  }
+
+  private static boolean isDml(String sql) {
+    return statementStartsWith(sql, DML_STATEMENTS);
+  }
+
+  private static boolean statementStartsWith(String sqlStatement, List<String> prefixes) {
+    return prefixes.stream().anyMatch(sqlPrefix -> sqlStatement.startsWith(sqlPrefix));
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementType.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+/** Describes the type of a SQL statement. */
+public enum StatementType {
+  SELECT,
+  DDL,
+  DML,
+  UNKNOWN;
+}

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -133,7 +133,7 @@ public class SpannerConnectionFactoryProviderTest {
 
 
     StepVerifier.create(connectionFactory.create()
-        .flatMapMany(c -> c.createStatement("sql").execute())
+        .flatMapMany(c -> c.createStatement("SELECT * from table").execute())
             .flatMap(result -> result.map((row,meta) -> row.get(0, String.class)))
         )
         .then(() -> {

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -168,8 +168,9 @@ public class SpannerStatementTest {
 
     when(this.mockClient.executeStreamingSql(any(), any(), any(), any(), any())).thenReturn(inputs);
 
-    Mono<Result> resultMono = Mono
-        .from(new SpannerStatement(this.mockClient, null, null, "").execute());
+    Mono<Result> resultMono =
+        Mono.from(new SpannerStatement(
+            this.mockClient, null, null, "SELECT * FROM table").execute());
 
     StepVerifier.create(resultMono.flatMap(r -> Mono.from(r.getRowsUpdated())))
         .expectNext(0)

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -136,6 +136,8 @@ public class SpannerIT {
                 + "  CATEGORY INT64 NOT NULL"
                 + ") PRIMARY KEY (UUID)"),
         null).get();
+
+    spanner.close();
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -136,8 +136,6 @@ public class SpannerIT {
                 + "  CATEGORY INT64 NOT NULL"
                 + ") PRIMARY KEY (UUID)"),
         null).get();
-
-    spanner.close();
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -59,4 +59,10 @@ public class StatementParserTest {
     String sql = "int number = 5";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.UNKNOWN);
   }
+
+  @Test
+  public void parseQueryWithOptionsPrefix() {
+    String sql = "@{FORCE_INDEX=index_name} @{JOIN_METHOD=HASH_JOIN} SELECT * FROM blahblah";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);
+  }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class StatementParserTest {
+
+  @Test
+  public void parsesSelectQueries() {
+    String sql = "SELECT * from blahblahblah";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);
+  }
+
+  @Test
+  public void parsesDmlQueries() {
+    String sql = "InSeRt INTO TABLE_NAME VALUES (value1, value2, value3,...valueN)";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DML);
+
+    sql = "DELETE FROM target_name WHERE true";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DML);
+
+    sql = "UPDATE Singers\n"
+        + "SET BirthDate = '1990-10-10'\n"
+        + "WHERE FirstName = 'Marc' AND LastName = 'Richards'";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DML);
+  }
+
+  @Test
+  public void parsesDdlQueries() {
+    String sql = "drop table Blarg";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DDL);
+
+    sql = "CREATE table foobar5000";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DDL);
+
+    sql = "ALTER TABLE table Add Column name STRING";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DDL);
+  }
+
+  @Test
+  public void parseUnknownQuery() {
+    String sql = "int number = 5";
+    assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.UNKNOWN);
+  }
+}


### PR DESCRIPTION
This adds the initial helper classes to parse statement types.

Contributes to DML and DDL efforts in which statement type must be known.