### PR TITLE
Update driver to comply with new SPI interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 jdk:
   - oraclejdk8
+dist: trusty
 
 branches:
   only:

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <r2dbc.version>0.8.0.M8</r2dbc.version>
-    <reactor.version>Californium-SR6</reactor.version>
+    <r2dbc.version>0.8.0.RC2</r2dbc.version>
+    <reactor.version>Dysprosium-RELEASE</reactor.version>
     <google-auth.version>0.15.0</google-auth.version>
     <mockito.version>2.23.0</mockito.version>
     <grpc.version>1.20.0</grpc.version>

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -24,7 +24,9 @@ import com.google.spanner.v1.TransactionOptions;
 import com.google.spanner.v1.TransactionOptions.ReadWrite;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionMetadata;
 import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.ValidationDepth;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.reactivestreams.Publisher;
@@ -157,7 +159,15 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
 
   @Override
   public Publisher<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
-    return null;
+    return Mono.error(
+        new UnsupportedOperationException("Changing isolation level is not supported."));
+  }
+
+  @Override
+  public IsolationLevel getTransactionIsolationLevel() {
+    // This is an approximation.
+    // Cloud Spanner's isolation guarantees are stronger than traditional RDBMS.
+    return IsolationLevel.SERIALIZABLE;
   }
 
   @Override
@@ -194,4 +204,28 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
     this.transactionOptions = transactionOptions;
   }
 
+  @Override
+  public Publisher<Boolean> validate(ValidationDepth validationDepth) {
+    // TODO: https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/162
+    return Mono.just(true);
+  }
+
+
+  @Override
+  public Publisher<Void> setAutoCommit(boolean b) {
+    // TODO: https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/165
+    throw new RuntimeException("Turning off autocommit is not supported yet.");
+  }
+
+  @Override
+  public boolean isAutoCommit() {
+    // TODO: https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/165
+    return true;
+  }
+
+  @Override
+  public ConnectionMetadata getMetadata() {
+    // TODO: https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/163
+    return null;
+  }
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRow.java
@@ -47,12 +47,20 @@ public class SpannerRow implements Row {
   }
 
   @Override
