### PR TITLE
Cloud Spanner - R2DBC - Spring data sample

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/README.adoc
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/README.adoc
@@ -1,7 +1,6 @@
 # Cloud Spanner Spring Data R2DBC sample
 
-
-This sample creates a table called BOOK on application startup, and deletes it prior to application shutdown.
+This sample creates a table called `BOOK` on application startup, and deletes it prior to application shutdown.
 
 ## Running the Sample
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/README.adoc
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/README.adoc
@@ -1,0 +1,16 @@
+# Cloud Spanner Spring Data R2DBC sample
+
+
+This sample creates a table called BOOK on application startup, and deletes it prior to application shutdown.
+
+## Running the Sample
+
+1. Run the sample from the command line, providing `spanner.instance`, `spanner.database` and `gcp.project` properties:
+
+```
+mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dspanner.instance=[SPANNER-INSTANCE] -Dspanner.database=[SPANNER-DATABASE] -Dgcp.project=GCP-PROJECT"
+```
+
+2. Visit http://localhost:8080/index.html
+
+3. Try the different actions available -- listing books, adding a new book, and searching for a book by its ID.

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -15,6 +15,17 @@
   <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
 
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot.experimental</groupId>
+        <artifactId>spring-boot-bom-r2dbc</artifactId>
+        <version>0.1.0.M3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -32,11 +43,17 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot.experimental</groupId>
+      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
+    </dependency>
+
+<!--
+    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-r2dbc</artifactId>
       <version>1.0.0.RELEASE</version>
     </dependency>
-
+-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -31,12 +31,6 @@
 
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>cloud-spanner-r2dbc</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
       <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -7,11 +7,13 @@
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
     <version>2.2.3.RELEASE</version>
+    <relativePath/>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
+  <version>0.2.0-SNAPSHOT</version>
 
   <dependencyManagement>
     <dependencies>
@@ -30,13 +32,13 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>cloud-spanner-r2dbc</artifactId>
-      <version>0.1.0</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -47,7 +49,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <version>2.2.4.RELEASE</version>
     </dependency>
 
   </dependencies>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.2.3.RELEASE</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
+
+
+
+  <dependencies>
+
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-spanner-r2dbc</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-r2dbc</artifactId>
+      <version>1.0.0.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>2.2.4.RELEASE</version>
+    </dependency>
+
+
+  </dependencies>
+
+</project>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -3,7 +3,6 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
@@ -13,7 +12,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
-
 
   <dependencyManagement>
     <dependencies>
@@ -28,7 +26,6 @@
   </dependencyManagement>
 
   <dependencies>
-
 
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -52,7 +49,6 @@
       <artifactId>spring-boot-starter-webflux</artifactId>
       <version>2.2.4.RELEASE</version>
     </dependency>
-
 
   </dependencies>
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -47,13 +47,6 @@
       <artifactId>spring-boot-starter-data-r2dbc</artifactId>
     </dependency>
 
-<!--
-    <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-r2dbc</artifactId>
-      <version>1.0.0.RELEASE</version>
-    </dependency>
--->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+/**
+ *
+ */
+public class Book {
+
+  private String title;
+
+  public Book(String title) {
+    this.title = title;
+  }
+
+  public String getTitle() {
+    return this.title;
+  }
+}

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -16,15 +16,27 @@
 
 package com.example;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
 /**
- *
+ * Book entity.
  */
