### PR TITLE
Exclude sample module from release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,6 @@
 
   </properties>
 
-  <modules>
-    <module>cloud-spanner-r2dbc</module>
-    <module>cloud-spanner-r2dbc-sample</module>
-  </modules>
-
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -273,8 +267,23 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>cloud-spanner-r2dbc</module>
+        <module>cloud-spanner-r2dbc-sample</module>
+      </modules>
+    </profile>
+
     <profile>
       <id>release</id>
+      <modules>
+        <module>cloud-spanner-r2dbc</module>
+      </modules>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Nexus staging plugin checks the value of `skipNexusStagingDeployMojo` property in the last module in reactor ([docs](https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment)). 

More information on this behavior: https://issues.sonatype.org/browse/NEXUS-9138

This PR excludes the samples module from the deploy profile.