### PR TITLE
disable deploy on the new sample

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
@@ -57,4 +57,18 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+          <mainClass>com.example.SampleApplication</mainClass>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -13,6 +13,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
+  <groupId>com.google.cloud</groupId>
   <version>0.2.0-SNAPSHOT</version>
 
   <dependencyManagement>
@@ -58,5 +59,25 @@
       <url>https://repo.spring.io/milestone</url>
     </repository>
   </repositories>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
 
 </project>

--- a/cloud-spanner-r2dbc-samples/pom.xml
+++ b/cloud-spanner-r2dbc-samples/pom.xml
@@ -36,16 +36,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
-        <configuration>
-          <mainClass>com.example.SampleApplication</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
1) Disable maven deploy on the sample
2) change group to reflect reality, as when it tried to deploy it was to the spring repo...
3) move mvn:exec application entry point where it belongs -- in the old sample instead of top-level samples dir.