### PR TITLE
Remove autoReleaseAfterClose property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <deploy.autorelease>true</deploy.autorelease>
 
     <google-cloud-bom.version>2.9.0</google-cloud-bom.version>
 
@@ -181,7 +180,6 @@
           <configuration>
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>${deploy.autorelease}</autoReleaseAfterClose>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
We don't want to set `autoReleaseAfterClose` to `true`.
We want to use the `drop` job or the `promote` job to decide what to do after staging the artifacts for release to Maven Central.