+@Table
 public class Book {
+
+  @Id
+  private String id;
 
   private String title;
 
-  public Book(String title) {
+  public Book(String id, String title) {
+    this.id = id;
     this.title = title;
+  }
+
+  public String getId() {
+    return id;
   }
 
   public String getTitle() {

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
@@ -16,14 +16,12 @@
 
 package com.example;
 
-import java.awt.print.Book;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 /**
- *
+ * Spring Data repository for books.
+ * <p>Query derivation is not supported yet.</p>
  */
-
 interface BookRepository extends ReactiveCrudRepository<Book, String> {
 
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/BookRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import java.awt.print.Book;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+/**
+ *
+ */
+
+interface BookRepository extends ReactiveCrudRepository<Book, String> {
+
+}

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/RestController.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/RestController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ *
+ */
+@org.springframework.web.bind.annotation.RestController
+public class RestController {
+
+  @Autowired
+  private DatabaseClient r2dbcClient;
+
+  @GetMapping("/list")
+  public Flux<Book> listBooks() {
+    return r2dbcClient.execute("SELECT id, title FROM BOOK")
+        .as(Book.class)
+        .fetch().all();
+     //   .map(b -> b.getTitle());
+
+    /*
+    this works
+    r2dbcClient.execute("SELECT title FROM BOOK")
+        .map(r -> (String)r.get(0))
+        .all();
+        */
+  }
+
+
+  @PostMapping("/add")
+  public Mono<Void> addBook(@RequestBody String bookTitle) {
+    return r2dbcClient.insert()
+        .into("book")
+        .value("id", UUID.randomUUID().toString())
+        .value("title", bookTitle)
+        .then().then(Mono.fromRunnable(() -> {
+          System.out.println("WRITING VALUE: " + bookTitle);
+        }));
+  }
+
+}

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -20,10 +20,14 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DR
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
+import java.net.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +40,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 import org.springframework.util.Assert;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
 
 /**
  * Driver application showing Cloud Spanner R2DBC use with Spring Data.
@@ -104,5 +110,14 @@ public class SpringDataR2dbcApp {
     }
 
     LOGGER.info("Finished deleting test table BOOK.");
+  }
+
+
+  @Bean
+  public RouterFunction<ServerResponse> indexRouter() {
+    // Serve static index.html at root.
+    return route(
+        GET("/"),
+        req -> ServerResponse.permanentRedirect(URI.create("/index.html")).build());
   }
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.util.Assert;
+
+/**
+ *
+ */
+@SpringBootApplication
+public class SpringDataR2dbcApp {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpringDataR2dbcApp.class);
+
+  private static final String SPANNER_INSTANCE = System.getProperty("spanner.instance");
+
+  private static final String SPANNER_DATABASE = System.getProperty("spanner.database");
+
+  private static final String GCP_PROJECT = System.getProperty("gcp.project");
+
+  @Autowired
+  private DatabaseClient r2dbcClient;
+
+  public static void main(String[] args) {
+    System.out.println("instance = " + SPANNER_INSTANCE);
+    Assert.notNull(INSTANCE, "Please provide spanner.instance property");
+    Assert.notNull(DATABASE, "Please provide spanner.database property");
+    Assert.notNull(GCP_PROJECT, "Please provide gcp.project property");
+
+    SpringApplication.run(SpringDataR2dbcApp.class, args);
+  }
+
+
+  @Bean
+  public static DatabaseClient r2dbcClient() {
+    ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        .option(Option.valueOf("project"), GCP_PROJECT)
+        .option(DRIVER, DRIVER_NAME)
+        .option(INSTANCE, SPANNER_INSTANCE)
+        .option(DATABASE, SPANNER_DATABASE)
+        .build());
+
+    return DatabaseClient.create(connectionFactory);
+  }
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void setUpData() {
+    LOGGER.info("Setting up test table BOOK...");
+   int rowsUPdated = r2dbcClient.execute("CREATE TABLE BOOK ("
+        + "  ID STRING(36) NOT NULL,"
+        + "  TITLE STRING(MAX) NOT NULL"
+        + ") PRIMARY KEY (ID)")
+    .fetch().rowsUpdated().block();
+    LOGGER.info("Finished setting up test table BOOK");
+  }
+
+  @EventListener({ContextClosedEvent.class, ApplicationReadyEvent.class})
+  public void tearDownData() {
+    LOGGER.info("Tearing down test table BOOK...");
+   /* int rowsUPdated = r2dbcClient.execute("DROP TABLE BOOK")
+        .fetch().rowsUpdated().block();
+
+    */
+    LOGGER.info("Finished tearing down test table BOOK.");
+
+  }
+}

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
@@ -20,36 +20,37 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- *
+ * Provides HTTP endpoints for manipulating the BOOK table.
+ * <ul>
+ *   <li>{@code /list} Returns all books in the table (GET).</li>
+ *   <li>{@code /add} Adds a new book with a given title and a generated UUID as {@code id} (POST).</li>
+ *   <li>{@code /search/\{id\}} Finds a single book by its ID.</li>
+ * </ul>
  */
-@org.springframework.web.bind.annotation.RestController
-public class RestController {
+@RestController
+public class WebController {
 
   @Autowired
   private DatabaseClient r2dbcClient;
+
+  @Autowired
+  private BookRepository r2dbcRepository;
 
   @GetMapping("/list")
   public Flux<Book> listBooks() {
     return r2dbcClient.execute("SELECT id, title FROM BOOK")
         .as(Book.class)
         .fetch().all();
-     //   .map(b -> b.getTitle());
-
-    /*
-    this works
-    r2dbcClient.execute("SELECT title FROM BOOK")
-        .map(r -> (String)r.get(0))
-        .all();
-        */
   }
-
 
   @PostMapping("/add")
   public Mono<Void> addBook(@RequestBody String bookTitle) {
@@ -57,9 +58,13 @@ public class RestController {
         .into("book")
         .value("id", UUID.randomUUID().toString())
         .value("title", bookTitle)
-        .then().then(Mono.fromRunnable(() -> {
-          System.out.println("WRITING VALUE: " + bookTitle);
-        }));
+        .then();
+  }
+
+
+  @GetMapping("/search/{id}")
+  public Mono<Book> searchBooks(@PathVariable String id) {
+    return r2dbcRepository.findById(id);
   }
 
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -83,14 +83,15 @@
   </div>
 
   <div class="buttonLink">
-  New Book Title: <input id="newBookTitle" name="title"/> <a class="buttonLink" href="/" onClick="return addBook();">Add Book</a>
+  New Book Title: <input id="newBookTitle" name="newBookTitle"/> <a class="buttonLink" href="/" onClick="return addBook();">Add Book</a>
   </div>
 
   <div class="buttonLink">
-    Search for: <input id="bookId"/> <a class="buttonLink" href="/" onClick="return findBookById();">Find Books</a>
+    Search for: <input id="bookId" name="bookId"/> <a class="buttonLink" href="/" onClick="return findBookById();">Find Books</a>
   </div>
 </div>
 
+<label for="result" style="display:block">Command Output</label>
 <textarea id="result" disabled="true" style="background-color: #DDEEFF; width: 80em; height: 30em;">
 
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -1,0 +1,69 @@
+<html>
+<head>
+  <title>Spring Data R2DBC for Cloud Spanner demo</title>
+  <script>
+
+    var xhr = new XMLHttpRequest();
+
+    function appendOutput(extraText) {
+      document.getElementById('result').value += (extraText + "\n\n\n");
+    }
+
+    function listBooks() {
+
+      fetch('/list', {
+        method: 'GET',
+      }).then(response => response.json())
+      .then(json => appendOutput("Book list:\n" + json.map(book => book.title).join('\n')));
+
+      return false;
+    }
+
+    function addBook() {
+      var newTitle = document.getElementById('newBookTitle').value;
+
+      fetch('/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json'},
+        body: newTitle
+      }).then(response => {
+         if (response.ok) {
+           appendOutput("Added book.");
+         } else {
+           appendOutput("Failed to add book.");
+         }
+       });
+
+
+      return false;
+    }
+
+  </script>
+
+  <style>
+    div.buttonLink {
+      margin-bottom: 1em;
+    }
+  </style>
+</head>
+
+
+<body>
+
+<div id="actions" style="padding-bottom: 3em;">
+  <div class="buttonLink">
+    <a href="/" onClick="return listBooks();">List Books</a>
+  </div>
+  <div class="buttonLink">
+  New Book Title: <input id="newBookTitle" name="title"/> <a class="buttonLink" href="/" onClick="return addBook();">Add Book</a>
+  </div>
+</div>
+
+<textarea id="result" disabled="true" style="background-color: aqua; width: 200em; height: 30em;">
+
+
+</textarea>
+
+
+</body>
+</html>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -3,10 +3,16 @@
   <title>Spring Data R2DBC for Cloud Spanner demo</title>
   <script>
 
-    var xhr = new XMLHttpRequest();
 
-    function appendOutput(extraText) {
-      document.getElementById('result').value += (extraText + "\n\n\n");
+    function appendOutput(extraText, books) {
+      const el = document.getElementById('result');
+      el.value += extraText;
+      if (books) {
+        for (let book of books) {
+          el.value += (book.title + "(" + book.id + ")\n");
+        }
+      }
+      el.value +=  "\n\n";
     }
 
     function listBooks() {
@@ -14,13 +20,17 @@
       fetch('/list', {
         method: 'GET',
       }).then(response => response.json())
-      .then(json => appendOutput("Book list:\n" + json.map(book => book.title).join('\n')));
+      .then(books => books.length > 0 ? appendOutput("Book list:\n", books) : appendOutput("No books found."));
 
       return false;
     }
 
     function addBook() {
-      var newTitle = document.getElementById('newBookTitle').value;
+      const newTitle = document.getElementById('newBookTitle').value;
+      if (!newTitle) {
+        appendOutput("Please provide non-empty title");
+        return false;
+      }
 
       fetch('/add', {
         method: 'POST',
@@ -33,6 +43,23 @@
            appendOutput("Failed to add book.");
          }
        });
+
+
+      return false;
+    }
+
+    function findBookById() {
+      const id = document.getElementById('bookId').value;
+      if (!id) {
+        appendOutput("Please provide non-empty id");
+        return false;
+      }
+
+      fetch('/search/' + id, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json'},
+      }).then(response => response.text())
+      .then(text => text.length ? appendOutput("Found book:", [JSON.parse(text)]) : appendOutput("Book not found"));
 
 
       return false;
@@ -51,15 +78,21 @@
 <body>
 
 <div id="actions" style="padding-bottom: 3em;">
+
   <div class="buttonLink">
     <a href="/" onClick="return listBooks();">List Books</a>
   </div>
+
   <div class="buttonLink">
   New Book Title: <input id="newBookTitle" name="title"/> <a class="buttonLink" href="/" onClick="return addBook();">Add Book</a>
   </div>
+
+  <div class="buttonLink">
+    Search for: <input id="bookId"/> <a class="buttonLink" href="/" onClick="return findBookById();">Find Books</a>
+  </div>
 </div>
 
-<textarea id="result" disabled="true" style="background-color: aqua; width: 200em; height: 30em;">
+<textarea id="result" disabled="true" style="background-color: aqua; width: 80em; height: 30em;">
 
 
 </textarea>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -92,7 +92,7 @@
   </div>
 </div>
 
-<textarea id="result" disabled="true" style="background-color: aqua; width: 80em; height: 30em;">
+<textarea id="result" disabled="true" style="background-color: #DDEEFF; width: 80em; height: 30em;">
 
 
 </textarea>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -3,7 +3,6 @@
   <title>Spring Data R2DBC for Cloud Spanner demo</title>
   <script>
 
-
     function appendOutput(extraText, books) {
       const el = document.getElementById('result');
       el.value += extraText;

--- a/cloud-spanner-r2dbc-samples/pom.xml
+++ b/cloud-spanner-r2dbc-samples/pom.xml
@@ -16,6 +16,7 @@
 
   <modules>
     <module>cloud-spanner-r2dbc-sample</module>
+    <module>cloud-spanner-spring-data-r2dbc-sample</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This sample creates a table called BOOK on application startup, and deletes it prior to application shutdown.

It provides three endpoints showing Spring Data R2DBC manipulation of Cloud Spanner data:
1) `/list` returns all books in the `BOOKS` table using the autoconfigured `DatabaseClient`.
2) `/add` inserts a book using the semantic insert in the autoconfigured `DatabaseClient`.
3) `/search/{id}` finds a specific book by ID using Spring Data R2DBC repository.

I owe an integration test, which I'd like to add in a follow-up PR.