### PR TITLE
Make TestKit run with other integration tests

### DIFF
--- a/cloud-spanner-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-sample/pom.xml
@@ -42,16 +42,6 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${apache-commons-io.version}</version>

--- a/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
+++ b/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
@@ -22,8 +22,8 @@ import com.google.cloud.ServiceOptions;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the sample application.
@@ -43,7 +43,7 @@ public class BookExampleAppIT {
   /**
    * Saves output.
    */
-  @BeforeClass
+  @BeforeAll
   public static void checkToRun() {
     systemOut = System.out;
     baos = new ByteArrayOutputStream();

--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -74,31 +74,7 @@
       <artifactId>r2dbc-spi-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
@@ -111,6 +87,7 @@
       <artifactId>google-cloud-core</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
 </project>

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SpannerColumnMetadata}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -21,8 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import java.time.Duration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -37,7 +37,7 @@ public class SpannerConnectionConfigurationTest {
   /**
    * Sets up mock credentials to avoid accessing filesystem to get default credentials.
    */
-  @Before
+  @BeforeEach
   public void setUpMockCredentials() {
     this.configurationBuilder = new SpannerConnectionConfiguration.Builder()
         .setCredentials(this.mockCredentials);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SpannerConnectionFactoryMetadata}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -26,8 +26,8 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,8 +44,8 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
@@ -71,7 +71,7 @@ public class SpannerConnectionFactoryProviderTest {
   /**
    * Initializes unit under test with a mock {@link Client}.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     this.mockClient =  mock(Client.class);
     this.spannerConnectionFactoryProvider = new SpannerConnectionFactoryProvider();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.spanner.r2dbc.client.Client;
 import com.google.spanner.v1.Session;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -38,7 +38,7 @@ public class SpannerConnectionFactoryTest {
   /**
    * Sets up {@link SpannerConnectionConfiguration} for test.
    */
-  @Before
+  @BeforeEach
   public void setupConnectionConfiguration() throws IOException {
     this.config = new SpannerConnectionConfiguration.Builder()
         .setProjectId("a-project")

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SpannerConnectionMetadata}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -48,8 +48,8 @@ import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.ValidationDepth;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -93,7 +93,7 @@ public class SpannerConnectionTest {
   /**
    * Initializes the mocks in the test.
    */
-  @Before
+  @BeforeEach
   public void setupMocks() {
     this.mockClient = mock(Client.class);
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
@@ -25,8 +25,8 @@ import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -43,7 +43,7 @@ public class SpannerResultTest {
   /**
    * Setup.
    */
-  @Before
+  @BeforeEach
   public void setup() {
 
     this.resultSetMetadata =

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
@@ -25,7 +25,7 @@ import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import io.r2dbc.spi.ColumnMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SpannerRowMetadata}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -29,7 +29,7 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SpannerRow}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -47,8 +47,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -84,7 +84,7 @@ public class SpannerStatementTest {
   private SpannerConnection mockConnection = mock(SpannerConnection.class);
 
 
-  @Before
+  @BeforeEach
   public void setupMocks() {
     when(this.mockConnection.beginTransaction()).thenReturn(Mono.empty());
     when(this.mockConnection.commitTransaction()).thenReturn(Mono.empty());

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.spanner.r2dbc.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -50,8 +50,8 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.test.StepVerifier;
 
@@ -69,7 +69,7 @@ public class GrpcClientTest {
   /**
    * Sets up execution context mock.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     this.mockContext = mock(StatementExecutionContext.class);
     when(this.mockContext.getSessionName()).thenReturn(SESSION_NAME);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.spanner.r2dbc.codecs;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.google.protobuf.Value;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import java.math.BigDecimal;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link DefaultCodecs}.
@@ -31,24 +31,25 @@ public class DefaultCodecsNegativeTest {
 
   private Codecs codecs = new DefaultCodecs();
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   @Test
   public void encodeException() {
-    this.exception.expect(IllegalArgumentException.class);
-    this.exception.expectMessage("Cannot encode parameter of type java.math.BigDecimal");
 
-    this.codecs.encode(BigDecimal.valueOf(100));
+    assertThrows(IllegalArgumentException.class,
+        () -> this.codecs.encode(BigDecimal.valueOf(100)),
+        "Cannot encode parameter of type java.math.BigDecimal");
   }
 
   @Test
   public void decodeException() {
-    this.exception.expect(IllegalArgumentException.class);
-    this.exception.expectMessage("Cannot decode value of type code: STRING\n"
-        + " to java.lang.Integer");
 
-    Value value = this.codecs.encode("abc");
-    this.codecs.decode(value, Type.newBuilder().setCode(TypeCode.STRING).build(), Integer.class);
+    assertThrows(IllegalArgumentException.class,
+        () -> {
+          Value value = this.codecs.encode("abc");
+          this.codecs.decode(
+              value, Type.newBuilder().setCode(TypeCode.STRING).build(), Integer.class);
+        },
+        "Cannot decode value of type code: STRING\n to java.lang.Integer"
+    );
+
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.r2dbc.codecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.google.protobuf.Value;
 import com.google.spanner.v1.Type;
@@ -24,18 +25,14 @@ import com.google.spanner.v1.TypeCode;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test for {@link DefaultCodecs}.
  */
-@RunWith(Parameterized.class)
 public class DefaultCodecsTest {
 
   private Codecs codecs = new DefaultCodecs();
@@ -43,68 +40,63 @@ public class DefaultCodecsTest {
   /**
    * Prepare parameters for parametrized test.
    */
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][]{
-        {new Boolean[]{true, false, true, null}, Boolean[].class,
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        arguments(new Boolean[]{true, false, true, null}, Boolean[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.BOOL).build()).build()},
-        {new ByteBuffer[]{ByteBuffer.wrap("ab".getBytes()), ByteBuffer.wrap("cd".getBytes()), null},
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.BOOL).build()).build()),
+        arguments(new ByteBuffer[]{
+            ByteBuffer.wrap("ab".getBytes()), ByteBuffer.wrap("cd".getBytes()), null},
             ByteBuffer[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.BYTES).build()).build()},
-        {new LocalDate[]{LocalDate.of(800, 12, 31), LocalDate.of(2019, 1, 1), null},
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.BYTES).build()).build()),
+        arguments(new LocalDate[]{
+            LocalDate.of(800, 12, 31), LocalDate.of(2019, 1, 1), null},
             LocalDate[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.DATE).build()).build()},
-        {new Double[]{2.0d, 3.0d, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN,
-            null}, Double[].class,
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.DATE).build()).build()),
+        arguments(new Double[]{
+            2.0d, 3.0d, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN, null},
+            Double[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.FLOAT64).build()).build()},
-        {new Long[]{2L, 1003L, null}, Long[].class,
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.FLOAT64).build()).build()),
+        arguments(new Long[]{2L, 1003L, null}, Long[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.INT64).build()).build()},
-        {new String[]{"abc", "def", null}, String[].class,
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.INT64).build()).build()),
+        arguments(new String[]{"abc", "def", null}, String[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
-                .setArrayElementType(Type.newBuilder().setCode(TypeCode.STRING).build()).build()},
-        {new LocalDateTime[]{LocalDateTime.parse("2007-12-03T10:15:30"),
-            LocalDateTime.parse("1999-06-05T10:12:51"), null},
+                .setArrayElementType(Type.newBuilder().setCode(TypeCode.STRING).build()).build()),
+        arguments(new LocalDateTime[]{LocalDateTime.parse("2007-12-03T10:15:30"),
+                LocalDateTime.parse("1999-06-05T10:12:51"), null},
             LocalDateTime[].class,
             Type.newBuilder().setCode(TypeCode.ARRAY)
                 .setArrayElementType(
-                    Type.newBuilder().setCode(TypeCode.TIMESTAMP).build()).build()},
+                    Type.newBuilder().setCode(TypeCode.TIMESTAMP).build()).build()),
 
