### PR TITLE
Test new tck framework

### DIFF
--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -20,6 +20,8 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DR
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_TWO_COLUMNS;
+import static io.r2dbc.spi.test.TestKit.TestStatement.SELECT_VALUE_TWO_COLUMNS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -37,13 +39,11 @@ import io.r2dbc.spi.Option;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.test.TestKit;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.core.PreparedStatementCallback;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -85,27 +84,9 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
     jdbcOperations = mock(JdbcOperations.class);
 
     doAnswer(invocation -> {
-      String query = invocation.getArgument(0);
-      executeDml(c -> c.createStatement(query.replace("INTO test ", "INTO test (value) ")
-          .replace("INTO test_two_column", "INTO test_two_column (col1,col2)")));
+      executeDml(c -> c.createStatement(invocation.getArgument(0)));
       return null;
     }).when(jdbcOperations).execute((String) any());
-
-    doAnswer(invocation -> {
-      String query = invocation.getArgument(0);
-
-      // The TCK uses java.sql JDBC classes that we have no implemented, but only in two cases
-      // that we can detect and substitute here.
-      if (query.equalsIgnoreCase("INSERT INTO clob_test VALUES (?)")) {
-        executeDml(c -> c.createStatement("INSERT INTO clob_test (value) VALUES (@val)")
-            .bind("val", "test-value"));
-      } else if (query.equalsIgnoreCase("INSERT INTO blob_test VALUES (?)")) {
-        executeDml(c -> c.createStatement("INSERT INTO blob_test (value) VALUES (@val)").bind("val",
-            StandardCharsets.UTF_8.encode("test-value").array()));
-      }
-
-      return null;
-    }).when(jdbcOperations).execute((String) any(), (PreparedStatementCallback) any());
 
     SpannerOptions options = SpannerOptions.newBuilder().build();
     Spanner spanner = options.getService();
@@ -119,7 +100,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
     createTableIfNeeded(id, "blob_test", " ( value BYTES(MAX) )  PRIMARY KEY (value)");
     createTableIfNeeded(id, "clob_test", " ( value BYTES(MAX) )  PRIMARY KEY (value)");
   }
-
 
   private static void createTableIfNeeded(DatabaseId id, String tableName, String definition) {
     Boolean tableExists = Mono.from(connectionFactory.create())
@@ -227,38 +207,16 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
      */
   }
 
