### PR TITLE
Add Kokoro CI job for publishing snapshots to Maven Central

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,8 +15,8 @@
 
 set -eo pipefail
 
-pushd $(dirname "$0")/../
-mvnw verify -B -V -DskipITs
-popd
+dir=$(dirname "$0")
 
-source $(dirname "$0")/release_snapshot.sh
+$dir/../mvnw verify -B -V -DskipITs
+
+source $dir/release_snapshot.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -17,6 +17,8 @@ set -eo pipefail
 
 dir=$(dirname "$0")
 
-$dir/../mvnw verify -B -V -DskipITs
+pushd $dir/../
+./mvnw verify -B -V -DskipITs
+popd
 
 source $dir/release_snapshot.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,6 +15,8 @@
 
 set -eo pipefail
 
-$(dirname "$0")/../mvnw verify -B -V -DskipITs
+pushd $(dirname "$0")/../
+mvnw verify -B -V -DskipITs
+popd
 
 source $(dirname "$0")/release_snapshot.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./mvnw verify -B -V -DskipITs;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-./mvnw verify -B -V -DskipITs
 
+pushd ..
+./mvnw verify -B -V -DskipITs
+popd

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-./mvnw verify -B -V -DskipITs;
+./mvnw verify -B -V -DskipITs
+

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,8 +15,6 @@
 
 set -eo pipefail
 
-pushd ..
 $(dirname "$0")/../mvnw verify -B -V -DskipITs
-popd
 
 source $(dirname "$0")/release_snapshot.sh

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 pushd ..
-./mvnw verify -B -V -DskipITs
+$(dirname "$0")/../mvnw verify -B -V -DskipITs
 popd
 
 source $(dirname "$0")/release_snapshot.sh

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Get secrets from keystore and set and environment variables
+setup_environment_secrets() {
+  export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
+  export GPG_TTY=$(tty)
+  export GPG_HOMEDIR=/gpg
+  mkdir $GPG_HOMEDIR
+  mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
+  mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg
+  export SONATYPE_USERNAME=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f1 -d'|')
+  export SONATYPE_PASSWORD=$(cat ${KOKORO_KEYSTORE_DIR}/70247_sonatype-credentials | cut -f2 -d'|')
+}
+
+create_settings_xml_file() {
+  echo "<settings>
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>" > $1
+}

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 setup_environment_secrets() {
   export GPG_PASSPHRASE=$(cat ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-passphrase)
   export GPG_TTY=$(tty)
-  export GPG_HOMEDIR=/gpg
+  export GPG_HOMEDIR=${TMPDIR}/gpg
   mkdir $GPG_HOMEDIR
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-pubkeyring $GPG_HOMEDIR/pubring.gpg
   mv ${KOKORO_KEYSTORE_DIR}/70247_maven-gpg-keyring $GPG_HOMEDIR/secring.gpg

--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "cloud-spanner-r2dbc/.kokoro/build.sh"

--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -1,3 +1,39 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 build_file: "cloud-spanner-r2dbc/.kokoro/build.sh"
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-keyring"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-passphrase"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "maven-gpg-pubkeyring"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 70247
+      keyname: "sonatype-credentials"
+    }
+  }
+}

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -11,12 +11,21 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the Licensecense.
 
 set -eo pipefail
 
-pushd ..
-./mvnw verify -B -V -DskipITs
-popd
+source $(dirname "$0")/common.sh
+MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../)/settings.xml
+pushd $(dirname "$0")/../
 
-source $(dirname "$0")/release_snapshot.sh
+setup_environment_secrets
+create_settings_xml_file "settings.xml"
+
+mvn clean deploy -B \
+  -DskipTests=true \
+  --settings ${MAVEN_SETTINGS_FILE} \
+  -Dgpg.executable=gpg \
+  -Dgpg.passphrase=${GPG_PASSPHRASE} \
+  -Dgpg.homedir=${GPG_HOMEDIR} \
+  -P release

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -15,15 +15,15 @@
 
 set -eo pipefail
 
-source $(dirname "$0")/common.sh
-MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../)/settings.xml
+dir=$(dirname "$0")
 
-pushd $(dirname "$0")/../
+source $dir/common.sh
+MAVEN_SETTINGS_FILE=$(realpath $dir/../)/settings.xml
 
 setup_environment_secrets