-        {true, Boolean.class, Type.newBuilder().setCode(TypeCode.BOOL).build()},
-        {false, Boolean.class, Type.newBuilder().setCode(TypeCode.BOOL).build()},
-        {ByteBuffer.wrap("ab".getBytes()), ByteBuffer.class,
-            Type.newBuilder().setCode(TypeCode.BYTES).build()},
-        {LocalDate.of(1992, 12, 31), LocalDate.class,
-            Type.newBuilder().setCode(TypeCode.DATE).build()},
-        {2.0d, Double.class, Type.newBuilder().setCode(TypeCode.FLOAT64).build()},
-        {12345L, Long.class, Type.newBuilder().setCode(TypeCode.INT64).build()},
-        {LocalDateTime.parse("1999-06-05T10:12:51"), LocalDateTime.class,
-            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build()},
-        {"abc", String.class, Type.newBuilder().setCode(TypeCode.STRING).build()},
-    });
+        arguments(true, Boolean.class, Type.newBuilder().setCode(TypeCode.BOOL).build()),
+        arguments(false, Boolean.class, Type.newBuilder().setCode(TypeCode.BOOL).build()),
+        arguments(ByteBuffer.wrap("ab".getBytes()), ByteBuffer.class,
+            Type.newBuilder().setCode(TypeCode.BYTES).build()),
+        arguments(LocalDate.of(1992, 12, 31), LocalDate.class,
+            Type.newBuilder().setCode(TypeCode.DATE).build()),
+        arguments(2.0d, Double.class, Type.newBuilder().setCode(TypeCode.FLOAT64).build()),
+        arguments(12345L, Long.class, Type.newBuilder().setCode(TypeCode.INT64).build()),
+        arguments(LocalDateTime.parse("1999-06-05T10:12:51"), LocalDateTime.class,
+            Type.newBuilder().setCode(TypeCode.TIMESTAMP).build()),
+        arguments("abc", String.class, Type.newBuilder().setCode(TypeCode.STRING).build())
+    );
   }
 