-  public <T> T get(Object identifier, Class<T> returnType) {
-    int columnIndex = this.rowMetadata.getColumnIndex(identifier);
-
+  public <T> T get(int columnIndex, Class<T> returnType) {
     Value spannerValue = this.values.get(columnIndex);
-    Type spannerType = (Type) this.rowMetadata.getColumnMetadata(identifier)
-            .getNativeTypeMetadata();
+    Type spannerType = (Type) this.rowMetadata.getColumnMetadata(columnIndex)
+        .getNativeTypeMetadata();
+
+    T decodedValue = codecs.decode(spannerValue, spannerType, returnType);
+    return decodedValue;
+  }
+
+  @Override
+  public <T> T get(String columnName, Class<T> returnType) {
+    Value spannerValue = this.values.get(this.rowMetadata.getColumnIndexByName(columnName));
+    Type spannerType = (Type) this.rowMetadata.getColumnMetadata(columnName)
+        .getNativeTypeMetadata();
 
     T decodedValue = codecs.decode(spannerValue, spannerType, returnType);
     return decodedValue;

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadata.java
@@ -65,9 +65,15 @@ public class SpannerRowMetadata implements RowMetadata {
   }
 
   @Override
-  public ColumnMetadata getColumnMetadata(Object identifier) {
-    int columnIndex = getColumnIndex(identifier);
-    return this.columnMetadatas.get(columnIndex);
+  public ColumnMetadata getColumnMetadata(int index) {
+    return this.columnMetadatas.get(index);
+  }
+
+  @Override
+  public ColumnMetadata getColumnMetadata(String identifier) {
+    int index = getColumnIndexByName(identifier);
+    // TODO: index validation
+    return this.columnMetadatas.get(index);
   }
 
   @Override
@@ -80,22 +86,7 @@ public class SpannerRowMetadata implements RowMetadata {
     return this.columnNames;
   }
 
-  /**
-   * Returns the column index of the value in a row for the given {@code identifier}.
-   */
-  int getColumnIndex(Object identifier) {
-    if (identifier instanceof Integer) {
-      return (Integer) identifier;
-    } else if (identifier instanceof String) {
-      return getColumnIndexByName((String) identifier);
-    } else {
-      throw new IllegalArgumentException(
-          String.format("Identifier '%s' is not a valid identifier. "
-              + "Should either be an Integer index or a String column name.", identifier));
-    }
-  }
-
-  private int getColumnIndexByName(String name) {
+  protected int getColumnIndexByName(String name) {
     if (!this.columnNameIndex.containsKey(name)) {
       throw new IllegalArgumentException(
           "The column name " + name + " does not exist for the Spanner row. "

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerStatement.java
@@ -86,12 +86,8 @@ public class SpannerStatement implements Statement {
   }
 
   @Override
-  public Statement bind(Object identifier, Object value) {
-    if (!(identifier instanceof String)) {
-      throw new IllegalArgumentException("Only String identifiers are supported");
-    }
-
-    this.statementBindings.createBind((String) identifier, value);
+  public Statement bind(String identifier, Object value) {
+    this.statementBindings.createBind(identifier, value);
     return this;
   }
 
@@ -101,7 +97,7 @@ public class SpannerStatement implements Statement {
   }
 
   @Override
-  public Statement bindNull(Object identifier, Class<?> type) {
+  public Statement bindNull(String identifier, Class<?> type) {
     return bind(identifier, new TypedNull(type));
   }
 

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -41,16 +41,6 @@ public class SpannerRowTest {
       = new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance());
 
   @Test
-  public void testInvalidIdentifier() {
-    SpannerRow row = new SpannerRow(
-        new ArrayList<>(), this.rowMetadata);
-
-    assertThatThrownBy(() -> row.get(true, String.class))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Identifier 'true' is not a valid identifier.");
-  }
-
-  @Test
   public void testOutOfBoundsIndex() {
     SpannerRow row = new SpannerRow(
         new ArrayList<>(), this.rowMetadata);

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -24,7 +24,6 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import ch.qos.logback.classic.Level;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnection;
@@ -113,11 +112,6 @@ public class SpannerIT {
    */
   @BeforeClass
   public static void setupSpannerTable() throws InterruptedException, ExecutionException {
-    // prevent printing out the contents of the actual Book rows being inserted
-    ch.qos.logback.classic.Logger root =
-        (ch.qos.logback.classic.Logger)
-            LoggerFactory.getLogger("io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler");
-    root.setLevel(Level.INFO);
 
     SpannerConnection con =
         Mono.from(connectionFactory.create())


### PR DESCRIPTION
## Version upgrades
* Upgraded SPI to 0.8.0.RC2.
* Upgraded Reactor to Dysprosium-RELEASE.

## New methods
* Updated `getTransactionIsolationLevel()` to always return SERIALIZABLE, since it's the closest to what Spanner's strong read actually does. 
* Updated `setTransactionIsolationLevel()` to throw `UnsupportedOperationException`. 
  * If/when R2DBC supports custom isolation levels, we can introduce the stale read modes.
* Placeholder for `validate()` method (TCK's `validate()` correctly fails).
* Placeholder for `setAutoCommit()` (TCK's `changeAutoCommitCommitsTransaction()` and `sameAutoCommitLeavesTransactionUnchanged()` correctly fail).

## Signature changes
* Split up `SpannerRow.get(Object)` into `get(int)` and `get(String)`, per SPI.
* Split `SpannerRowMetadata.getColumnMetadata(Object)` into `getColumnMetadata(int)` and `getColumnMetadata(String)` per SPI.
* Updated `SpannerStatement.bind(Object)` to `bind(String)` per SPI.
  * Removed type verification test, since this is now compile-time.

## TCK test changes
* Updated connection pool `maxSize` to 15, since the default is now 10, and the max can't be smaller than default.
* Removed runtime logback configuration; it did not seem necessary, as the default log level when running tests is already WARN. In related newsw, TCK tests no longer brings in a Spring Boot starter, so logback is not a dependency.