-create_settings_xml_file "settings.xml"
+create_settings_xml_file $MAVEN_SETTINGS_FILE
 
-$(dirname "$0")/../mvn clean deploy -B \
+$dir/../mvn clean deploy -B \
   -DskipTests=true \
   --settings ${MAVEN_SETTINGS_FILE} \
   -Dgpg.executable=gpg \

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -15,10 +15,6 @@
 
 set -eo pipefail
 
-# Start the releasetool reporter
-python3 -m pip install gcp-releasetool
-python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
-
 dir=$(dirname "$0")
 
 source $dir/common.sh

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -15,6 +15,10 @@
 
 set -eo pipefail
 
+# Start the releasetool reporter
+python3 -m pip install gcp-releasetool
+python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+
 dir=$(dirname "$0")
 
 source $dir/common.sh

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0")/../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn clean deploy -B \
+$(dirname "$0")/../mvnw clean deploy -B \
   -DskipTests=true \
   --settings ${MAVEN_SETTINGS_FILE} \
   -Dgpg.executable=gpg \

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -17,15 +17,18 @@ set -eo pipefail
 
 source $(dirname "$0")/common.sh
 MAVEN_SETTINGS_FILE=$(realpath $(dirname "$0")/../)/settings.xml
+
 pushd $(dirname "$0")/../
 
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-$(dirname "$0")/../mvnw clean deploy -B \
+$(dirname "$0")/../mvn clean deploy -B \
   -DskipTests=true \
   --settings ${MAVEN_SETTINGS_FILE} \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
   -Dgpg.homedir=${GPG_HOMEDIR} \
   -P release
+
+popd

--- a/.kokoro/release_snapshot.sh
+++ b/.kokoro/release_snapshot.sh
@@ -18,12 +18,15 @@ set -eo pipefail
 dir=$(dirname "$0")
 
 source $dir/common.sh
-MAVEN_SETTINGS_FILE=$(realpath $dir/../)/settings.xml
+
+pushd $dir/../
+
+MAVEN_SETTINGS_FILE=$(realpath .)/settings.xml
 
 setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
-$dir/../mvn clean deploy -B \
+./mvnw clean deploy -B \
   -DskipTests=true \
   --settings ${MAVEN_SETTINGS_FILE} \
   -Dgpg.executable=gpg \

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,64 @@
   <version>0.1.0-SNAPSHOT</version>
 
   <name>Google Cloud Spanner R2DBC</name>
+  <description>Reactive R2DBC driver implementation for Cloud Spanner.</description>
+  <url>https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>ChengyuanZhao</id>
+      <name>Chengyuan Zhao</name>
+      <email>cccz@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>dmitry-s</id>
+      <name>Dmitry Solomakha</name>
+      <email>dsolomakha@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>dzou</id>
+      <name>Daniel Zou</name>
+      <email>dzou@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>elefeint</id>
+      <name>Elena Felder</name>
+      <email>elfel@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>meltsufin</id>
+      <name>Mike Eltsufin</name>
+      <email>meltsufin@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+
+  <scm>
+    <connection>scm:git:git@github.com:GoogleCloudPlatform/cloud-spanner-r2dbc.git</connection>
+    <developerConnection>scm:git:git@github.com:GoogleCloudPlatform/cloud-spanner-r2dbc.git</developerConnection>
+    <url>https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,8 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
-                <configuration> <!-- add this to disable checking -->
+                <configuration>
+                  <!-- ignore javadoc errors -->
                   <additionalparam>-Xdoclint:none</additionalparam>
                   <source>8</source>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,13 @@
     <tag>HEAD</tag>
   </scm>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -305,5 +305,55 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,10 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+                <configuration> <!-- add this to disable checking -->
+                  <additionalparam>-Xdoclint:none</additionalparam>
+                  <source>8</source>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Adds `continous.cfg` build configuration for Kokoro. The job first builds the project skipping integration tests, and then deploys (publishes) the snapshot version to Sonatype Snapshots Repository. See: https://oss.sonatype.org/content/repositories/snapshots/com/google/cloud/cloud-spanner-r2dbc/.

This PR also adds all of the [required](https://central.sonatype.org/pages/requirements.html) metadata for publishing to Maven Central.