### PR TITLE
Migrate V2 DDL execution to client library

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -78,16 +78,17 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   public ConnectionFactory create(ConnectionFactoryOptions connectionFactoryOptions) {
 
     SpannerConnectionConfiguration config = createConfiguration(connectionFactoryOptions);
-    if (this.client == null) {
-      // GrpcClient should only be instantiated if/when a SpannerConnectionFactory is needed.
-      this.client = new GrpcClient(config.getCredentials());
-    }
 
     if (connectionFactoryOptions.hasOption(Option.valueOf("client-implementation"))
         && connectionFactoryOptions.getValue(Option.valueOf("client-implementation"))
         .equals("client-library")) {
-      return new SpannerClientLibraryConnectionFactory(this.client, config);
+      return new SpannerClientLibraryConnectionFactory(config);
+
     } else {
+      if (this.client == null) {
+        // GrpcClient should only be instantiated if/when a SpannerConnectionFactory is needed.
+        this.client = new GrpcClient(config.getCredentials());
+      }
       return new SpannerConnectionFactory(this.client, config);
     }
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -16,11 +16,8 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.DatabaseAdminClient;
-import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
-import com.google.cloud.spanner.r2dbc.client.Client;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
 import io.r2dbc.spi.Batch;
@@ -47,13 +44,14 @@ public class SpannerClientLibraryConnection implements Connection {
 
   /**
    * Cloud Spanner implementation of R2DBC Connection SPI.
-   * @param client Cloud Spanner client library database client
+   * @param spanner Cloud Spanner spanner library database client
    * @param config driver configuration extracted from URL or passed directly to connection factory.
    */
-  public SpannerClientLibraryConnection(Spanner client, SpannerConnectionConfiguration config) {
+  public SpannerClientLibraryConnection(Spanner spanner, SpannerConnectionConfiguration config) {
 
     this.executorService = Executors.newFixedThreadPool(config.getThreadPoolSize());
-    this.clientLibraryAdapter = new DatabaseClientReactiveAdapter(client, this.executorService, config);
+    this.clientLibraryAdapter =
+        new DatabaseClientReactiveAdapter(spanner, this.executorService, config);
 
   }
 
@@ -78,8 +76,6 @@ public class SpannerClientLibraryConnection implements Connection {
     throw new UnsupportedOperationException();
   }
 
-  // TODO: test whether select statements interspersed with update statements need to be handled
-  // as part of async flow
   @Override
   public Statement createStatement(String query) {
     StatementType type = StatementParser.getStatementType(query);

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -38,31 +38,21 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory 
   private SpannerConnectionConfiguration config;
 
   private Spanner client;
-  private DatabaseClient databaseClient;
-  private DatabaseAdminClient databaseAdminClient;
-
-  // fall back to grpc for unsupported client library async functionality (DDL)
-  private Client grpcClient;
 
   /** TODO: add proper javadoc. */
   public SpannerClientLibraryConnectionFactory(
       Client grpcClient, SpannerConnectionConfiguration config) {
     this.config = config;
-    this.grpcClient = grpcClient;
 
     SpannerOptions options = SpannerOptions.newBuilder().build();
     // TODO: allow customizing project ID.
 
     this.client = options.getService();
-    this.databaseClient = this.client.getDatabaseClient(
-        DatabaseId.of(config.getProjectId(), config.getInstanceName(), config.getDatabaseName()));
-    this.databaseAdminClient = this.client.getDatabaseAdminClient();
   }
 
   @Override
   public Publisher<? extends Connection> create() {
-    return Mono.just(new SpannerClientLibraryConnection(
-        this.databaseClient, this.databaseAdminClient, this.grpcClient, this.config));
+    return Mono.just(new SpannerClientLibraryConnection(this.client, this.config));
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -16,13 +16,9 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.DatabaseAdminClient;
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
-import com.google.cloud.spanner.r2dbc.client.Client;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -37,22 +33,21 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory 
 
   private SpannerConnectionConfiguration config;
 
-  private Spanner client;
+  private Spanner spannerClient;
 
   /** TODO: add proper javadoc. */
-  public SpannerClientLibraryConnectionFactory(
-      Client grpcClient, SpannerConnectionConfiguration config) {
+  public SpannerClientLibraryConnectionFactory(SpannerConnectionConfiguration config) {
     this.config = config;
 
     SpannerOptions options = SpannerOptions.newBuilder().build();
     // TODO: allow customizing project ID.
 
-    this.client = options.getService();
+    this.spannerClient = options.getService();
   }
 
   @Override
   public Publisher<? extends Connection> create() {
-    return Mono.just(new SpannerClientLibraryConnection(this.client, this.config));
+    return Mono.just(new SpannerClientLibraryConnection(this.spannerClient, this.config));
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
@@ -19,7 +19,6 @@ package com.google.cloud.spanner.r2dbc.v2;
 import com.google.cloud.spanner.r2dbc.SpannerResult;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -33,6 +32,7 @@ public class SpannerClientLibraryDdlStatement implements Statement {
    * Creates a ready-to-run Cloud Spanner DDL statement.
    *
    * @param query query to execute; does not support placeholders
+   * @param clientLibraryAdapter client library implementation of core functionality
    */
   public SpannerClientLibraryDdlStatement(
       String query,
@@ -67,17 +67,8 @@ public class SpannerClientLibraryDdlStatement implements Statement {
   }
 
   @Override
-  public Publisher<? extends Result> execute() {
+  public Mono<? extends Result> execute() {
     return this.clientLibraryAdapter.runDdlStatement(this.query)
         .map(unusedVoid -> new SpannerResult(Flux.empty(), Mono.just(0)));
-
-    /*return this.grpcClient
-        .executeDdl(
-            this.config.getFullyQualifiedDatabaseName(),
-            Collections.singletonList(this.query),
-            this.config.getDdlOperationTimeout(),
-            this.config.getDdlOperationPollInterval())
-        .map(operation -> new SpannerResult(Flux.empty(), Mono.just(0)));*/
-
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
@@ -16,38 +16,29 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.SpannerResult;
-import com.google.cloud.spanner.r2dbc.client.Client;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
-import java.util.Collections;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class SpannerClientLibraryDdlStatement implements Statement {
 
-  private Client grpcClient;
-
   private String query;
 
-  private SpannerConnectionConfiguration config;
+  private DatabaseClientReactiveAdapter clientLibraryAdapter;
 
   /**
    * Creates a ready-to-run Cloud Spanner DDL statement.
    *
    * @param query query to execute; does not support placeholders
-   * @param grpcClient TEMPORARY, to be removed
-   * @param config spanner config containing operation timeouts etc.
    */
   public SpannerClientLibraryDdlStatement(
       String query,
-      Client grpcClient,
-      SpannerConnectionConfiguration config) {
-    this.grpcClient = grpcClient;
+      DatabaseClientReactiveAdapter clientLibraryAdapter) {
     this.query = query;
-    this.config = config;
+    this.clientLibraryAdapter = clientLibraryAdapter;
   }
 
   @Override
@@ -77,14 +68,16 @@ public class SpannerClientLibraryDdlStatement implements Statement {
 
   @Override
   public Publisher<? extends Result> execute() {
-    // There is no DDL async support, so fall back to gRPC.
+    return this.clientLibraryAdapter.runDdlStatement(this.query)
+        .map(unusedVoid -> new SpannerResult(Flux.empty(), Mono.just(0)));
 
-    return this.grpcClient
+    /*return this.grpcClient
         .executeDdl(
             this.config.getFullyQualifiedDatabaseName(),
             Collections.singletonList(this.query),
             this.config.getDdlOperationTimeout(),
             this.config.getDdlOperationPollInterval())
-        .map(operation -> new SpannerResult(Flux.empty(), Mono.just(0)));
+        .map(operation -> new SpannerResult(Flux.empty(), Mono.just(0)));*/
+
   }
 }


### PR DESCRIPTION
DDL execution now goes through the client library, which allowed `SpannerConnectionFactoryProvider` to finally remove the vestigial `GrpcClient` from V2.

Other changes:
* Folded `databaseClient`/`databaseAdminClient` into `DatabaseClientReactiveAdapter`, simplifying `SpannerClientLibraryConnection`, which no longer needs those or any configuration.
* Renamed `ClientLibraryBasedIntegrationTest` to `ClientLibraryBasedIT` for consistency, and to stop confusing failsafe, which we did not set up to pick up the former pattern.
* Renamed `DatabaseClientReactiveAdapter.runSelectStatement()` to `runSelectStatementAsFlux()` to avoid confusion between public and private overloaded methods. Also considered naming it `runSelectStatementInternal()` or `runSelectStatementWithCallback()`. Not sure whether the end result is any easier on the eyes tbh.