### PR TITLE
Run SELECT statements in transactions

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -18,15 +18,14 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement.Builder;
 import com.google.cloud.spanner.r2dbc.statement.TypedNull;
-import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
 
 /**
- * Cloud Spanner implementation of R2DBC SPI for query statements.
+ * Cloud Spanner base implementation of R2DBC SPI for query and DML statements.
+ *
+ * <p>Supports parameter binding.
  */
 abstract class AbstractSpannerClientLibraryStatement implements Statement {
 
@@ -42,7 +41,8 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
    * @param clientLibraryAdapter client library implementation of core functionality
    * @param query query to run, with `@` placeholders expected as parameters.
    */
-  public AbstractSpannerClientLibraryStatement(DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
+  public AbstractSpannerClientLibraryStatement(
+      DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
     this.clientLibraryAdapter = clientLibraryAdapter;
     this.statementBuilder = com.google.cloud.spanner.Statement.newBuilder(query);
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.cloud.spanner.Statement.Builder;
+import com.google.cloud.spanner.r2dbc.statement.TypedNull;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Cloud Spanner implementation of R2DBC SPI for query statements.
+ */
+abstract class AbstractSpannerClientLibraryStatement implements Statement {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AbstractSpannerClientLibraryStatement.class);
+
+  protected final DatabaseClientReactiveAdapter clientLibraryAdapter;
+
+  protected final Builder statementBuilder;
+
+  /**
+   * Creates a ready-to-run Cloud Spanner statement.
+   * @param clientLibraryAdapter client library implementation of core functionality
+   * @param query query to run, with `@` placeholders expected as parameters.
+   */
+  public AbstractSpannerClientLibraryStatement(DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
+    this.clientLibraryAdapter = clientLibraryAdapter;
+    this.statementBuilder = com.google.cloud.spanner.Statement.newBuilder(query);
+  }
+
+  @Override
+  public Statement add() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Statement bind(int index, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Statement bind(String name, Object value) {
+    ClientLibraryBinder.bind(this.statementBuilder, name, value);
+    return this;
+  }
+
+  @Override
+  public Statement bindNull(int index, Class<?> type) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Statement bindNull(String name, Class<?> type) {
+    ClientLibraryBinder.bind(this.statementBuilder, name, new TypedNull(type));
+    return this;
+  }
+
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -108,7 +108,7 @@ class DatabaseClientReactiveAdapter {
   private void clearTransactionManager() {
     LOGGER.debug("close transaction manager");
     this.txnContext = null;
-    //this.lastStep = null;
+    this.lastStep = null;
     this.transactionManager.close();
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -106,7 +106,6 @@ public class SpannerClientLibraryConnection implements Connection {
       LOGGER.debug("DML statement detected: " + query);
       return new SpannerClientLibraryDmlStatement(this.clientLibraryAdapter, query);
     }
-
     return new SpannerClientLibraryStatement(this.clientLibraryAdapter, query);
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -106,7 +106,8 @@ public class SpannerClientLibraryConnection implements Connection {
       LOGGER.debug("DML statement detected: " + query);
       return new SpannerClientLibraryDmlStatement(this.clientLibraryAdapter, query);
     }
-    return new SpannerClientLibraryStatement(this.dbClient, query, this.executorService);
+
+    return new SpannerClientLibraryStatement(this.clientLibraryAdapter, query);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,56 +26,25 @@ import reactor.core.publisher.Mono;
 /**
  * Cloud Spanner implementation of R2DBC SPI for DML statements.
  */
-public class SpannerClientLibraryDmlStatement implements Statement {
+public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryStatement {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SpannerClientLibraryDmlStatement.class);
-
-  private DatabaseClientReactiveAdapter clientLibraryAdapter;
-
-  private String query;
 
   /**
    * Creates a ready-to-run Cloud Spanner DML statement.
    * @param clientLibraryAdapter client library implementation of core functionality
    * @param query query to run
    */
-  // TODO: accept a transaction
   public SpannerClientLibraryDmlStatement(DatabaseClientReactiveAdapter clientLibraryAdapter,
       String query) {
-    this.clientLibraryAdapter = clientLibraryAdapter;
-    this.query = query;
-  }
-
-  @Override
-  public Statement add() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bind(int index, Object value) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bind(String name, Object value) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bindNull(int index, Class<?> type) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bindNull(String name, Class<?> type) {
-    throw new UnsupportedOperationException();
+    super(clientLibraryAdapter, query);
   }
 
   @Override
   public Publisher<? extends Result> execute() {
     return this.clientLibraryAdapter
-        .runDmlStatement(com.google.cloud.spanner.Statement.of(this.query))
+        .runDmlStatement(this.statementBuilder.build())
         .transform(numRowsUpdatedMono -> Mono.just(
             new SpannerClientLibraryResult(Flux.empty(), numRowsUpdatedMono.map(this::longToInt))));
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -23,19 +23,20 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 /**
- * Cloud Spanner implementation of R2DBC SPI for query statements.
+ * Cloud Spanner implementation of R2DBC SPI for SELECT query statements.
  */
 public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatement {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SpannerClientLibraryStatement.class);
 
-   /**
+  /**
    * Creates a ready-to-run Cloud Spanner statement.
    * @param clientLibraryAdapter client library implementation of core functionality
    * @param query query to run, with `@` placeholders expected as parameters.
    */
-  public SpannerClientLibraryStatement(DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
+  public SpannerClientLibraryStatement(
+      DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
     super(clientLibraryAdapter, query);
   }
 
@@ -45,6 +46,5 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
         .runSelectStatement(this.statementBuilder.build())
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty())));
   }
-
 
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -16,71 +16,27 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.AsyncResultSet;
-import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.spanner.Statement.Builder;
-import com.google.cloud.spanner.r2dbc.statement.TypedNull;
 import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Statement;
-import java.util.concurrent.ExecutorService;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 /**
  * Cloud Spanner implementation of R2DBC SPI for query statements.
  */
-public class SpannerClientLibraryStatement implements Statement {
+public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatement {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SpannerClientLibraryStatement.class);
 
-  private DatabaseClientReactiveAdapter clientLibraryAdapter;
-
-  private final Builder statementBuilder;
-
-  /**
+   /**
    * Creates a ready-to-run Cloud Spanner statement.
    * @param clientLibraryAdapter client library implementation of core functionality
    * @param query query to run, with `@` placeholders expected as parameters.
    */
-  // TODO: accept a transaction
   public SpannerClientLibraryStatement(DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
-    this.clientLibraryAdapter = clientLibraryAdapter;
-    //this.query = query;
-    this.statementBuilder = com.google.cloud.spanner.Statement.newBuilder(query);
-  }
-
-  // TODO (elfel): remind me about adding batched parameters -- supported in only DML?
-  @Override
-  public Statement add() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bind(int index, Object value) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bind(String name, Object value) {
-    ClientLibraryBinder.bind(this.statementBuilder, name, value);
-    return this;
-  }
-
-  @Override
-  public Statement bindNull(int index, Class<?> type) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Statement bindNull(String name, Class<?> type) {
-    ClientLibraryBinder.bind(this.statementBuilder, name, new TypedNull(type));
-    return this;
+    super(clientLibraryAdapter, query);
   }
 
   @Override
@@ -88,22 +44,6 @@ public class SpannerClientLibraryStatement implements Statement {
     return this.clientLibraryAdapter
         .runSelectStatement(this.statementBuilder.build())
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty())));
-        /*
-    // TODO: unplaceholder singleUse, extract into member to allow transaction options customization
-    // make note -- timestamp bound passed as part of transaction type
-    return Flux.<SpannerClientLibraryRow>create(
-        sink -> {
-          AsyncResultSet ars =
-              this.databaseClient.singleUse().executeQueryAsync(this.statementBuilder.build());
-          sink.onCancel(ars::cancel);
-
-          // TODO: handle backpressure by asking callback to signal CallbackResponse.PAUSE
-          //   Use sink.onRequest() to keep track of cumulative demand
-          ars.setCallback(this.executorService, rs -> this.callback(sink, rs));
-        })
-        .transform(rowFlux -> Mono.just(new SpannerClientLibraryResult(rowFlux, Mono.just(0))));
-
-         */
   }
 
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
@@ -44,6 +44,10 @@ public class ClientLibraryBasedIntegrationTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ClientLibraryBasedIntegrationTest.class);
 
+  static final String INSERT_QUERY = "INSERT BOOKS (UUID, TITLE, AUTHOR, CATEGORY, FICTION, " +
+    "PUBLISHED, WORDS_PER_SENTENCE) VALUES (@uuid, 'A Sound of Thunder', 'Ray Bradbury', " +
+    "@category, TRUE, '1952-06-28', @wordCount)";
+
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(
           ConnectionFactoryOptions.builder()
@@ -141,7 +145,11 @@ public class ClientLibraryBasedIntegrationTest {
     StepVerifier.create(
         Mono.from(
             // TODO: replace hardcoded values with bind variables
-            conn.createStatement(makeInsertQuery(id, 100, 20.8)).execute())
+            conn.createStatement(INSERT_QUERY)
+                .bind("uuid", id)
+                .bind("category", 100L)
+                .bind("wordCount", 20.8)
+                .execute())
             .flatMapMany(rs -> rs.getRowsUpdated())
     ).expectNext(1).verifyComplete();
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
@@ -178,7 +178,8 @@ public class ClientLibraryBasedIntegrationTest {
                 c.beginTransaction(),
                 Flux.from(c.createStatement(makeInsertQuery(uuid1, 100, 15.0)).execute())
                     .flatMap(r -> r.getRowsUpdated()),
-                c.commitTransaction()))
+                c.commitTransaction(),
+                c.close()))
     ).expectNext(1).verifyComplete();
 
     StepVerifier.create(

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
@@ -44,9 +44,9 @@ public class ClientLibraryBasedIntegrationTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ClientLibraryBasedIntegrationTest.class);
 
