### PR TITLE
Avoid running javadoc:jar if build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ install:
 
 script:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
-      ./mvnw verify -B -V;
+      ./mvnw verify javadoc:jar@attach-javadocs -B -V;
     else
-      ./mvnw verify -B -V -DskipITs;
+      ./mvnw verify javadoc:jar@attach-javadocs -B -V -DskipITs;
     fi;
-  - ./mvnw clean javadoc:jar@attach-javadocs


### PR DESCRIPTION
In Travis, all steps in the `script` run regardless if the previous one failed. This makes it harder to find the error when the build fails.
Avoid this issue by using a single step in the `script`.