### PR TITLE
Switch StatementParser to pass through to the facade

### DIFF
--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -68,16 +68,17 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- Connection API from the Cloud Spanner client library -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-spanner</artifactId>
+      <version>1.52.1-SNAPSHOT</version>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-spi-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-spanner</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>1.52.1-SNAPSHOT</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class StatementParserTest {
@@ -61,6 +62,7 @@ public class StatementParserTest {
   }
 
   @Test
+  @Disabled
   public void parseQueryWithOptionsPrefix() {
     String sql = "@{FORCE_INDEX=index_name} @{JOIN_METHOD=HASH_JOIN} SELECT * FROM blahblah";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.spanner.r2dbc.statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class StatementParserTest {
@@ -62,7 +61,6 @@ public class StatementParserTest {
   }
 
   @Test
-  @Disabled
   public void parseQueryWithOptionsPrefix() {
     String sql = "@{FORCE_INDEX=index_name} @{JOIN_METHOD=HASH_JOIN} SELECT * FROM blahblah";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner</artifactId>
-        <version>1.52.1-SNAPSHOT</version>
+        <version>1.53.0</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <google-cloud-bom.version>4.1.1</google-cloud-bom.version>
+    <google-cloud-bom.version>5.1.0</google-cloud-bom.version>
 
     <r2dbc.version>0.8.1.RELEASE</r2dbc.version>
     <reactor.version>Dysprosium-SR5</reactor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- override to snapshot until Connection API released -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner</artifactId>
+        <version>1.52.1-SNAPSHOT</version>
+      </dependency>
+
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>


### PR DESCRIPTION
Updates to the latest Cloud Spanner client library and uses its Connection API to check query type.

Also updates cloud libraries BOM, but it has not had time to pull in the newest Cloud Spanner client library, so an override is needed.

Co-authored-by: @dmitry-s
Fixes #236.