### PR TITLE
decimate request size

### DIFF
--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -154,7 +154,7 @@ public class SpannerIT {
   @Test
   public void testLargeReadWrite() {
     // string size must be below 10 MB
-    int maxStringLength = 1000000;
+    int maxStringLength = 100000;
 
     int numberOfBooks = 20;
 


### PR DESCRIPTION
Switching to `ExecuteBatchDml` lowered the amount of data that could be sent without tripping `INVALID_ARGUMENT: Request payload size exceeds the limit: 1048576 bytes.`.
