### PR TITLE
Correctly propagate errors from Batch DML

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerBatch.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerBatch.java
@@ -21,7 +21,6 @@ import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import com.google.spanner.v1.ExecuteBatchDmlRequest.Statement;
-import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Result;
 import java.util.ArrayList;
@@ -58,14 +57,10 @@ public class SpannerBatch implements Batch {
 
   @Override
   public Publisher<? extends Result> execute() {
-    return executeInTransaction().flatMapIterable(ExecuteBatchDmlResponse::getResultSetsList)
+    return this.client.executeBatchDml(this.ctx, this.statements)
         .map(resultSet -> {
           int count = Math.toIntExact(resultSet.getStats().getRowCountExact());
           return new SpannerResult(Flux.empty(), Mono.just(count));
         });
-  }
-
-  private Mono<ExecuteBatchDmlResponse> executeInTransaction() {
-    return this.client.executeBatchDml(this.ctx, this.statements);
   }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
@@ -25,7 +25,6 @@ import com.google.cloud.spanner.r2dbc.statement.TypedNull;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import com.google.protobuf.Struct;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
-import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.PartialResultSet;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
@@ -133,9 +132,7 @@ public class SpannerStatement implements Statement {
                       .build())
               .collect(Collectors.toList());
 
-      return this.client
-          .executeBatchDml(this.ctx, dmlStatements)
-          .flatMapIterable(ExecuteBatchDmlResponse::getResultSetsList)
+      return this.client.executeBatchDml(this.ctx, dmlStatements)
           .map(partialResultSet -> Math.toIntExact(partialResultSet.getStats().getRowCountExact()))
           .map(rowCount -> new SpannerResult(Flux.empty(), Mono.just(rowCount)));
     }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -114,7 +114,7 @@ public interface Client {
    *
    * @param ctx connection-specific state.
    * @param statements list of DML statements to execute.
-   * @return the {@link ExecuteBatchDmlResponse} returned after executing the query
+   * @return the {@link ResultSet}s returned after executing the query
    */
   Flux<ResultSet> executeBatchDml(StatementExecutionContext ctx, List<Statement> statements);
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -21,8 +21,8 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Struct;
 import com.google.spanner.v1.CommitResponse;
 import com.google.spanner.v1.ExecuteBatchDmlRequest.Statement;
-import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.Session;
 import com.google.spanner.v1.Transaction;
 import com.google.spanner.v1.TransactionOptions;
@@ -116,8 +116,7 @@ public interface Client {
    * @param statements DML SQL statements to execute.
    * @return
    */
-  Mono<ExecuteBatchDmlResponse> executeBatchDml(
-      StatementExecutionContext ctx, List<Statement> statements);
+  Flux<ResultSet> executeBatchDml(StatementExecutionContext ctx, List<Statement> statements);
 
   /**
    * Execute a DDL query.

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -52,6 +52,7 @@ import com.google.spanner.v1.Type;
 import io.grpc.CallCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import java.time.Duration;
@@ -229,6 +230,14 @@ public class GrpcClient implements Client {
                 return Mono.empty();
               }
             });
+      }
+    })
+    .handle((response, sink) -> {
+      if (response.hasStatus() && response.getStatus().getCode() != Status.Code.OK.value()) {
+        sink.error(
+            new R2dbcNonTransientResourceException(response.getStatus().getMessage()));
+      } else {
+        sink.next(response);
       }
     });
   }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -144,7 +144,7 @@ public class SpannerConnectionTest {
         = new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
     String sql = "insert into books values (title) @title";
 
-    when(this.mockClient.executeBatchDml(any(), any())).thenReturn(Mono.empty());
+    when(this.mockClient.executeBatchDml(any(), any())).thenReturn(Flux.empty());
 
     StepVerifier.create(
         Mono.fromSupplier(() -> connection.createStatement(sql))

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -33,7 +33,6 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest.Statement;
-import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.ResultSetMetadata;
@@ -228,12 +227,8 @@ public class SpannerStatementTest {
         .setStats(ResultSetStats.newBuilder().setRowCountExact(555).build())
         .build();
 
-    ExecuteBatchDmlResponse executeBatchDmlResponse = ExecuteBatchDmlResponse.newBuilder()
-        .addResultSets(resultSet)
-        .build();
-
     when(this.mockClient.executeBatchDml(any(), any()))
-        .thenReturn(Mono.just(executeBatchDmlResponse));
+        .thenReturn(Flux.just(resultSet));
 
     StepVerifier.create(Flux.from(
         new SpannerStatement(this.mockClient, this.mockContext, "Insert into books", TEST_CONFIG)
@@ -258,13 +253,8 @@ public class SpannerStatementTest {
         .setStats(ResultSetStats.newBuilder().setRowCountExact(777).build())
         .build();
 
-    ExecuteBatchDmlResponse executeBatchDmlResponse = ExecuteBatchDmlResponse.newBuilder()
-        .addResultSets(resultSet1)
-        .addResultSets(resultSet2)
-        .build();
-
     when(this.mockClient.executeBatchDml(any(), any()))
-        .thenReturn(Mono.just(executeBatchDmlResponse));
+        .thenReturn(Flux.just(resultSet1, resultSet2));
 
     when(this.mockContext.getTransactionId()).thenReturn(transactionId);
 
@@ -322,10 +312,6 @@ public class SpannerStatementTest {
         .setStats(ResultSetStats.getDefaultInstance())
         .build();
 
-    ExecuteBatchDmlResponse executeBatchDmlResponse = ExecuteBatchDmlResponse.newBuilder()
-        .addResultSets(resultSet)
-        .build();
-
     List<Statement> statementList = Collections.singletonList(
         ExecuteBatchDmlRequest.Statement.newBuilder()
             .setSql(sql)
@@ -333,7 +319,7 @@ public class SpannerStatementTest {
             .build());
 
     when(this.mockClient.executeBatchDml(this.mockContext, statementList))
-        .thenReturn(Mono.just(executeBatchDmlResponse));
+        .thenReturn(Flux.just(resultSet));
 
     SpannerStatement statement =
         new SpannerStatement(this.mockClient, this.mockContext, sql, TEST_CONFIG);

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -260,6 +260,14 @@ public class SpannerIT {
         .verifyComplete();
   }
 
+  @Test
+  public void testDmlExceptions() {
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(conn -> conn.createStatement("INSERT BOOKS asdfasdfasdf").execute()))
+        .expectErrorMatches(err -> err.getMessage().contains("Syntax error:"))
+        .verify();
+  }
 
   @Test
   public void testSingleUseDml() {

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -270,6 +270,25 @@ public class SpannerIT {
   }
 
   @Test
+  public void testMultipleDmlExceptions() {
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(conn ->
+                conn.createBatch()
+                    .add("INSERT BOOKS (UUID, TITLE, AUTHOR, CATEGORY, FICTION, "
+                        + "PUBLISHED, WORDS_PER_SENTENCE) VALUES ('23', 'blarg', "
+                        + "'joe', 245, true, DATE '2013-12-25', 20)")
+                    .add("INSERT BOOKS asdfasdfasdfjasidg")
+                    .add("INSERT BOOKS (UUID, TITLE, AUTHOR, CATEGORY, FICTION, PUBLISHED, "
+                        + "WORDS_PER_SENTENCE) VALUES ('24', 'blarg2', 'Bob', "
+                        + "245, true, DATE '2013-12-25', 20)")
+                    .execute()))
+        .expectNextMatches(result -> Mono.from(result.getRowsUpdated()).block() == 1)
+        .expectErrorMatches(err -> err.getMessage().contains("Syntax error:"))
+        .verify();
+  }
+
+  @Test
   public void testSingleUseDml() {
     long count = executeReadQuery(
         connectionFactory,


### PR DESCRIPTION
Make DML queries propagate error from the response object if present.

[ExecuteBatchDmlResponse contains a Status](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#executebatchdmlresponse) which contains message if DML query fails. 

Fixes #148 