-  static final String INSERT_QUERY = "INSERT BOOKS (UUID, TITLE, AUTHOR, CATEGORY, FICTION, " +
-    "PUBLISHED, WORDS_PER_SENTENCE) VALUES (@uuid, 'A Sound of Thunder', 'Ray Bradbury', " +
-    "@category, TRUE, '1952-06-28', @wordCount)";
+  static final String INSERT_QUERY = "INSERT BOOKS (UUID, TITLE, AUTHOR, CATEGORY, FICTION, "
+      + "PUBLISHED, WORDS_PER_SENTENCE) VALUES (@uuid, 'A Sound of Thunder', 'Ray Bradbury', "
+      + "@category, TRUE, '1952-06-28', @wordCount)";
 
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(
@@ -71,7 +71,7 @@ public class ClientLibraryBasedIntegrationTest {
     SpannerClientLibraryConnection con =
         Mono.from(connectionFactory.create()).cast(SpannerClientLibraryConnection.class).block();
 
-   /* try {
+    try {
       Mono.from(con.createStatement("DROP TABLE BOOKS").execute()).block();
     } catch (Exception e) {
       LOGGER.info("The BOOKS table doesn't exist", e);
@@ -91,9 +91,7 @@ public class ClientLibraryBasedIntegrationTest {
                         + "  CATEGORY INT64 NOT NULL"
                         + ") PRIMARY KEY (UUID)")
                 .execute())
-        .block();*/
-
-
+        .block();
   }
 
   /**


### PR DESCRIPTION
Fixes #253 
Fixes #242.

Fixes #254, since I refactored Select/DML statements to inherit from the same `AbstractSpannerClientLibraryStatement` (happy to rename it more meaningfully to `ParameterBindingClientLibraryStatement`).

Other changes:
* Renamed some `DatabaseClientReactiveAdapter` state fields for readability: currentTransactionFuture -> txnContext, asyncTransactionLastStep -> lastStep.
* I changed the future-to-publisher conversion helpers to return void and to send data to a passed-in publisher sink because helper methods returning `ApiFuture` proved impossible to adapt for SELECT statements: `.then()` expects an ApiFuture, but all SELECT functionality returns `AsyncResultSet`. So there was a conflict between the type that can be converted to a Flux (`AsyncResultSet`) and the type that the client library transaction chaining requires (`ApiFuture`). Passing a sink into all of that conversion instead of creating it externally from a nicely packaged `ApiFuture` solves all of this. I renamed `convertFutureToMono` to `adaptFutureToMono` to reflect the change. This is all private helper methods, so not public API at all.

The lambda formatting is a grudging compromise between me and checkstyle. Suggestions on making it look better gleefully accepted.