### PR TITLE
Add DDL options Propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,54 @@
 
 An implementation of the [R2DBC](https://r2dbc.io/) driver for [Cloud Spanner](https://cloud.google.com/spanner/) is being developed in this repository.
 
+## Setup Instructions
+
+This section describes how to setup and begin using the Cloud Spanner R2DBC driver.
+
+### Maven
+
+Below is the Maven coordinates for this driver:
+
+```
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>cloud-spanner-r2dbc</artifactId>
+  <version> TBD </version>
+</dependency>
+```
+
+### Usage
+
+The entry point to using the R2DBC driver is to first configure the R2DBC connection factory.
+
+```
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PROJECT;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
+
+ConnectionFactory connectionFactory =
+    ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        .option(DRIVER, "spanner")
+        .option(PROJECT, "your-gcp-project-id")
+        .option(INSTANCE, "your-spanner-instance")
+        .option(DATABASE, "your-database-name")
+        .build());
+        
+// The R2DBC connection may now be created.
+Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+```
+
+The following options are available to be configured for the connection factory:
+
+| Option Name | Description                | Required | Default Value |
+|-------------|----------------------------|----------|---------------|
+| `DRIVER`    | Must be "spanner"          | True     |               |
+| `PROJECT`   | Your GCP Project ID        | True     |               |
+| `INSTANCE`  | Your Spanner Instance name | True     |               |
+| `DATABASE`  | Your Spanner Database name | True     |               |
+| `PARTIAL_RESULT_SET_FETCH_SIZE` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
+
 ## Mapping of Data Types
 Cloud Spanner R2DBC Driver supports the following types:
-
 
 | Spanner Type | Java type         |
 |--------------|-------------------|

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following options are available to be configured for the connection factory:
 | `INSTANCE`  | Your Spanner Instance name | True     |               |
 | `DATABASE`  | Your Spanner Database name | True     |               |
 | `PARTIAL_RESULT_SET_FETCH_SIZE` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
+| `DDL_OPERATION_TIMEOUT` | Duration to wait for a DDL operation to complete before timing out | False | 600 seconds |
+| `DDL_OPERATION_POLL_INTERVAL` | Duration to wait between each polling request for the completion of a DDL operation | False | 5 seconds |
 
 ## Mapping of Data Types
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ The following options are available to be configured for the connection factory:
 
 | Option Name | Description                | Required | Default Value |
 |-------------|----------------------------|----------|---------------|
-| `DRIVER`    | Must be "spanner"          | True     |               |
-| `PROJECT`   | Your GCP Project ID        | True     |               |
-| `INSTANCE`  | Your Spanner Instance name | True     |               |
-| `DATABASE`  | Your Spanner Database name | True     |               |
-| `GOOGLE_CREDENTIALS` | Optional [Google credentials](https://cloud.google.com/docs/authentication/production) to specify for your Google Cloud account. | False | If not provided, credentials will be [inferred from your runtime environment](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically).
-| `PARTIAL_RESULT_SET_FETCH_SIZE` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
-| `DDL_OPERATION_TIMEOUT` | Duration to wait for a DDL operation to complete before timing out | False | 600 seconds |
-| `DDL_OPERATION_POLL_INTERVAL` | Duration to wait between each polling request for the completion of a DDL operation | False | 5 seconds |
+| `driver`    | Must be "spanner"          | True     |               |
+| `project`   | Your GCP Project ID        | True     |               |
+| `instance`  | Your Spanner Instance name | True     |               |
+| `database`  | Your Spanner Database name | True     |               |
+| `google_credentials` | Optional [Google credentials](https://cloud.google.com/docs/authentication/production) to specify for your Google Cloud account. | False | If not provided, credentials will be [inferred from your runtime environment](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically).
+| `partial_result_set_fetch_size` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
+| `ddl_operation_timeout` | Duration in seconds to wait for a DDL operation to complete before timing out | False | 600 seconds |
+| `ddl_operation_poll_interval` | Duration in seconds to wait between each polling request for the completion of a DDL operation | False | 5 seconds |
 
 
 ## Mapping of Data Types

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -128,6 +128,16 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
+    public Builder setDdlOperationTimeout(Duration duration) {
+      this.ddlOperationTimeout = duration;
+      return this;
+    }
+
+    public Builder setDdlOperationPollInterval(Duration duration) {
+      this.ddlOperationPollInterval = duration;
+      return this;
+    }
+
     /**
      * Constructs an instance of the {@link SpannerConnectionConfiguration}.
      */

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -28,6 +28,7 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
+import java.time.Duration;
 
 /**
  * An implementation of {@link ConnectionFactoryProvider} for creating {@link
@@ -45,8 +46,17 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   /** Option name for GCP Spanner instance. */
   public static final Option<String> INSTANCE = Option.valueOf("instance");
 
-  public static final Option<Integer> PARTIAL_RESULT_SET_FETCH_SIZE
-      = Option.valueOf("partial_result_set_fetch_size");
+  /** Number of partial result sets to buffer during a read query operation. */
+  public static final Option<Integer> PARTIAL_RESULT_SET_FETCH_SIZE =
+      Option.valueOf("partial_result_set_fetch_size");
+
+  /** Duration to wait for a DDL operation before timing out. */
+  public static final Option<Duration> DDL_OPERATION_TIMEOUT =
+      Option.valueOf("ddl_operation_timeout");
+
+  /** Duration to wait between each poll checking for the completion of DDL operations. */
+  public static final Option<Duration> DDL_OPERATION_POLL_INTERVAL =
+      Option.valueOf("ddl_operation_poll_interval");
 
   /**
    * Option specifying the location of the GCP credentials file.
@@ -97,6 +107,14 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
     if (options.hasOption(PARTIAL_RESULT_SET_FETCH_SIZE)) {
       configBuilder.setPartialResultSetFetchSize(options.getValue(PARTIAL_RESULT_SET_FETCH_SIZE));
+    }
+
+    if (options.hasOption(DDL_OPERATION_TIMEOUT)) {
+      configBuilder.setDdlOperationTimeout(options.getValue(DDL_OPERATION_TIMEOUT));
+    }
+
+    if (options.hasOption(DDL_OPERATION_POLL_INTERVAL)) {
+      configBuilder.setDdlOperationPollInterval(options.getValue(DDL_OPERATION_POLL_INTERVAL));
     }
 
     return configBuilder.build();

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -113,5 +114,19 @@ public class SpannerConnectionConfigurationTest {
         .setDatabaseName("db")
         .build();
     assertThat(config.getPartialResultSetFetchSize()).isEqualTo(42);
+  }
+
+  @Test
+  public void ddlOperationWaitSettings() {
+    SpannerConnectionConfiguration config = this.configurationBuilder
+        .setProjectId("project1")
+        .setInstanceName("an-instance")
+        .setDatabaseName("db")
+        .setDdlOperationTimeout(Duration.ofSeconds(23))
+        .setDdlOperationPollInterval(Duration.ofSeconds(45))
+        .build();
+
+    assertThat(config.getDdlOperationTimeout()).isEqualTo(Duration.ofSeconds(23));
+    assertThat(config.getDdlOperationPollInterval()).isEqualTo(Duration.ofSeconds(45));
   }
 }


### PR DESCRIPTION
Allow DDL timeout and poll settings to be propagated from the spanner configuration settings.