-  // override to fix DDL for Spanner.
-  @Override
-  @Test
-  public void prepareStatement() {
-    Mono.from(getConnectionFactory().create())
-        .delayUntil(c -> c.beginTransaction())
-        .flatMapMany(connection -> {
-          Statement statement = connection.createStatement(
-              String.format("INSERT INTO test (value) VALUES(%s)", getPlaceholder(0)));
-
-          IntStream.range(0, 10)
-              .forEach(i -> statement.bind(getIdentifier(0), i).add());
-
-          return Flux.from(statement
-              .execute())
-              .concatWith(close(connection));
-        })
-        .as(StepVerifier::create)
-        .expectNextCount(10).as("values from insertions")
-        .verifyComplete();
-  }
-
   // override. column names are case-sensitive in Spanner.
   @Override
   @Test
   public void duplicateColumnNames() {
-    getJdbcOperations().execute("INSERT INTO test_two_column VALUES (100, 'hello')");
+    getJdbcOperations().execute(expand(INSERT_TWO_COLUMNS));
 
     Mono.from(getConnectionFactory().create())
         .flatMapMany(connection -> Flux.from(connection
 
-            .createStatement("SELECT col1 AS value, col2 AS VALUE FROM test_two_column")
+            .createStatement(expand(SELECT_VALUE_TWO_COLUMNS))
             .execute())
 
             .flatMap(result -> result
@@ -275,9 +233,8 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   // override. column names are case-sensitive in Spanner.
   @Override
   @Test
-  @Disabled // TODO: GH-252
   public void columnMetadata() {
-    getJdbcOperations().execute("INSERT INTO test_two_column VALUES (100, 'hello')");
+    getJdbcOperations().execute(expand(INSERT_TWO_COLUMNS));
 
     Mono.from(getConnectionFactory().create())
         .flatMapMany(connection -> Flux.from(connection
@@ -399,28 +356,28 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
      */
   }
 
-  // DML syntax needed to be fixed.
+  // Returns Long instead of Integer. Equivalent test in V1 did not need an override.
   @Override
   @Test
   public void transactionCommit() {
-    executeDml(c -> c.createStatement("INSERT INTO test (value) VALUES (100)"));
+    executeDml(c -> c.createStatement(expand(TestStatement.INSERT_VALUE100)));
 
     Mono.from(getConnectionFactory().create())
         .<Object>flatMapMany(connection -> Mono.from(connection.beginTransaction())
-            .<Object>thenMany(Flux.from(connection.createStatement("SELECT value FROM test")
-                .execute())
-                .flatMap(this::extractColumnsLong))
+            .<Object>thenMany(
+                Flux.from(connection.createStatement(expand(TestStatement.SELECT_VALUE)).execute())
+                    .flatMap(this::extractColumnsLong))
 
             // NOTE: this defer is a from() in the original. needs a follow up to resolve
             .concatWith(Flux.from(connection.createStatement(
-                String.format("INSERT INTO test (value) VALUES (%s)", getPlaceholder(0)))
+                String.format(expand(TestStatement.INSERT_VALUE_PLACEHOLDER, getPlaceholder(0))))
                 .bind(getIdentifier(0), 200)
                 .execute())
-                .flatMap(TestKit::extractRowsUpdated))
-            .concatWith(Flux.from(connection.createStatement("SELECT value FROM test")
+                .flatMap(this::extractRowsUpdated))
+            .concatWith(Flux.from(connection.createStatement(expand(TestStatement.SELECT_VALUE))
                 .execute())
                 .flatMap(this::extractColumnsLong))
-            .concatWith(Flux.from(connection.createStatement("SELECT value FROM test")
+            .concatWith(Flux.from(connection.createStatement(expand(TestStatement.SELECT_VALUE))
                 .execute())
                 .flatMap(this::extractColumnsLong))
             .concatWith(close(connection)))
@@ -449,25 +406,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
      */
   }
 
-  // DML syntax fix.
-  @Override
-  @Test
-  public void bindNull() {
-    Mono.from(getConnectionFactory().create())
-        .delayUntil(c -> c.beginTransaction())
-        .flatMapMany(connection -> Flux.from(connection
-
-            .createStatement(
-                String.format("INSERT INTO test (value) VALUES(%s)", getPlaceholder(0)))
-            .bindNull(getIdentifier(0), Integer.class).add()
-            .execute())
-
-            .concatWith(close(connection)))
-        .as(StepVerifier::create)
-        .expectNextCount(1).as("rows inserted")
-        .verifyComplete();
-  }
-
   @Override
   @Test
   @Disabled // TODO: GH-275
@@ -477,11 +415,11 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
             Flux.from(connection.setAutoCommit(false))
                 .thenMany(connection.beginTransaction())
                 // DML syntax fix adding column list
-                .thenMany(connection.createStatement(
-                    "INSERT INTO test (value) VALUES(200)").execute())
+                .thenMany(
+                    connection.createStatement(expand(TestStatement.INSERT_VALUE200)).execute())
                 .flatMap(Result::getRowsUpdated)
                 .thenMany(connection.setAutoCommit(true))
-                .thenMany(connection.createStatement("SELECT value FROM test").execute())
+                .thenMany(connection.createStatement(expand(TestStatement.SELECT_VALUE)).execute())
                 .flatMap(it -> it.map((row, metadata) -> row.get("value")))
                 .concatWith(close(connection))
         )
@@ -500,8 +438,8 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
         .flatMapMany(connection ->
             Flux.from(connection.setAutoCommit(false))
                 .thenMany(connection.beginTransaction())
-                .thenMany(connection.createStatement(
-                    "INSERT INTO test (value) VALUES(200)").execute())
+                .thenMany(
+                    connection.createStatement(expand(TestStatement.INSERT_VALUE200)).execute())
                 .flatMap(Result::getRowsUpdated)
                 .thenMany(connection.setAutoCommit(false))
                 .thenMany(connection.rollbackTransaction())
@@ -519,4 +457,8 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
 
   }
 
+  @Override
+  public String expand(TestStatement statement, Object... args) {
+    return SpannerTestKitStatements.expand(statement, args);
+  }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
@@ -20,12 +20,8 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DR
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
-import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_BLOB_VALUE_PLACEHOLDER;
-import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_CLOB_VALUE_PLACEHOLDER;
 import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_TWO_COLUMNS;
-import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE100;
 import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE200;
-import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE_PLACEHOLDER;
 import static io.r2dbc.spi.test.TestKit.TestStatement.SELECT_VALUE;
 import static io.r2dbc.spi.test.TestKit.TestStatement.SELECT_VALUE_TWO_COLUMNS;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,8 +44,6 @@ import io.r2dbc.spi.test.TestKit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -67,25 +61,6 @@ import reactor.test.StepVerifier;
  * Cloud Spanner R2DBC TCK test implementation.
  */
 public class SpannerTestKit implements TestKit<String> {
-
-  private static final Map<TestStatement, Function<Object[], String>> STATEMENTS = new HashMap<>();
-
-  static {
-    STATEMENTS.put(INSERT_VALUE100, args -> "INSERT INTO test (value) VALUES (100)");
-    STATEMENTS.put(INSERT_VALUE200, args -> "INSERT INTO test (value) VALUES (200)");
-    STATEMENTS.put(INSERT_TWO_COLUMNS,
-        args -> "INSERT INTO test_two_column (col1,col2) VALUES (100, 'hello')");
-    STATEMENTS.put(INSERT_BLOB_VALUE_PLACEHOLDER, args ->
-        String.format("INSERT INTO blob_test VALUES (?)", args));
-    STATEMENTS.put(INSERT_CLOB_VALUE_PLACEHOLDER, args ->
-        String.format("INSERT INTO clob_test VALUES (?)", args));
-    STATEMENTS.put(INSERT_VALUE_PLACEHOLDER,
-        args -> String.format("INSERT INTO test (value) VALUES (%s)", args));
-
-    // Spanner column names are case-sensitive
-    STATEMENTS.put(SELECT_VALUE_TWO_COLUMNS,
-        args -> "SELECT col1 AS value, col2 AS VALUE FROM test_two_column");
-  }
 
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(ConnectionFactoryOptions.builder()
@@ -411,11 +386,6 @@ public class SpannerTestKit implements TestKit<String> {
 
   @Override
   public String expand(TestStatement statement, Object... args) {
-
-    if (STATEMENTS.containsKey(statement)) {
-      return STATEMENTS.get(statement).apply(args);
-    }
-
-    return String.format(doGetSql(statement), args);
+    return SpannerTestKitStatements.expand(statement, args);
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKitStatements.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKitStatements.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.it;
+
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_BLOB_VALUE_PLACEHOLDER;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_CLOB_VALUE_PLACEHOLDER;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_TWO_COLUMNS;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE100;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE200;
+import static io.r2dbc.spi.test.TestKit.TestStatement.INSERT_VALUE_PLACEHOLDER;
+import static io.r2dbc.spi.test.TestKit.TestStatement.SELECT_VALUE_TWO_COLUMNS;
+
+import io.r2dbc.spi.test.TestKit.TestStatement;
+import java.util.HashMap;
+import java.util.Map;
+
+class SpannerTestKitStatements {
+
+  static final Map<TestStatement, String> STATEMENTS = new HashMap<>();
+
+  static {
+    STATEMENTS.put(INSERT_VALUE100,"INSERT INTO test (value) VALUES (100)");
+    STATEMENTS.put(INSERT_VALUE200, "INSERT INTO test (value) VALUES (200)");
+    STATEMENTS.put(INSERT_TWO_COLUMNS,
+        "INSERT INTO test_two_column (col1,col2) VALUES (100, 'hello')");
+    STATEMENTS.put(INSERT_BLOB_VALUE_PLACEHOLDER, "INSERT INTO blob_test VALUES (?)");
+    STATEMENTS.put(INSERT_CLOB_VALUE_PLACEHOLDER, "INSERT INTO clob_test VALUES (?)");
+    STATEMENTS.put(INSERT_VALUE_PLACEHOLDER,"INSERT INTO test (value) VALUES (%s)");
+
+    // Spanner column names are case-sensitive
+    STATEMENTS.put(SELECT_VALUE_TWO_COLUMNS,
+        "SELECT col1 AS value, col2 AS VALUE FROM test_two_column");
+  }
+
+  static String expand(TestStatement statement, Object... args) {
+    String sql = STATEMENTS.get(statement);
+    if (sql == null) {
+      sql = statement.getSql();
+    }
+
+    return String.format(sql, args);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
     <google-cloud-bom.version>10.0.0</google-cloud-bom.version>
 
-    <r2dbc.version>0.8.1.RELEASE</r2dbc.version>
+    <r2dbc.version>0.8.3.BUILD-SNAPSHOT</r2dbc.version>
     <reactor.version>Dysprosium-SR5</reactor.version>
 
     <mockito.version>3.3.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 
     <google-cloud-bom.version>10.0.0</google-cloud-bom.version>
 
-    <r2dbc.version>0.8.3.BUILD-SNAPSHOT</r2dbc.version>
-    <reactor.version>Dysprosium-SR5</reactor.version>
+    <r2dbc.version>0.8.3.RELEASE</r2dbc.version>
+    <reactor.version>Dysprosium-SR12</reactor.version>
 
     <mockito.version>3.3.0</mockito.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Remove TCK test overrides that were necessary due to DML syntax requiring column list in Spanner.

R2DBC SPI 0.8.3 containing the TCK changes was released. I also upgraded Reactor to the same version that's in SPI.

There are still two reasons for overrides:
1) Spanner returning `Long` even when `Integer` is requested -- work tracked in #276.
2) the driver breaking R2DBC spec by treating columns as case insensitive -- decision pending on #271.