### PR TITLE
Rename test to get picked up by Failsafe

### DIFF
--- a/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
+++ b/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 /**
  * Tests the sample application.
  */
-public class BookExampleAppTest {
+public class BookExampleAppIT {
 
   public static final String TEST_INSTANCE = "reactivetest";
 


### PR DESCRIPTION
This test needs to run as an integration test; otherwise credentials are not available.