### PR TITLE
Allow URLs to be passed through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,29 @@ The following options are available to be configured for the connection factory:
 | Option Name | Description                | Required | Default Value |
 |-------------|----------------------------|----------|---------------|
 | `driver`    | Must be "spanner"          | True     |               |
-| `project`   | Your GCP Project ID        | True     |               |
-| `instance`  | Your Spanner Instance name | True     |               |
-| `database`  | Your Spanner Database name | True     |               |
+| `project`   | Your GCP Project ID        | True (if `url` not provided) | |
+| `instance`  | Your Spanner Instance name | True (if `url` not provided) | |
+| `database`  | Your Spanner Database name | True (if `url` not provided) | |
+| `url`       | A Cloud Spanner R2DBC URL specifying your Spanner database. An alternative to specifying `project`, `instance`, and `database` | False |
 | `google_credentials` | Optional [Google credentials](https://cloud.google.com/docs/authentication/production) override to specify for your Google Cloud account. | False | If not provided, credentials will be [inferred from your runtime environment](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically).
 | `partial_result_set_fetch_size` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
 | `ddl_operation_timeout` | Duration in seconds to wait for a DDL operation to complete before timing out | False | 600 seconds |
 | `ddl_operation_poll_interval` | Duration in seconds to wait between each polling request for the completion of a DDL operation | False | 5 seconds |
+
+### Connection URLs
+
+You may elect to connect to your Spanner database the `url` property instead of specifying the
+`project`, `instance`, and `database` properties separately.
+
+A Cloud Spanner R2DBC URL is constructed using the following format:
+
+```
+r2dbc:spanner://spanner.googleapis.com:443/projects/${PROJECT_NAME}/instances/${INSTANCE_NAME}/databases/${DB_NAME}
+```
+
+- `${PROJECT_NAME}`: Replace with the name of your Google Cloud Platform Project ID.
+- `${INSTANCE_NAME}`: Replace with the name of your Spanner Instance.
+- `${DB_NAME}`: Replace with the name of your Spanner database.
 
 ## Mapping of Data Types
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The following options are available to be configured for the connection factory:
 | `project`   | Your GCP Project ID        | True (if `url` not provided) | |
 | `instance`  | Your Spanner Instance name | True (if `url` not provided) | |
 | `database`  | Your Spanner Database name | True (if `url` not provided) | |
-| `url`       | A Cloud Spanner R2DBC URL specifying your Spanner database. An alternative to specifying `project`, `instance`, and `database` | False |
+| `url`       | A Cloud Spanner R2DBC URL specifying your Spanner database. An alternative to specifying `project`, `instance`, and `database` separately. | False |
 | `google_credentials` | Optional [Google credentials](https://cloud.google.com/docs/authentication/production) override to specify for your Google Cloud account. | False | If not provided, credentials will be [inferred from your runtime environment](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically).
 | `partial_result_set_fetch_size` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
 | `ddl_operation_timeout` | Duration in seconds to wait for a DDL operation to complete before timing out | False | 600 seconds |
@@ -141,8 +141,8 @@ The following options are available to be configured for the connection factory:
 
 ### Connection URLs
 
-You may elect to connect to your Spanner database the `url` property instead of specifying the
-`project`, `instance`, and `database` properties separately.
+You may specify the coordinates of your Cloud Spanner database using the `url` property instead of
+specifying the `project`, `instance`, and `database` properties separately.
 
 A Cloud Spanner R2DBC URL is constructed using the following format:
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -169,7 +169,7 @@ public class SpannerConnectionConfiguration {
       }
 
       SpannerConnectionConfiguration configuration;
-      if (url != null) {
+      if (this.url != null) {
         configuration = new SpannerConnectionConfiguration(this.url, this.credentials);
       } else {
         configuration = new SpannerConnectionConfiguration(

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -46,6 +46,11 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   /** Option name for GCP Spanner instance. */
   public static final Option<String> INSTANCE = Option.valueOf("instance");
 
+  /**
+   * Option name for specifying the Cloud Spanner R2DBC URL.
+   */
+  public static final Option<String> URL = Option.valueOf("url");
+
   /** Number of partial result sets to buffer during a read query operation. */
   public static final Option<Integer> PARTIAL_RESULT_SET_FETCH_SIZE =
       Option.valueOf("partial_result_set_fetch_size");
@@ -98,26 +103,32 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
   private static SpannerConnectionConfiguration createConfiguration(
       ConnectionFactoryOptions options) {
-    SpannerConnectionConfiguration.Builder configBuilder
-        = new SpannerConnectionConfiguration.Builder()
-        .setProjectId(options.getRequiredValue(PROJECT))
-        .setInstanceName(options.getRequiredValue(INSTANCE))
-        .setDatabaseName(options.getRequiredValue(DATABASE))
-        .setCredentials(options.getValue(GOOGLE_CREDENTIALS));
+
+    SpannerConnectionConfiguration.Builder config = new SpannerConnectionConfiguration.Builder();
+
+    if (options.hasOption(URL)) {
+      config.setUrl(options.getValue(URL));
+    } else {
+      config.setProjectId(options.getRequiredValue(PROJECT))
+          .setInstanceName(options.getRequiredValue(INSTANCE))
+          .setDatabaseName(options.getRequiredValue(DATABASE));
+    }
+
+    config.setCredentials(options.getValue(GOOGLE_CREDENTIALS));
 
     if (options.hasOption(PARTIAL_RESULT_SET_FETCH_SIZE)) {
-      configBuilder.setPartialResultSetFetchSize(options.getValue(PARTIAL_RESULT_SET_FETCH_SIZE));
+      config.setPartialResultSetFetchSize(options.getValue(PARTIAL_RESULT_SET_FETCH_SIZE));
     }
 
     if (options.hasOption(DDL_OPERATION_TIMEOUT)) {
-      configBuilder.setDdlOperationTimeout(options.getValue(DDL_OPERATION_TIMEOUT));
+      config.setDdlOperationTimeout(options.getValue(DDL_OPERATION_TIMEOUT));
     }
 
     if (options.hasOption(DDL_OPERATION_POLL_INTERVAL)) {
-      configBuilder.setDdlOperationPollInterval(options.getValue(DDL_OPERATION_POLL_INTERVAL));
+      config.setDdlOperationPollInterval(options.getValue(DDL_OPERATION_POLL_INTERVAL));
     }
 
-    return configBuilder.build();
+    return config.build();
   }
 
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -131,7 +131,24 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void databaseUrlSettings() {
+  public void databaseUrlMatchesPropertyConfiguration() {
+    SpannerConnectionConfiguration urlBased =
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects/my-project/instances/my-instance/databases/my-database")
+            .build();
+
+    SpannerConnectionConfiguration propertyBased = this.configurationBuilder
+        .setProjectId("my-project")
+        .setInstanceName("my-instance")
+        .setDatabaseName("my-database")
+        .build();
+
+    assertThat(urlBased).isEqualTo(propertyBased);
+  }
+
+  @Test
+  public void databaseUrlExtracting() {
     SpannerConnectionConfiguration config =
         this.configurationBuilder
             .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
@@ -140,5 +157,43 @@ public class SpannerConnectionConfigurationTest {
 
     assertThat(config.getFullyQualifiedDatabaseName())
         .isEqualTo("projects/my-project/instances/my-instance/databases/my-database");
+  }
+
+  @Test
+  public void invalidUrlFormats() {
+    assertThatThrownBy(() ->
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects//instances/my-instance/databases/my-database")
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() ->
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects/proj/instances//databases/my-database")
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() ->
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects/a/instances/b/databases/c/d")
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() ->
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects/a/instances/b/databases/c d")
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() ->
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "foobar")
+            .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -129,4 +129,16 @@ public class SpannerConnectionConfigurationTest {
     assertThat(config.getDdlOperationTimeout()).isEqualTo(Duration.ofSeconds(23));
     assertThat(config.getDdlOperationPollInterval()).isEqualTo(Duration.ofSeconds(45));
   }
+
+  @Test
+  public void databaseUrlSettings() {
+    SpannerConnectionConfiguration config =
+        this.configurationBuilder
+            .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
+                + "projects/my-project/instances/my-instance/databases/my-database")
+            .build();
+
+    assertThat(config.getFullyQualifiedDatabaseName())
+        .isEqualTo("projects/my-project/instances/my-instance/databases/my-database");
+  }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -21,6 +21,7 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.GO
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PARTIAL_RESULT_SET_FETCH_SIZE;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PROJECT;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.URL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +82,21 @@ public class SpannerConnectionFactoryProviderTest {
   public void testCreate() {
     ConnectionFactory spannerConnectionFactory =
         this.spannerConnectionFactoryProvider.create(SPANNER_OPTIONS);
+    assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+  }
+
+  @Test
+  public void testCreateFactoryWithUrl() {
+    ConnectionFactoryOptions optionsWithUrl =
+        ConnectionFactoryOptions.builder()
+            .option(DRIVER, DRIVER_NAME)
+            .option(URL, "r2dbc:spanner://spanner.googleapis.com:443/projects/"
+                + "myproject/instances/reactivetest/databases/testdb")
+            .build();
+
+    ConnectionFactory spannerConnectionFactory =
+        this.spannerConnectionFactoryProvider.create(optionsWithUrl);
     assertThat(spannerConnectionFactory).isNotNull();
     assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
@@ -17,9 +17,8 @@
 package com.google.cloud.spanner.r2dbc.it;
 
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
-import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.URL;
 import static com.google.cloud.spanner.r2dbc.it.SpannerQueryUtil.executeReadQuery;
-import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +27,6 @@ import com.google.cloud.ServiceOptions;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import io.r2dbc.spi.Option;
 import io.r2dbc.spi.R2dbcNonTransientException;
 import java.util.List;
 import org.junit.Before;
@@ -41,17 +39,13 @@ public class SpannerDdlIT {
 
   private static final Logger logger = LoggerFactory.getLogger(SpannerDdlIT.class);
 
-  public static final String TEST_INSTANCE = "reactivetest";
-
-  public static final String TEST_DATABASE = "testdb";
-
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(ConnectionFactoryOptions.builder()
-          // TODO: consider whether to bring autodiscovery of project ID
-          .option(Option.valueOf("project"), ServiceOptions.getDefaultProjectId())
           .option(DRIVER, DRIVER_NAME)
-          .option(INSTANCE, TEST_INSTANCE)
-          .option(DATABASE, TEST_DATABASE)
+          .option(URL,
+              "r2dbc:spanner://spanner.googleapis.com:443/projects/"
+                  + ServiceOptions.getDefaultProjectId()
+                  + "/instances/reactivetest/databases/testdb")
           .build());
 
   /**


### PR DESCRIPTION
Simple propagation for a Cloud Spanner R2DBC URL to be passed through config.

Fixes #30.