### PR TITLE
Move Statement Bindings to Separate Class for Organization

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementBindings.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/statement/StatementBindings.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+import com.google.cloud.spanner.r2dbc.codecs.Codec;
+import com.google.cloud.spanner.r2dbc.codecs.Codecs;
+import com.google.cloud.spanner.r2dbc.codecs.DefaultCodecs;
+import com.google.cloud.spanner.r2dbc.util.Assert;
+import com.google.protobuf.Struct;
+import com.google.spanner.v1.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a set of bindings for a Spanner SQL statement.
+ */
+public class StatementBindings {
+
+  private static final Codecs codecs = new DefaultCodecs();
+
+  private Struct.Builder currentStruct;
+
+  private final List<Struct> structList;
+
+  private final Map<String, Codec> resolvedCodecs;
+
+  private final Map<String, Type> typesMap;
+
+  /**
+   * Constructs a {@link StatementBindings} object representing a list of bindings for a Spanner
+   * statement.
+   */
+  public StatementBindings() {
+    this.currentStruct = Struct.newBuilder();
+    this.structList = new ArrayList<>();
+    this.resolvedCodecs = new HashMap<>();
+    this.typesMap = new HashMap<>();
+  }
+
+  /**
+   * Adds the current binding to the list of bindings for the statement and starts a new parameter
+   * binding.
+   */
+  public void completeBinding() {
+    if (this.currentStruct.getFieldsCount() > 0) {
+      this.structList.add(this.currentStruct.build());
+      this.currentStruct = Struct.newBuilder();
+    }
+  }
+
+  /**
+   * Add an additional param-to-value binding pair to the current parameter binding.
+   */
+  public void createBind(String identifier, Object value) {
+    Assert.requireNonNull(identifier, "Identifier must not be null.");
+    Assert.requireNonNull(value, "Value bound must not be null.");
+
+    Object valToStore;
+    Class classToStore;
+
+    if (value.getClass().equals(TypedNull.class)) {
+      valToStore = null;
+      classToStore = ((TypedNull) value).getType();
+    } else {
+      valToStore = value;
+      classToStore = value.getClass();
+    }
+
+    Codec codec = this.resolvedCodecs
+        .computeIfAbsent(identifier, n -> codecs.getCodec(classToStore));
+
+    this.currentStruct.putFields(identifier, codec.encode(valToStore));
+
+    if (this.structList.isEmpty()) {
+      // first binding, fill types map
+      this.typesMap.put(identifier, Type.newBuilder().setCode(codec.getTypeCode()).build());
+    }
+  }
+
+  /**
+   * Returns the built binding for the statement.
+   */
+  public List<Struct> getBindings() {
+    completeBinding();
+
+    if (this.structList.isEmpty()) {
+      return Collections.singletonList(Struct.getDefaultInstance());
+    } else {
+      return this.structList;
+    }
+  }
+
+  public Map<String, Type> getTypes() {
+    return this.typesMap;
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/r2dbc/statement/TypedNull.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/statement/TypedNull.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+/**
+ * A helper class. Spanner queries require nulls to be bound with their column's actual type.
+ */
+public class TypedNull {
+
+  private final Class type;
+
+  public TypedNull(Class type) {
+    this.type = type;
+  }
+
+  public Class getType() {
+    return this.type;
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import org.junit.Test;
+
+public class StatementBindingsTest {
+
+  @Test
+  public void addBasicBinding() {
+    StatementBindings statementBindings = new StatementBindings();
+    statementBindings.createBind("name", "John");
+    statementBindings.createBind("age", 50);
+    statementBindings.completeBinding();
+
+    assertThat(statementBindings.getTypes())
+        .containsExactly(
+            entry("name", Type.newBuilder().setCode(TypeCode.STRING).build()),
+            entry("age", Type.newBuilder().setCode(TypeCode.INT64).build()));
+
+    assertThat(statementBindings.getBindings())
+        .containsExactly(
+            Struct.newBuilder()
+                .putFields("name", Value.newBuilder().setStringValue("John").build())
+                .putFields("age", Value.newBuilder().setStringValue("50").build())
+                .build());
+  }
+
+  @Test
+  public void testNoopAddBinding() {
+    StatementBindings statementBindings = new StatementBindings();
+    statementBindings.completeBinding();
+    statementBindings.completeBinding();
+    statementBindings.completeBinding();
+
+    assertThat(statementBindings.getTypes()).isEmpty();
+    assertThat(statementBindings.getBindings()).containsExactly(Struct.getDefaultInstance());
+  }
+}


### PR DESCRIPTION
Moves the Statement bindings logic to separate class for organization.

Purpose for doing this: This will allow us to add more logic to the statement class to support DML, DDL, and normal queries without the class becoming too big.