### PR TITLE
Propagate Specific R2dbc Exceptions by Error Code

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -243,8 +243,7 @@ public class GrpcClient implements Client {
         R2dbcException exception =
             SpannerExceptionUtil.createR2dbcException(
                 response.getStatus().getCode(),
-                response.getStatus().getMessage(),
-                null);
+                response.getStatus().getMessage());
         results = results.concatWith(Mono.error(exception));
       }
       return results;

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -20,6 +20,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.spanner.r2dbc.StatementExecutionContext;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import com.google.cloud.spanner.r2dbc.util.ObservableReactiveUtil;
+import com.google.cloud.spanner.r2dbc.util.SpannerExceptionUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.Operation;
@@ -55,6 +56,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.auth.MoreCallCredentials;
+import io.r2dbc.spi.R2dbcException;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import java.time.Duration;
 import java.util.List;
@@ -238,9 +240,12 @@ public class GrpcClient implements Client {
     .flatMapMany(response -> {
       Flux<ResultSet> results = Flux.fromIterable(response.getResultSetsList());
       if (response.hasStatus() && response.getStatus().getCode() != Status.Code.OK.value()) {
-        results = results.concatWith(
-            Mono.error(
-                new R2dbcNonTransientResourceException(response.getStatus().getMessage())));
+        R2dbcException exception =
+            SpannerExceptionUtil.createR2dbcException(
+                response.getStatus().getCode(),
+                response.getStatus().getMessage(),
+                null);
+        results = results.concatWith(Mono.error(exception));
       }
       return results;
     });

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
@@ -78,7 +78,7 @@ public class ObservableReactiveUtil {
 
     @Override
     public void onError(Throwable throwable) {
-      this.sink.error(SpannerExceptionUtil.createWrappedR2dbcException(throwable));
+      this.sink.error(SpannerExceptionUtil.createR2dbcException(throwable));
     }
 
     @Override
@@ -125,7 +125,7 @@ public class ObservableReactiveUtil {
     @Override
     public void onError(Throwable throwable) {
       this.terminalEventReceived = true;
-      this.sink.error(SpannerExceptionUtil.createWrappedR2dbcException(throwable));
+      this.sink.error(SpannerExceptionUtil.createR2dbcException(throwable));
     }
 
     @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
@@ -16,13 +16,9 @@
 
 package com.google.cloud.spanner.r2dbc.util;
 
-import static com.google.cloud.spanner.r2dbc.util.SpannerExceptionUtil.isRetryable;
-
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
-import io.r2dbc.spi.R2dbcNonTransientResourceException;
-import io.r2dbc.spi.R2dbcTransientResourceException;
 import java.util.function.Consumer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -82,13 +78,7 @@ public class ObservableReactiveUtil {
 
     @Override
     public void onError(Throwable throwable) {
-      if (isRetryable(throwable)) {
-        throwable = new R2dbcTransientResourceException(throwable.getMessage(), throwable);
-      } else {
-        throwable = new R2dbcNonTransientResourceException(throwable.getMessage(), throwable);
-      }
-
-      this.sink.error(throwable);
+      this.sink.error(SpannerExceptionUtil.createWrappedR2dbcException(throwable));
     }
 
     @Override
@@ -135,14 +125,7 @@ public class ObservableReactiveUtil {
     @Override
     public void onError(Throwable throwable) {
       this.terminalEventReceived = true;
-
-      if (isRetryable(throwable)) {
-        throwable = new R2dbcTransientResourceException(throwable.getMessage(), throwable);
-      } else {
-        throwable = new R2dbcNonTransientResourceException(throwable.getMessage(), throwable);
-      }
-
-      this.sink.error(throwable);
+      this.sink.error(SpannerExceptionUtil.createWrappedR2dbcException(throwable));
     }
 
     @Override

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
@@ -46,27 +46,14 @@ public class SpannerExceptionUtil {
           "Received unexpected EOS on DATA frame from server");
 
   /**
-   * Manually creates an {@link R2dbcException} from a provided error code, message, and base
-   * exception.
+   * Manually creates an {@link R2dbcException} from a provided error code and message.
    *
    * @param errorCode the Spanner error code of the error.
    * @param message the error message.
-   * @param baseException the base exception that was thrown.
    * @return the resulting {@link R2dbcException} that is propagated to the user.
    */
-  public static R2dbcException createR2dbcException(
-      int errorCode, String message, @Nullable Throwable baseException) {
-
-    switch (errorCode) {
-      case Code.ALREADY_EXISTS_VALUE:
-        return new R2dbcDataIntegrityViolationException(message, null, errorCode, baseException);
-      case Code.INVALID_ARGUMENT_VALUE:
-        return new R2dbcBadGrammarException(message, null, errorCode, baseException);
-      case Code.PERMISSION_DENIED_VALUE:
-        return new R2dbcPermissionDeniedException(message, null, errorCode, baseException);
-      default:
-        return new R2dbcNonTransientResourceException(message, null, errorCode, baseException);
-    }
+  public static R2dbcException createR2dbcException(int errorCode, String message) {
+    return createR2dbcException(errorCode, message, null);
   }
 
   /**
@@ -75,7 +62,7 @@ public class SpannerExceptionUtil {
    * @param baseException the base exception that is thrown
    * @return the resulting {@link R2dbcException} that is propagated to the user.
    */
-  public static R2dbcException createWrappedR2dbcException(Throwable baseException) {
+  public static R2dbcException createR2dbcException(Throwable baseException) {
     if (!(baseException instanceof StatusRuntimeException)) {
       return new R2dbcNonTransientResourceException(baseException.getMessage(), baseException);
     }
@@ -87,7 +74,27 @@ public class SpannerExceptionUtil {
       return new R2dbcTransientResourceException(
           baseException.getMessage(), null, errorCode, baseException);
     } else {
-      return createR2dbcException(errorCode, baseException.getMessage(), baseException);
+      return createR2dbcException(
+          errorCode, baseException.getMessage(), baseException);
+    }
+  }
+
+  /**
+   * Private helper to manually create an {@link R2dbcException} given the error code,
+   * error message and base exception.
+   */
+  private static R2dbcException createR2dbcException(
+      int errorCode, String message, @Nullable Throwable baseException) {
+
+    switch (errorCode) {
+      case Code.ALREADY_EXISTS_VALUE:
+        return new R2dbcDataIntegrityViolationException(message, null, errorCode, baseException);
+      case Code.INVALID_ARGUMENT_VALUE:
+        return new R2dbcBadGrammarException(message, null, errorCode, baseException);
+      case Code.PERMISSION_DENIED_VALUE:
+        return new R2dbcPermissionDeniedException(message, null, errorCode, baseException);
+      default:
+        return new R2dbcNonTransientResourceException(message, null, errorCode, baseException);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
@@ -63,7 +63,9 @@ public class SpannerExceptionUtil {
    * @return the resulting {@link R2dbcException} that is propagated to the user.
    */
   public static R2dbcException createR2dbcException(Throwable baseException) {
-    if (!(baseException instanceof StatusRuntimeException)) {
+    if (baseException == null) {
+      return new R2dbcNonTransientResourceException();
+    } else if (!(baseException instanceof StatusRuntimeException)) {
       return new R2dbcNonTransientResourceException(baseException.getMessage(), baseException);
     }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
@@ -107,7 +107,7 @@ public class SpannerExceptionUtil {
   private static boolean isRetryable(StatusRuntimeException statusRuntimeException) {
     if (statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL
         && RETRYABLE_ERROR_MESSAGES.stream().anyMatch(
-        errorFragment -> statusRuntimeException.getMessage().contains(errorFragment))) {
+            errorFragment -> statusRuntimeException.getMessage().contains(errorFragment))) {
       return true;
     }
 

--- a/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
@@ -16,14 +16,21 @@
 
 package com.google.cloud.spanner.r2dbc.util;
 
+import com.google.rpc.Code;
 import com.google.rpc.RetryInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
+import io.r2dbc.spi.R2dbcBadGrammarException;
+import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
+import io.r2dbc.spi.R2dbcException;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import io.r2dbc.spi.R2dbcPermissionDeniedException;
+import io.r2dbc.spi.R2dbcTransientResourceException;
 import java.time.Duration;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Extracts metadata from exceptions thrown during Spanner RPCs.
@@ -32,13 +39,57 @@ public class SpannerExceptionUtil {
   private static final Metadata.Key<RetryInfo> KEY_RETRY_INFO =
       ProtoUtils.keyForProto(RetryInfo.getDefaultInstance());
 
-
   private static final Set<String> RETRYABLE_ERROR_MESSAGES =
       CollectionsBuilder.setOf(
           "HTTP/2 error code: INTERNAL_ERROR",
           "Connection closed with unknown cause",
           "Received unexpected EOS on DATA frame from server");
 
+  /**
+   * Manually creates an {@link R2dbcException} from a provided error code, message, and base
+   * exception.
+   *
+   * @param errorCode the Spanner error code of the error.
+   * @param message the error message.
+   * @param baseException the base exception that was thrown.
+   * @return the resulting {@link R2dbcException} that is propagated to the user.
+   */
+  public static R2dbcException createR2dbcException(
+      int errorCode, String message, @Nullable Throwable baseException) {
+
+    switch (errorCode) {
+      case Code.ALREADY_EXISTS_VALUE:
+        return new R2dbcDataIntegrityViolationException(message, null, errorCode, baseException);
+      case Code.INVALID_ARGUMENT_VALUE:
+        return new R2dbcBadGrammarException(message, null, errorCode, baseException);
+      case Code.PERMISSION_DENIED_VALUE:
+        return new R2dbcPermissionDeniedException(message, null, errorCode, baseException);
+      default:
+        return new R2dbcNonTransientResourceException(message, null, errorCode, baseException);
+    }
+  }
+
+  /**
+   * Extracts metadata of a thrown exception and creates a {@link R2dbcException} from it.
+   *
+   * @param baseException the base exception that is thrown
+   * @return the resulting {@link R2dbcException} that is propagated to the user.
+   */
+  public static R2dbcException createWrappedR2dbcException(Throwable baseException) {
+    if (!(baseException instanceof StatusRuntimeException)) {
+      return new R2dbcNonTransientResourceException(baseException.getMessage(), baseException);
+    }
+
+    StatusRuntimeException statusRuntimeException = (StatusRuntimeException) baseException;
+    int errorCode = statusRuntimeException.getStatus().getCode().value();
+
+    if (isRetryable(statusRuntimeException)) {
+      return new R2dbcTransientResourceException(
+          baseException.getMessage(), null, errorCode, baseException);
+    } else {
+      return createR2dbcException(errorCode, baseException.getMessage(), baseException);
+    }
+  }
 
   /**
    * Returns whether an exception thrown should be retried.
@@ -46,23 +97,16 @@ public class SpannerExceptionUtil {
    * <p>Derived from google-cloud-java/SpannerExceptionFactory.java:
    * https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
    */
-  static boolean isRetryable(Throwable cause) {
-    if (cause instanceof StatusRuntimeException) {
-      StatusRuntimeException statusRuntimeException = (StatusRuntimeException) cause;
-
-      if (statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL
-          && RETRYABLE_ERROR_MESSAGES.stream().anyMatch(
-              errorFragment -> cause.getMessage().contains(errorFragment))) {
-        return true;
-      }
-
-      if (statusRuntimeException.getStatus().getCode() == Code.RESOURCE_EXHAUSTED
-          && extractRetryDelay(statusRuntimeException) != null) {
-        return true;
-      }
+  private static boolean isRetryable(StatusRuntimeException statusRuntimeException) {
+    if (statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL
+        && RETRYABLE_ERROR_MESSAGES.stream().anyMatch(
+        errorFragment -> statusRuntimeException.getMessage().contains(errorFragment))) {
+      return true;
     }
 
-    return false;
+    return statusRuntimeException.getStatus().getCode() == Status.Code.RESOURCE_EXHAUSTED
+        && extractRetryDelay(statusRuntimeException) != null;
+
   }
 
   /**

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
@@ -16,26 +16,46 @@
 
 package com.google.cloud.spanner.r2dbc.util;
 
+import static com.google.cloud.spanner.r2dbc.util.SpannerExceptionUtil.createWrappedR2dbcException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Duration;
+import com.google.rpc.Code;
 import com.google.rpc.RetryInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
+import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
+import io.r2dbc.spi.R2dbcException;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import io.r2dbc.spi.R2dbcPermissionDeniedException;
+import io.r2dbc.spi.R2dbcTransientResourceException;
 import java.io.IOException;
 import org.junit.Test;
 
 public class SpannerExceptionUtilTest {
 
   @Test
-  public void testNonRetryableException() {
-    assertThat(SpannerExceptionUtil.isRetryable(new IllegalArgumentException())).isFalse();
-    assertThat(SpannerExceptionUtil.isRetryable(new IOException())).isFalse();
+  public void testCreateR2dbcException() {
+    R2dbcException exception = SpannerExceptionUtil.createR2dbcException(
+        Code.ALREADY_EXISTS_VALUE, "test", null);
 
-    StatusRuntimeException nonRetryableException = new StatusRuntimeException(Status.ABORTED);
-    assertThat(SpannerExceptionUtil.isRetryable(nonRetryableException)).isFalse();
+    assertThat(exception).isInstanceOf(R2dbcDataIntegrityViolationException.class);
+    assertThat(exception).hasMessage("test");
+  }
+
+  @Test
+  public void testNonRetryableException() {
+    assertThat(createWrappedR2dbcException(new IllegalArgumentException()))
+        .isInstanceOf(R2dbcNonTransientResourceException.class);
+    assertThat(createWrappedR2dbcException((new IOException())))
+        .isInstanceOf(R2dbcNonTransientResourceException.class);
+
+    StatusRuntimeException nonRetryableException =
+        new StatusRuntimeException(Status.PERMISSION_DENIED);
+    assertThat(createWrappedR2dbcException(nonRetryableException))
+        .isInstanceOf(R2dbcPermissionDeniedException.class);
   }
 
   @Test
@@ -44,7 +64,8 @@ public class SpannerExceptionUtilTest {
         new StatusRuntimeException(
             Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"), null);
 
-    assertThat(SpannerExceptionUtil.isRetryable(retryableException)).isTrue();
+    assertThat(createWrappedR2dbcException(retryableException))
+        .isInstanceOf(R2dbcTransientResourceException.class);
   }
 
   @Test
@@ -60,6 +81,7 @@ public class SpannerExceptionUtilTest {
     StatusRuntimeException retryableException =
         new StatusRuntimeException(Status.RESOURCE_EXHAUSTED, errorMetadata);
 
-    assertThat(SpannerExceptionUtil.isRetryable(retryableException)).isTrue();
+    assertThat(createWrappedR2dbcException(retryableException))
+        .isInstanceOf(R2dbcTransientResourceException.class);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc.util;
 
-import static com.google.cloud.spanner.r2dbc.util.SpannerExceptionUtil.createWrappedR2dbcException;
+import static com.google.cloud.spanner.r2dbc.util.SpannerExceptionUtil.createR2dbcException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Duration;
@@ -39,7 +39,7 @@ public class SpannerExceptionUtilTest {
   @Test
   public void testCreateR2dbcException() {
     R2dbcException exception = SpannerExceptionUtil.createR2dbcException(
-        Code.ALREADY_EXISTS_VALUE, "test", null);
+        Code.ALREADY_EXISTS_VALUE, "test");
 
     assertThat(exception).isInstanceOf(R2dbcDataIntegrityViolationException.class);
     assertThat(exception).hasMessage("test");
@@ -47,14 +47,14 @@ public class SpannerExceptionUtilTest {
 
   @Test
   public void testNonRetryableException() {
-    assertThat(createWrappedR2dbcException(new IllegalArgumentException()))
+    assertThat(createR2dbcException(new IllegalArgumentException()))
         .isInstanceOf(R2dbcNonTransientResourceException.class);
-    assertThat(createWrappedR2dbcException((new IOException())))
+    assertThat(createR2dbcException((new IOException())))
         .isInstanceOf(R2dbcNonTransientResourceException.class);
 
     StatusRuntimeException nonRetryableException =
         new StatusRuntimeException(Status.PERMISSION_DENIED);
-    assertThat(createWrappedR2dbcException(nonRetryableException))
+    assertThat(createR2dbcException(nonRetryableException))
         .isInstanceOf(R2dbcPermissionDeniedException.class);
   }
 
@@ -64,7 +64,7 @@ public class SpannerExceptionUtilTest {
         new StatusRuntimeException(
             Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"), null);
 
-    assertThat(createWrappedR2dbcException(retryableException))
+    assertThat(createR2dbcException(retryableException))
         .isInstanceOf(R2dbcTransientResourceException.class);
   }
 
@@ -81,7 +81,7 @@ public class SpannerExceptionUtilTest {
     StatusRuntimeException retryableException =
         new StatusRuntimeException(Status.RESOURCE_EXHAUSTED, errorMetadata);
 
-    assertThat(createWrappedR2dbcException(retryableException))
+    assertThat(createR2dbcException(retryableException))
         .isInstanceOf(R2dbcTransientResourceException.class);
   }
 }


### PR DESCRIPTION
If a Spanner-specific exception is thrown, this adds support to extract the error code if present and construct the appropriate R2dbc exception subclass based upon the error code.

Fixes #154.