### PR TITLE
Add refdoc for Spring Data R2DBC Dialect

### DIFF
--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -36,13 +36,12 @@ These features include:
 
 * Spring configuration support using Java based `@Configuration` classes.
 * Annotation based mapping metadata.
-* Automatic implementation of Repository interfaces including support.
-* Support for Reactive Transactions
+* Automatic implementation of Repository interfaces.
+* Support for Reactive Transactions.
 * Schema and data initialization utilities.
 
 See the [Spring Data R2DBC documentation](https://docs.spring.io/spring-data/r2dbc/docs/1.0.x/reference/html/#reference) for more information on how to use Spring Data R2DBC.
 
 ## Sample Application
 
-We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample)
-which demonstrates using the Spring Data R2DBC with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).
+We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample) which demonstrates using the Spring Data R2DBC framework with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).

--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -1,0 +1,55 @@
+# Cloud Spanner Spring Data R2DBC
+
+The Spring Data R2DBC Dialect for Cloud Spanner enables the usage of [Spring Data R2DBC](https://github.com/spring-projects/spring-data-r2dbc) with Spanner.
+
+The goal of the Spring Data project is to create easy and consistent ways of using data access technologies from Spring Framework applications.
+
+## Setup
+
+To begin using Spring Data R2DBC with Cloud Spanner, add the following dependencies to your project:
+
+```xml
+<dependencies>
+    <!-- The Spring Data R2DBC framework -->
+    <dependency>
+          <groupId>org.springframework.data</groupId>
+          <artifactId>spring-data-r2dbc</artifactId>
+          <version>${spring-data-r2dbc.version}</version>
+    </dependency>
+
+    <!-- R2DBC Driver for Cloud Spanner -->
+    <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>cloud-spanner-r2dbc</artifactId>
+        <version>${cloud-spanner-r2dbc-version}</version>
+    </dependency>
+
+    <!-- Dialect to enable Spring Data R2DBC for Cloud Spanner -->
+    <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
+        <version>${cloud-spanner-r2dbc-version}</version>
+    </dependency>
+</dependencies>
+```
+
+## Overview
+
+Spring Data R2DBC allows you to use the convenient features of Spring Data in a Reactive environment.
+These features include:
+
+* Spring configuration support using Java based `@Configuration` classes.
+* Annotation based mapping metadata.
+* Automatic implementation of Repository interfaces including support.
+* Support for Reactive Transactions
+* Schema and data initialization utilities.
+
+See the [Spring Data R2DBC documentation](https://github.com/spring-projects/spring-data-r2dbc#features) for more information.
+
+## Sample Application
+
+We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample)
+which demonstrates using the Spring Data R2DBC with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).
+
+
+

--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -10,21 +10,17 @@ To begin using Spring Data R2DBC with Cloud Spanner, add the following dependenc
 
 ```xml
 <dependencies>
-    <!-- The Spring Data R2DBC framework -->
+    <!-- The starter dependency for the Spring Data R2DBC framework. -->
     <dependency>
-          <groupId>org.springframework.data</groupId>
-          <artifactId>spring-data-r2dbc</artifactId>
-          <version>${spring-data-r2dbc.version}</version>
+        <groupId>org.springframework.boot.experimental</groupId>
+        <artifactId>spring-boot-starter-data-r2dbc</artifactId>
+        <version>${r2dbc-version}</version>
     </dependency>
 
-    <!-- R2DBC Driver for Cloud Spanner -->
-    <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>cloud-spanner-r2dbc</artifactId>
-        <version>${cloud-spanner-r2dbc-version}</version>
-    </dependency>
-
-    <!-- Dialect to enable Spring Data R2DBC for Cloud Spanner -->
+    <!--
+        Dialect for Spring Data R2DBC Spanner; This includes the
+        Cloud Spanner R2DBC driver as a transitive dependency.
+    -->
     <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>

--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -50,6 +50,3 @@ See the [Spring Data R2DBC documentation](https://github.com/spring-projects/spr
 
 We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample)
 which demonstrates using the Spring Data R2DBC with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).
-
-
-

--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -44,7 +44,7 @@ These features include:
 * Support for Reactive Transactions
 * Schema and data initialization utilities.
 
-See the [Spring Data R2DBC documentation](https://github.com/spring-projects/spring-data-r2dbc#features) for more information.
+See the [Spring Data R2DBC documentation](https://docs.spring.io/spring-data/r2dbc/docs/1.0.x/reference/html/#reference) for more information on how to use Spring Data R2DBC.
 
 ## Sample Application
 


### PR DESCRIPTION
Add a refdoc for using Spring Data R2DBC with Cloud Spanner.

I included a basic summary, setup instructions, and sample application links. Kept the refdoc short; I found that additional details on how to use spring data r2dbc would duplicate the content in the standard [spring data r2dbc docs](https://github.com/spring-projects/spring-data-r2dbc#features).