### PR TITLE
Add ability to turn autocommit on and off

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -216,6 +216,14 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
   }
 
 
+  /**
+   * Changes the autocommit mode of the current connection. No-op if the value is unchanged.
+   * <p>If autocommit was previously off and a read/write transaction is in progress, the
+   * transaction is committed first.
+   *
+   * @param newAutoCommit whether autocommit should be on or off in the future.
+   * @return {@link Mono} of the transaction commit operation, if applicable; empty mono otherwise.
+   */
   @Override
   public Publisher<Void> setAutoCommit(boolean newAutoCommit) {
     return Mono.defer(() -> {
@@ -230,6 +238,16 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
     });
   }
 
+  /**
+   * Determines current autocommit state of the connection (default is autocommit-on).
+   * Autocommit applies to DML queries only.
+   *
+   * <p>When autocommit is on, each standalone DML query will be executed in its own Read/Write
+   * transaction.
+   * <p>For batching multiple DML queries, see {@link #createBatch()}.
+   *
+   * @return whether autocommit mode is on.
+   */
   @Override
   public boolean isAutoCommit() {
     return this.autoCommit;

--- a/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnection.java
@@ -218,6 +218,7 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
 
   /**
    * Changes the autocommit mode of the current connection. No-op if the value is unchanged.
+   *
    * <p>If autocommit was previously off and a read/write transaction is in progress, the
    * transaction is committed first.
    *
@@ -244,6 +245,7 @@ public class SpannerConnection implements Connection, StatementExecutionContext 
    *
    * <p>When autocommit is on, each standalone DML query will be executed in its own Read/Write
    * transaction.
+   * 
    * <p>For batching multiple DML queries, see {@link #createBatch()}.
    *
    * @return whether autocommit mode is on.

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.r2dbc.client.Client;
@@ -282,6 +284,85 @@ public class SpannerConnectionTest {
       }
       prevNum = num;
     }
+  }
+
+  @Test
+  public void autocommitOnByDefault() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    assertThat(connection.isAutoCommit()).isTrue();
+  }
+
+  @Test
+  public void turningAutocommitOnIsNoopWhenAlreadyOn() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    StepVerifier.create(connection.setAutoCommit(true))
+        .verifyComplete();
+    assertThat(connection.isAutoCommit()).isTrue();
+    verifyZeroInteractions(this.mockClient);
+  }
+
+  @Test
+  public void turningAutocommitOffIsNoopWhenAlreadyOff() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    StepVerifier.create(
+        Mono.from(connection.setAutoCommit(false))
+            .then(Mono.from(connection.setAutoCommit(false)))
+    ).verifyComplete();
+
+    assertThat(connection.isAutoCommit()).isFalse();
+    verifyZeroInteractions(this.mockClient);
+  }
+
+
+  @Test
+  public void turningAutocommitOffWorksLocally() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    StepVerifier.create(connection.setAutoCommit(false))
+        .verifyComplete();
+    assertThat(connection.isAutoCommit()).isFalse();
+    verifyZeroInteractions(this.mockClient);
+  }
+
+  @Test
+  public void startingTransactionTurnsOffAutocommit() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    StepVerifier.create(
+        Mono.from(connection.beginTransaction())
+    ).verifyComplete();
+
+    verify(this.mockClient).beginTransaction(eq(TEST_SESSION_NAME), any());
+    assertThat(connection.isAutoCommit()).isFalse();
+  }
+
+  @Test
+  public void turningAutocommitOnCommitsExistingTransaction() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    StepVerifier.create(
+        Mono.from(connection.setAutoCommit(false))
+            .then(connection.beginTransaction())
+            .then(Mono.from(connection.setAutoCommit(true)))
+    ).verifyComplete();
+
+    verify(this.mockClient).beginTransaction(eq(TEST_SESSION_NAME), any());
+    verify(this.mockClient).commitTransaction(eq(TEST_SESSION_NAME), any());
+    assertThat(connection.isAutoCommit()).isTrue();
+  }
+
+  @Test
+  public void turningAutocommitOnDoesNotAffectNonReadwriteTransaction() {
+    SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
+    TransactionOptions readonlyTransaction = TransactionOptions.newBuilder()
+        .setReadOnly(ReadOnly.getDefaultInstance()).build();
+
+    StepVerifier.create(
+        Mono.from(connection.setAutoCommit(false))
+            .then(connection.beginTransaction(readonlyTransaction))
+            .then(Mono.from(connection.setAutoCommit(true)))
+    ).verifyComplete();
+
+    verify(this.mockClient).beginTransaction(TEST_SESSION_NAME, readonlyTransaction);
+    verify(this.mockClient, times(0)).commitTransaction(eq(TEST_SESSION_NAME), any());
+    assertThat(connection.isAutoCommit()).isTrue();
   }
 
   private PartialResultSet makeBookPrs(String bookName) {

--- a/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
Keeps separate state for autocommit; does not rely on transaction.
A couple of edge case scenarios:
* autocommit was turned off but transaction not started yet. In this case, attempting DML statements will still behave as if autocommit is turned on (a side effect of current GrpcClient.executeBatchDml implementation). I can see an argument for changing this to conform to SPI behavior of committing in-progress transaction upon autocommit being turned off.
* autocommit was turned back on while a non-readwrite transaction is in progress -- this will NOT result in read/write transaction being committed. This is different from the more typical scenario, in which autocommit is turned back on while a Read/Write transaction is in progress, and transaction gets committed automatically. The reason for this is that a read-only transaction guarantees consistent reads, and closing the transaction without user instruction could lead to inconsistent reads. This will never happen through a framework such as Spring Data, as read-only transactions are not part of the R2DBC SPI. Therefore, a user has to intentionally start a read-only transaction by downcasting `Connection` as `SpannerConnection` and using the custom overloaded `beginTransaction(TransactionOptions)` method.