-  @Parameter
-  public Object val;
-
-  @Parameter(1)
-  public Class<?> type;
-
-  @Parameter(2)
-  public Type valueType;
-
-  @Test
-  public void codecsTest() {
-    Value value = this.codecs.encode(this.val);
+  /** Validates that every supported type converts to expected value. */
+  @ParameterizedTest
+  @MethodSource("data")
+  public void codecsTest(Object val, Class<?> type, Type valueType) {
+    Value value = this.codecs.encode(val);
     Value nullValue = this.codecs.encode(null);
 
-    assertThat(this.codecs.decode(value, this.valueType, this.type)).isEqualTo(this.val);
+    assertThat(this.codecs.decode(value, valueType, type)).isEqualTo(val);
 
-    assertThat(this.codecs.decode(nullValue, this.valueType, this.type)).isNull();
+    assertThat(this.codecs.decode(nullValue, valueType, type)).isNull();
   }
 
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
@@ -28,8 +28,8 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.R2dbcNonTransientException;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -47,7 +47,7 @@ public class SpannerDdlIT {
   /**
    * Setup the testing environment for DDL integration tests.
    */
-  @Before
+  @BeforeEach
   public void setupEnvironment() {
     try {
       Mono.from(connectionFactory.create())

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -55,10 +55,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -88,7 +88,7 @@ public class SpannerIT {
   /**
    * Setup the Spanner stub for testing.
    */
-  @Before
+  @BeforeEach
   public void setupStubs() throws IOException {
     this.grpcClient = new GrpcClient(GoogleCredentials.getApplicationDefault());
     this.spanner = this.grpcClient.getSpanner();
@@ -98,7 +98,7 @@ public class SpannerIT {
         "DELETE FROM books WHERE true");
   }
 
-  @After
+  @AfterEach
   public void shutdown() {
     this.grpcClient.close().block();
   }
@@ -106,7 +106,7 @@ public class SpannerIT {
   /**
    * Setup the Spanner table for testing.
    */
-  @BeforeClass
+  @BeforeAll
   public static void setupSpannerTable() throws InterruptedException, ExecutionException {
 
     SpannerConnection con =

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
@@ -43,10 +43,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Function;
 import java.util.stream.IntStream;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,7 +202,7 @@ public class SpannerTestKit implements TestKit<String> {
     return jdbcOperations;
   }
 
-  @Ignore
+  @Disabled
   @Override
   @Test
   public void transactionRollback() {
@@ -215,7 +215,7 @@ public class SpannerTestKit implements TestKit<String> {
      */
   }
 
-  @Ignore
+  @Disabled
   @Override
   @Test
   public void bindFails() {
@@ -300,7 +300,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void returnGeneratedValues() {
     /*
@@ -309,7 +309,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void clobInsert() {
     /*
@@ -318,7 +318,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void blobInsert() {
     /*
@@ -327,7 +327,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void blobSelect() {
     /*
@@ -336,7 +336,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void clobSelect() {
     /*
@@ -345,7 +345,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void batch() {
     /*
@@ -354,7 +354,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void savePoint() {
     /*
@@ -363,7 +363,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void savePointStartsTransaction() {
     /*
@@ -372,7 +372,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void prepareStatementWithIncompleteBindingFails() {
     /*
@@ -381,7 +381,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void prepareStatementWithIncompleteBatchFails() {
     /*
@@ -423,7 +423,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Ignore
+  @Disabled
   @Test
   public void compoundStatement() {
     /*

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatementBindingsTest {
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner.r2dbc.statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatementParserTest {
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.spanner.r2dbc.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link Assert}.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.spanner.r2dbc.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CollectionsBuilderTest {
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -23,7 +23,7 @@ import io.grpc.StatusRuntimeException;
 import io.r2dbc.spi.R2dbcNonTransientException;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import io.r2dbc.spi.R2dbcTransientResourceException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
@@ -32,7 +32,7 @@ import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.R2dbcTransientResourceException;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SpannerExceptionUtilTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.0-M4</version>
         <executions>
           <execution>
             <id>failsafe-integration-tests</id>
@@ -242,6 +242,12 @@
             <goals>
               <goal>integration-test</goal>
             </goals>
+            <configuration>
+              <includes>
+                <include>**/*TestKit.java</include>
+                <include>**/*IT.java</include>
+              </includes>
+            </configuration>
           </execution>
           <execution>
             <id>failsafe-verify</id>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <slf4j.version>1.7.29</slf4j.version>
 
     <assertj.version>3.12.2</assertj.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>5.5.2</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -134,6 +134,13 @@
 
       <!-- Test dependencies -->
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.r2dbc</groupId>
         <artifactId>r2dbc-spi-test</artifactId>
         <version>${r2dbc.version}</version>
@@ -143,12 +150,6 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -166,6 +167,44 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <!-- Common test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 
   <build>
@@ -233,8 +272,19 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M4</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.0.0-M4</version>
+        <configuration>
+          <includes>
+            <include>**/*TestKit.java</include>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
         <executions>
           <execution>
             <id>failsafe-integration-tests</id>
@@ -242,12 +292,6 @@
             <goals>
               <goal>integration-test</goal>
             </goals>
-            <configuration>
-              <includes>
-                <include>**/*TestKit.java</include>
-                <include>**/*IT.java</include>
-              </includes>
-            </configuration>
           </execution>
           <execution>
             <id>failsafe-verify</id>


### PR DESCRIPTION
So that was a 3 line change. But it turns out that running TestKit (which is a JUnit5 test suite) makes old JUnit4 tests not run. I could have added vintage engine to pom, but this seemed like a good point to migrate tests to JUnit5.

Most test changes are boilerplate except for Codec tests (parametrization and exception validation changed).

Fixes #176 .