### PR TITLE
Add Implementation-Version to generated jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,18 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
+      </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
               </manifest>
             </archive>
           </configuration>
-      </plugin>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
Sets maven jar plugin property `addDefaultImplementationEntries`.

The result is addition of an extra three lines to the manifest:

```
Implementation-Title: Google Cloud Spanner R2DBC Driver
Implementation-Version: 0.2.0-SNAPSHOT
Implementation-Vendor: Google LLC
```


Fixes #216.