### PR TITLE
Fix driver version to current snapshot

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -18,6 +18,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>cloud-spanner-r2dbc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot.experimental</groupId>
         <artifactId>spring-boot-bom-r2dbc</artifactId>
         <version>0.1.0.M3</version>
@@ -26,7 +31,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
The Spring Boot BOM links to the old snapshot version (#221), but regardless the sample should depend on the latest snapshot from current project.