### PR TITLE
Implement connection validation

### DIFF
--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/Client.java
@@ -141,4 +141,10 @@ public interface Client {
    * @return a {@link Mono} that indicates that a client has been closed
    */
   Mono<Void> close();
+
+  /**
+   * Validates session associated with the passed in {@link StatementExecutionContext}.
+   * @return {@link Mono} of whether the connection is working.
+   */
+  Mono<Boolean> healthcheck(StatementExecutionContext ctx);
 }

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -40,6 +40,7 @@ import com.google.spanner.v1.ExecuteBatchDmlRequest;
 import com.google.spanner.v1.ExecuteBatchDmlRequest.Statement;
 import com.google.spanner.v1.ExecuteBatchDmlResponse;
 import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ExecuteSqlRequest.Builder;
 import com.google.spanner.v1.PartialResultSet;
 import com.google.spanner.v1.ResultSet;
 import com.google.spanner.v1.RollbackRequest;
@@ -61,6 +62,8 @@ import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -81,12 +84,17 @@ public class GrpcClient implements Client {
 
   private static final String USER_AGENT_LIBRARY_NAME = "cloud-spanner-r2dbc";
 
+  private static final String HEALTHCHECK_SQL = "SELECT 1";
+
   private static final int PORT = 443;
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final ManagedChannel channel;
   private final SpannerStub spanner;
   private final DatabaseAdminStub databaseAdmin;
   private final OperationsStub operations;
+
 
   /**
    * Initializes the Cloud Spanner gRPC async stub.
@@ -260,10 +268,7 @@ public class GrpcClient implements Client {
     return Flux.defer(() -> {
       Assert.requireNonNull(ctx.getSessionName(), "Session name must not be null");
 
-      ExecuteSqlRequest.Builder executeSqlRequest =
-          ExecuteSqlRequest.newBuilder()
-              .setSql(sql)
-              .setSession(ctx.getSessionName());
+      ExecuteSqlRequest.Builder executeSqlRequest = buildSqlRequest(ctx, sql);
 
       if (params != null) {
         executeSqlRequest
@@ -329,6 +334,30 @@ public class GrpcClient implements Client {
         this.channel.shutdownNow();
       }
     });
+  }
+
+  @Override
+  public Mono<Boolean> healthcheck(StatementExecutionContext ctx) {
+    return Mono.defer(() -> {
+      if (ctx.getSessionName() == null) {
+        return Mono.just(false);
+      }
+
+      return ObservableReactiveUtil.<ResultSet>unaryCall(
+          obs -> this.spanner.executeSql(buildSqlRequest(ctx, HEALTHCHECK_SQL).build(), obs)
+      )
+          .map(rs -> Boolean.TRUE)
+          .onErrorResume(error -> {
+            this.logger.warn("Spanner healthcheck failed", error);
+            return Mono.just(Boolean.FALSE);
+          });
+    });
+  }
+
+  private Builder buildSqlRequest(StatementExecutionContext ctx, String sql) {
+    return ExecuteSqlRequest.newBuilder()
+        .setSql(sql)
+        .setSession(ctx.getSessionName());
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -88,7 +88,7 @@ public class GrpcClient implements Client {
 
   private static final int PORT = 443;
 
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(GrpcClient.class);
 
   private final ManagedChannel channel;
   private final SpannerStub spanner;
@@ -348,7 +348,7 @@ public class GrpcClient implements Client {
       )
           .map(rs -> Boolean.TRUE)
           .onErrorResume(error -> {
-            this.logger.warn("Spanner healthcheck failed", error);
+            this.LOGGER.warn("Cloud Spanner healthcheck failed", error);
             return Mono.just(Boolean.FALSE);
           });
     });

--- a/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerExample.java
+++ b/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerExample.java
@@ -105,13 +105,11 @@ public class SpannerExample implements TestKit<String> {
 
     DatabaseId id = DatabaseId.of(options.getProjectId(), TEST_INSTANCE, TEST_DATABASE);
     DatabaseAdminClient dbAdminClient = spanner.getDatabaseAdminClient();
-    /*runDdl(id, dbAdminClient, "CREATE TABLE test ( value INT64 ) PRIMARY KEY (value)");
+    runDdl(id, dbAdminClient, "CREATE TABLE test ( value INT64 ) PRIMARY KEY (value)");
     runDdl(id, dbAdminClient,
         "CREATE TABLE test_two_column ( col1 INT64, col2 STRING(MAX) )  PRIMARY KEY (col1)");
     runDdl(id, dbAdminClient, "CREATE TABLE blob_test ( value BYTES(MAX) )  PRIMARY KEY (value)");
     runDdl(id, dbAdminClient, "CREATE TABLE clob_test ( value BYTES(MAX) )  PRIMARY KEY (value)");
-
-     */
   }
 
   private static void runDdl(DatabaseId id, DatabaseAdminClient dbAdminClient, String query) {


### PR DESCRIPTION
### Behavior change:
* Null out session when connection is closed.
* Local validation relies on having a valid session (it checks for session name, but that's only going to be non-null if and only if the connection is non-null.)
* Remote validation is implemented as a low-level `GrpcClient` healthcheck. It sends a trivial query to Spanner over `executeSql` (as opposed to `executeStreamingSql`).

### TCK test change:
* Removed session pools from TCK tests
* Suppressed error logging when already-existing tables try to get created. This operation also takes forever; need to check whether pre-querying tables will be faster.

Fixes #162 .