### PR TITLE
Bind multiple statements

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -41,7 +41,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
 
   private com.google.cloud.spanner.Statement.Builder currentStatementBuilder;
 
-  private boolean incompleteBinding = false;
+  private boolean startedBinding = false;
 
   private List<com.google.cloud.spanner.Statement> statements;
 
@@ -67,7 +67,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
 
     this.statements.add(this.currentStatementBuilder.build());
     this.currentStatementBuilder = com.google.cloud.spanner.Statement.newBuilder(this.query);
-    this.incompleteBinding = false;
+    this.startedBinding = false;
 
     return this;
   }
@@ -75,9 +75,9 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
   @Override
   public Publisher<? extends Result> execute() {
     if (this.statements != null) {
-      if (this.incompleteBinding) {
+      if (this.startedBinding) {
         this.statements.add(this.currentStatementBuilder.build());
-        this.incompleteBinding = false;
+        this.startedBinding = false;
         this.currentStatementBuilder = null;
       }
       return executeMultiple(this.statements);
@@ -99,7 +99,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
   @Override
   public Statement bind(String name, Object value) {
     ClientLibraryBinder.bind(this.currentStatementBuilder, name, value);
-    this.incompleteBinding = true;
+    this.startedBinding = true;
     return this;
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -39,7 +39,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
 
   protected final DatabaseClientReactiveAdapter clientLibraryAdapter;
 
-  protected com.google.cloud.spanner.Statement.Builder currentStatementBuilder;
+  private com.google.cloud.spanner.Statement.Builder currentStatementBuilder;
 
   private boolean incompleteBinding = false;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -85,10 +85,10 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
     return executeSingle(this.currentStatementBuilder.build());
   }
 
-  public abstract Mono<SpannerClientLibraryResult> executeSingle(
+  protected abstract Mono<SpannerClientLibraryResult> executeSingle(
       com.google.cloud.spanner.Statement statement);
 
-  public abstract Flux<SpannerClientLibraryResult> executeMultiple(
+  protected abstract Flux<SpannerClientLibraryResult> executeMultiple(
       List<com.google.cloud.spanner.Statement> statements);
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -184,7 +184,8 @@ class DatabaseClientReactiveAdapter {
     return runBatchDmlInternal(ctx -> ctx.batchUpdateAsync(statements));
   }
 
-  private <T> Mono<T> runBatchDmlInternal(Function<TransactionContext, ApiFuture<T>> asyncOperation) {
+  private <T> Mono<T> runBatchDmlInternal(
+      Function<TransactionContext, ApiFuture<T>> asyncOperation) {
     return convertFutureToMono(() -> {
       if (this.isInTransaction()) {
 
@@ -194,8 +195,7 @@ class DatabaseClientReactiveAdapter {
         AsyncTransactionStep<? extends Object, T> updateStatementFuture =
             this.lastStep == null
                 ? this.txnContext.then(
-                (ctx, unusedVoid) -> asyncOperation.apply(ctx),
-                this.executorService)
+                    (ctx, unusedVoid) -> asyncOperation.apply(ctx), this.executorService)
                 : this.lastStep.then(
                     (ctx, unusedPreviousResult) -> asyncOperation.apply(ctx),
                     this.executorService);

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -175,8 +175,8 @@ class DatabaseClientReactiveAdapter {
 
   /**
    * Allows running DML statements in a batch.
-   * <p>
-   * If no transaction is active, a single-use transaction will be used.
+   *
+   * <p>If no transaction is active, a single-use transaction will be used.
    *
    * @return reactive pipeline for running the provided DML statements
    */

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -175,8 +175,8 @@ class DatabaseClientReactiveAdapter {
 
   /**
    * Allows running DML statements in a batch.
-   *
-   * <p>If no transaction is active, a single-use transaction will be used.
+   * <p>
+   * If no transaction is active, a single-use transaction will be used.
    *
    * @return reactive pipeline for running the provided DML statements
    */

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -17,11 +17,8 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement;
-import io.r2dbc.spi.Result;
 import java.util.List;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-import org.reactivestreams.Publisher;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -58,10 +55,9 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
     return this.clientLibraryAdapter
         .runBatchDml(statements)
         .flatMapMany(numRowsArray ->
-              Flux.fromStream(
-                  LongStream.of(numRowsArray).boxed()
-                      .map(numRows -> new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows))))
-              )
+              Flux.fromArray(ArrayUtils.toObject(numRowsArray))
+                  .map(numRows -> new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows))))
+
         );
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -58,7 +58,6 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
               Flux.fromArray(ArrayUtils.toObject(numRowsArray))
                   .map(numRows ->
                       new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows))))
-
         );
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -42,9 +42,9 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
   }
 
   @Override
-  public Publisher<? extends Result> execute() {
+  public Publisher<? extends Result> executeInternal() {
     return this.clientLibraryAdapter
-        .runDmlStatement(this.statementBuilder.build())
+        .runDmlStatement(this.currentStatementBuilder.build())
         .transform(numRowsUpdatedMono -> Mono.just(
             new SpannerClientLibraryResult(Flux.empty(), numRowsUpdatedMono.map(this::longToInt))));
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -48,7 +48,7 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
   @Override
   public Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
-        .runDmlStatement(this.currentStatementBuilder.build())
+        .runDmlStatement(statement)
         .transform(numRowsUpdatedMono -> Mono.just(
             new SpannerClientLibraryResult(Flux.empty(), numRowsUpdatedMono.map(this::longToInt))));
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -43,7 +43,7 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
   }
 
   @Override
-  public Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
+  protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
         .runDmlStatement(statement)
         .transform(numRowsUpdatedMono -> Mono.just(
@@ -51,12 +51,13 @@ public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibra
   }
 
   @Override
-  public Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
+  protected Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
     return this.clientLibraryAdapter
         .runBatchDml(statements)
         .flatMapMany(numRowsArray ->
               Flux.fromArray(ArrayUtils.toObject(numRowsArray))
-                  .map(numRows -> new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows))))
+                  .map(numRows ->
+                      new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows))))
 
         );
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -46,15 +46,15 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
   @Override
   public Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
-        .runSelectStatement(this.currentStatementBuilder.build())
+        .runSelectStatement(statement)
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single();
   }
 
   @Override
   public Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
-    return Flux.fromIterable(statements).flatMap(statement ->
+    return Flux.fromIterable(statements).flatMapSequential(statement ->
         this.clientLibraryAdapter
-        .runSelectStatement(this.currentStatementBuilder.build())
+        .runSelectStatement(statement)
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single());
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -41,9 +41,9 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
   }
 
   @Override
-  public Publisher<? extends Result> execute() {
+  public Publisher<? extends Result> executeInternal() {
     return this.clientLibraryAdapter
-        .runSelectStatement(this.statementBuilder.build())
+        .runSelectStatement(this.currentStatementBuilder.build())
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty())));
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -42,14 +42,14 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
   }
 
   @Override
-  public Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
+  protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
         .runSelectStatement(statement)
         .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single();
   }
 
   @Override
-  public Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
+  protected Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
     return Flux.fromIterable(statements).flatMapSequential(statement ->
         this.clientLibraryAdapter.runSelectStatement(statement)
             .transform(

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -50,9 +50,6 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
 
   @Override
   protected Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
-    return Flux.fromIterable(statements).flatMapSequential(statement ->
-        this.clientLibraryAdapter.runSelectStatement(statement)
-            .transform(
-                rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single());
+    return Flux.fromIterable(statements).flatMapSequential(statement -> executeSingle(statement));
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -17,9 +17,7 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement;
-import io.r2dbc.spi.Result;
 import java.util.List;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -53,8 +51,8 @@ public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryS
   @Override
   public Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
     return Flux.fromIterable(statements).flatMapSequential(statement ->
-        this.clientLibraryAdapter
-        .runSelectStatement(statement)
-        .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single());
+        this.clientLibraryAdapter.runSelectStatement(statement)
+            .transform(
+                rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single());
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -441,7 +441,7 @@ public class ClientLibraryBasedIT {
   }
 
   /* This test
-  1) exercises s a different internal code path than selectMultipleBoundParameterSetsNoTransaction()
+  1) exercises a different internal code path than selectMultipleBoundParameterSetsNoTransaction()
   2) omits the final add() for the last bound row.
   */
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -87,14 +87,14 @@ public class ClientLibraryBasedIT {
                       "CREATE TABLE BOOKS ("
                           + "  UUID STRING(36) NOT NULL,"
                           + "  TITLE STRING(256) NOT NULL,"
-                          + "  AUTHOR STRING(256) NOT NULL,"
+                          + "  AUTHOR STRING(256),"
                           + "  SYNOPSIS STRING(MAX),"
                           + "  EDITIONS ARRAY<STRING(MAX)>,"
-                          + "  FICTION BOOL NOT NULL,"
-                          + "  PUBLISHED DATE NOT NULL,"
-                          + "  WORDS_PER_SENTENCE FLOAT64 NOT NULL,"
-                          + "  CATEGORY INT64 NOT NULL,"
-                          + "  PRICE NUMERIC NOT NULL"
+                          + "  FICTION BOOL,"
+                          + "  PUBLISHED DATE,"
+                          + "  WORDS_PER_SENTENCE FLOAT64,"
+                          + "  CATEGORY INT64,"
+                          + "  PRICE NUMERIC"
                           + ") PRIMARY KEY (UUID)")
                   .execute())
           .block();
@@ -378,6 +378,153 @@ public class ClientLibraryBasedIT {
         Flux.from(conn.createStatement(listTables).bind("table", tableName).execute())
             .flatMap(this::getFirstNumber)
     ).expectNext(0L).as("Table not found after deletion").verifyComplete();
+  }
+
+  @Test
+  public void selectMultipleBoundParameterSetsNoTransaction() {
+
+    String uuid1 = "params-no-transaction-" + this.random.nextInt();
+    String uuid2 = "params-no-transaction-" + this.random.nextInt();
+    String uuid3 = "params-no-transaction-" + this.random.nextInt();
+
+    // set up 3 test rows
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(c -> Flux.concat(
+                Flux.from(c.createStatement(makeInsertQuery(uuid1, 100, 3)).execute())
+                    .flatMap(r -> r.getRowsUpdated()),
+                Flux.from(c.createStatement(makeInsertQuery(uuid2, 100, 5)).execute())
+                    .flatMap(r -> r.getRowsUpdated()),
+                Flux.from(c.createStatement(makeInsertQuery(uuid3, 100, 7)).execute())
+                    .flatMap(r -> r.getRowsUpdated())
+            ))
+
+    ).expectNext(1, 1, 1).verifyComplete();
+
+    StepVerifier.create(
+        Mono.from(connectionFactory.create()).flatMapMany(
+            conn -> Flux.from(
+                conn.createStatement("SELECT count(*) FROM BOOKS WHERE WORDS_PER_SENTENCE > @words")
+                    .bind("words", 8).add()
+                    .bind("words", 7).add()
+                    .bind("words", 5).add()
+                    .bind("words", 4).add()
+                    .bind("words", 0).add()
+                    .execute()
+            )
+            .flatMapSequential(rs -> rs.map((row, rmeta) -> row.get(1, Long.class))))
+    ).expectNext(0L, 0L, 1L, 2L, 3L).as("Row count matches bound variables").verifyComplete();
+
+  }
+
+  /* This test
+  1) exercises s a different internal code path than selectMultipleBoundParameterSetsNoTransaction()
+  2) omits the final add() for the last bound row.
+  */
+  @Test
+  public void selectMultipleBoundParameterSetsInTransaction() {
+
+    String uuid1 = "params-no-transaction-" + this.random.nextInt();
+    String uuid2 = "params-no-transaction-" + this.random.nextInt();
+    String uuid3 = "params-no-transaction-" + this.random.nextInt();
+
+    // set up 3 test rows
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(c -> Flux.concat(
+                Flux.from(c.createStatement(makeInsertQuery(uuid1, 100, 3)).execute())
+                    .flatMap(r -> r.getRowsUpdated()),
+                Flux.from(c.createStatement(makeInsertQuery(uuid2, 100, 5)).execute())
+                    .flatMap(r -> r.getRowsUpdated()),
+                Flux.from(c.createStatement(makeInsertQuery(uuid3, 100, 7)).execute())
+                    .flatMap(r -> r.getRowsUpdated())
+            ))
+
+    ).expectNext(1, 1, 1).verifyComplete();
+
+    StepVerifier.create(
+        Mono.from(connectionFactory.create()).flatMapMany(
+            conn -> Flux.concat(
+                conn.beginTransaction(),
+                Flux.from(
+                  conn.createStatement("SELECT count(*) FROM BOOKS WHERE WORDS_PER_SENTENCE > @words")
+                      .bind("words", 8).add()
+                      .bind("words", 7).add()
+                      .bind("words", 5).add()
+                      .bind("words", 4).add()
+                      .bind("words", 0) // Final .add() missing intentionally
+                    .execute()).flatMapSequential(rs -> rs.map((row, rmeta) -> row.get(1, Long.class))),
+                conn.commitTransaction())
+            )
+
+    ).expectNext(0L, 0L, 1L, 2L, 3L).as("Row count matches bound variables").verifyComplete();
+
+  }
+
+  @Test
+  public void insertMultipleBoundParameterSetsNoTransaction() {
+
+    String uuid1 = "params-no-transaction-" + this.random.nextInt();
+    String uuid2 = "params-no-transaction-" + this.random.nextInt();
+    String uuid3 = "params-no-transaction-" + this.random.nextInt();
+
+    String statement =
+        "INSERT BOOKS (UUID, TITLE) VALUES (@uuid, @title)";
+    StepVerifier.create(
+        Mono.from(connectionFactory.create()).flatMapMany(
+            conn -> Flux.from(
+                conn.createStatement(statement)
+                    .bind("uuid", uuid1).bind("title", "A").add()
+                    .bind("uuid", uuid2).bind("title", "B").add()
+                    .bind("uuid", uuid3).bind("title", "C").add()
+                    .execute()
+            )
+                .flatMap(rs -> rs.getRowsUpdated()))
+    ).expectNext(1, 1, 1).as("Row insert count matches").verifyComplete();
+
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(c -> c.createStatement(
+                "SELECT UUID, TITLE FROM BOOKS ORDER BY TITLE")
+                .execute()
+            ).flatMap(rs -> rs.map((row, rmeta) -> row.get("TITLE", String.class) + row.get("UUID", String.class))))
+        .expectNext("A" + uuid1, "B" + uuid2, "C" + uuid3)
+        .as("Found previously inserted rows")
+        .verifyComplete();
+  }
+
+  @Test
+  public void insertMultipleBoundParameterSetsInTransaction() {
+
+    String uuid1 = "params-no-transaction-" + this.random.nextInt();
+    String uuid2 = "params-no-transaction-" + this.random.nextInt();
+    String uuid3 = "params-no-transaction-" + this.random.nextInt();
+
+    String statement =
+        "INSERT BOOKS (UUID, TITLE) VALUES (@uuid, @title)";
+    StepVerifier.create(
+        Mono.from(connectionFactory.create()).flatMapMany(
+            conn -> Flux.concat(
+                conn.beginTransaction(),
+                Flux.from(conn.createStatement(statement)
+                    .bind("uuid", uuid1).bind("title", "A").add()
+                    .bind("uuid", uuid2).bind("title", "B").add()
+                    .bind("uuid", uuid3).bind("title", "C").add()
+                    .execute()).flatMap(rs -> rs.getRowsUpdated()),
+                conn.commitTransaction()
+            )
+        )
+    ).expectNext(1, 1, 1).as("Row insert count matches").verifyComplete();
+
+    StepVerifier.create(
+        Mono.from(connectionFactory.create())
+            .flatMapMany(c -> c.createStatement(
+                "SELECT UUID, TITLE FROM BOOKS ORDER BY TITLE")
+                .execute()
+            ).flatMap(rs -> rs.map((row, rmeta) -> row.get("TITLE", String.class) + row.get("UUID", String.class))))
+        .expectNext("A" + uuid1, "B" + uuid2, "C" + uuid3)
+        .as("Found previously inserted rows")
+        .verifyComplete();
   }
 
   private Publisher<Long> getFirstNumber(Result result) {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -230,7 +230,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   // override to fix DDL for Spanner.
   @Override
   @Test
-  @Disabled // TODO: GH-273
   public void prepareStatement() {
     Mono.from(getConnectionFactory().create())
         .delayUntil(c -> c.beginTransaction())
@@ -453,7 +452,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   // DML syntax fix.
   @Override
   @Test
-  @Disabled // TODO: GH-273
   public void bindNull() {
     Mono.from(getConnectionFactory().create())
         .delayUntil(c -> c.beginTransaction())

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -1,0 +1,11 @@
+package com.google.cloud.spanner.r2dbc.v2;
+
+import org.junit.jupiter.api.Test;
+
+public class AbstractSpannerClientLibraryStatementTest {
+
+	@Test
+	public void incompleteBindingFalseWhenNoParametersNeeded() {
+
+	}
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -1,11 +1,218 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spanner.r2dbc.v2;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Value;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 public class AbstractSpannerClientLibraryStatementTest {
 
-	@Test
-	public void incompleteBindingFalseWhenNoParametersNeeded() {
+  DatabaseClientReactiveAdapter mockAdapter;
 
-	}
+  /** Mocks DatabaseClientReactiveAdapter to return hard-coded results for DML running methods. */
+  @BeforeEach
+  public void setUpAdapterResponse() {
+    this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+    when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(19L));
+
+    when(this.mockAdapter.runBatchDml(anyList())).thenReturn(Mono.just(new long[] {7L, 11L, 13L}));
+  }
+
+  @Test
+  public void noParametersSendsSingleStatement() {
+    String query = "SELECT * FROM tbl";
+    FakeStatement statement = new FakeStatement(this.mockAdapter, query);
+
+    StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
+        .expectNext(19)
+        .verifyComplete();
+
+    ArgumentCaptor<Statement> capturedStatement = ArgumentCaptor.forClass(Statement.class);
+    verify(this.mockAdapter).runDmlStatement(capturedStatement.capture());
+    assertThat(capturedStatement.getValue().getSql()).isEqualTo(query);
+    assertThat(capturedStatement.getValue().getParameters()).isEmpty();
+    verifyNoMoreInteractions(this.mockAdapter);
+  }
+
+  @Test
+  public void singleSetOfParametersWithNoAddSendsOneStatement() {
+    String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
+    FakeStatement statement = new FakeStatement(this.mockAdapter, query);
+
+    statement.bind("one", "111");
+    statement.bind("two", "222");
+    statement.bind("three", "333");
+
+    StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
+        .expectNext(19)
+        .verifyComplete();
+
+    ArgumentCaptor<Statement> capturedStatement = ArgumentCaptor.forClass(Statement.class);
+    verify(this.mockAdapter).runDmlStatement(capturedStatement.capture());
+    assertThat(capturedStatement.getValue().getSql()).isEqualTo(query);
+    assertThat(capturedStatement.getValue().getParameters())
+        .hasSize(3)
+        .containsEntry("one", Value.string("111"))
+        .containsEntry("two", Value.string("222"))
+        .containsEntry("three", Value.string("333"));
+    verifyNoMoreInteractions(this.mockAdapter);
+  }
+
+  @Test
+  public void singleSetOfParametersWithAddTriggersBatchWithOneStatement() {
+    String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
+    FakeStatement statement = new FakeStatement(this.mockAdapter, query);
+
+    statement.bind("one", "111");
+    statement.bind("two", "222");
+    statement.bind("three", "333");
+    statement.add();
+
+    StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
+        .expectNext(7, 11, 13)
+        .verifyComplete();
+
+    ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);
+    verify(this.mockAdapter).runBatchDml(params.capture());
+    assertThat(params.getValue()).hasSize(1);
+    assertThat(params.getValue().get(0).getSql()).isEqualTo(query);
+    assertThat(params.getValue().get(0).getParameters())
+        .hasSize(3)
+        .containsEntry("one", Value.string("111"))
+        .containsEntry("two", Value.string("222"))
+        .containsEntry("three", Value.string("333"));
+
+    verifyNoMoreInteractions(this.mockAdapter);
+  }
+
+  @Test
+  public void twoParameterSetsWithNoTrailingAddSendsTwoStatements() {
+    String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
+    FakeStatement statement = new FakeStatement(this.mockAdapter, query);
+
+    statement.bind("one", "A111");
+    statement.bind("two", "A222");
+    statement.bind("three", "A333");
+    statement.add();
+    statement.bind("one", "B111");
+    statement.bind("two", "B222");
+    statement.bind("three", "B333");
+
+    StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
+        .expectNext(7, 11, 13)
+        .verifyComplete();
+
+    ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);
+
+    verify(this.mockAdapter).runBatchDml(params.capture());
+    assertThat(params.getValue()).hasSize(2);
+    assertThat(params.getValue().get(0).getParameters()).hasSize(3);
+    assertThat(params.getValue().get(0).getParameters())
+        .containsEntry("one", Value.string("A111"))
+        .containsEntry("two", Value.string("A222"))
+        .containsEntry("three", Value.string("A333"));
+    assertThat(params.getValue().get(1).getParameters())
+        .containsEntry("one", Value.string("B111"))
+        .containsEntry("two", Value.string("B222"))
+        .containsEntry("three", Value.string("B333"));
+
+    verifyNoMoreInteractions(this.mockAdapter);
+  }
+
+  @Test
+  public void twoParameterSetsWithTrailingAddSendsTwoStatements() {
+    String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
+    FakeStatement statement = new FakeStatement(this.mockAdapter, query);
+
+    statement.bind("one", "A111");
+    statement.bind("two", "A222");
+    statement.bind("three", "A333");
+    statement.add();
+    statement.bind("one", "B111");
+    statement.bind("two", "B222");
+    statement.bind("three", "B333");
+    statement.add();
+
+    StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
+        .expectNext(7, 11, 13)
+        .verifyComplete();
+
+    ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);
+
+    verify(this.mockAdapter).runBatchDml(params.capture());
+    assertThat(params.getValue()).hasSize(2);
+    assertThat(params.getValue().get(0).getParameters()).hasSize(3);
+    assertThat(params.getValue().get(0).getParameters())
+        .containsEntry("one", Value.string("A111"))
+        .containsEntry("two", Value.string("A222"))
+        .containsEntry("three", Value.string("A333"));
+    assertThat(params.getValue().get(1).getParameters())
+        .containsEntry("one", Value.string("B111"))
+        .containsEntry("two", Value.string("B222"))
+        .containsEntry("three", Value.string("B333"));
+
+    verifyNoMoreInteractions(this.mockAdapter);
+  }
+
+  /* Exercises the mock `DatabaseClientReactiveAdapter`; return values don't matter */
+  static class FakeStatement extends AbstractSpannerClientLibraryStatement {
+
+    public FakeStatement(DatabaseClientReactiveAdapter adapter, String query) {
+      super(adapter, query);
+    }
+
+    @Override
+    public Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
+      return this.clientLibraryAdapter
+          .runDmlStatement(statement)
+          .map(
+              numRows ->
+                  new SpannerClientLibraryResult(Flux.empty(), Mono.just(numRows.intValue())));
+    }
+
+    @Override
+    public Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
+      return this.clientLibraryAdapter
+          .runBatchDml(statements)
+          .flatMapMany(
+              rowCountArray ->
+                  Flux.fromStream(
+                      LongStream.of(rowCountArray)
+                          .boxed()
+                          .map(
+                              rowCount ->
+                                  new SpannerClientLibraryResult(
+                                      Flux.empty(), Mono.just(rowCount.intValue())))));
+    }
+  }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class SpannerClientLibraryDmlStatementTest {
+
+  DatabaseClientReactiveAdapter mockAdapter;
+
+  @BeforeEach
+  public void setUpAdapterResponse() {
+    this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+  }
+
+  @Test
+  public void executeSingleNoRowsUpdated() {
+    when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(0L));
+
+    SpannerClientLibraryDmlStatement dmlStatement =
+        new SpannerClientLibraryDmlStatement(this.mockAdapter, "irrelevant sql");
+
+    StepVerifier.create(
+            Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated()))
+        .expectNext(0)
+        .verifyComplete();
+  }
+
+  @Test
+  public void executeMultiple() {
+    when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(0L));
+
+    SpannerClientLibraryDmlStatement dmlStatement =
+        new SpannerClientLibraryDmlStatement(this.mockAdapter, "irrelevant sql");
+
+    StepVerifier.create(
+            Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated()))
+        .expectNext(0)
+        .verifyComplete();
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+public class SpannerClientLibraryStatementTest {
+
+  DatabaseClientReactiveAdapter mockAdapter;
+
+  static Struct SINGLE_COLUMN_STRUCT1 = Struct.newBuilder().add(Value.string("resultA")).build();
+  static Struct SINGLE_COLUMN_STRUCT2 = Struct.newBuilder().add(Value.string("resultB")).build();
+
+  @BeforeEach
+  public void setUpAdapterResponse() {
+    this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+  }
+
+  @Test
+  public void executeSingleNoRowsUpdated() {
+    when(this.mockAdapter.runSelectStatement(any(Statement.class)))
+        .thenReturn(Flux.just(new SpannerClientLibraryRow(SINGLE_COLUMN_STRUCT1)));
+
+    SpannerClientLibraryStatement statement =
+        new SpannerClientLibraryStatement(this.mockAdapter, "SELECT whatever FROM unused");
+
+    StepVerifier.create(
+        Flux.from(statement.execute()).flatMap(result -> result.getRowsUpdated()))
+        // SELECT statements never have updated row counts.
+        .verifyComplete();
+
+    StepVerifier.create(
+        Flux.from(statement.execute()).flatMap(
+            result -> result.map((r, rm) -> r.get(1, String.class))))
+        .expectNext("resultA")
+        .verifyComplete();
+  }
+
+  @Test
+  public void executeMultipleReturnsExpectedValuesAndCallsAdapterForEachParameterizedSelect() {
+
+    String query = "SELECT * from table WHERE column=%col1";
+    Statement expectedSpannerStatement1 = Statement.newBuilder(query)
+        .bind("col1").to("val1").build();
+    Statement expectedSpannerStatement2 = Statement.newBuilder(query)
+        .bind("col1").to("val2").build();
+
+    when(this.mockAdapter.runSelectStatement(eq(expectedSpannerStatement1)))
+        .thenReturn(Flux.just(new SpannerClientLibraryRow(SINGLE_COLUMN_STRUCT1)));
+    when(this.mockAdapter.runSelectStatement(eq(expectedSpannerStatement2)))
+        .thenReturn(Flux.just(new SpannerClientLibraryRow(SINGLE_COLUMN_STRUCT2)));
+
+    io.r2dbc.spi.Statement statement =
+        new SpannerClientLibraryStatement(this.mockAdapter, query)
+        .bind("col1", "val1").add()
+        .bind("col1", "val2");
+
+    StepVerifier.create(
+        Flux.from(statement.execute()).flatMapSequential(
+            result -> result.map((r, rm) -> r.get(1, String.class))))
+        .expectNext("resultA", "resultB")
+        .verifyComplete();
+
+    verify(this.mockAdapter).runSelectStatement(eq(expectedSpannerStatement1));
+    verify(this.mockAdapter).runSelectStatement(eq(expectedSpannerStatement2));
+    verifyNoMoreInteractions(this.mockAdapter);
+
+  }
+}


### PR DESCRIPTION
This PR covers the `Statement.bind().bind().add()` flow for both SELECT and DML.

Other changes:
* `AbstractSpannerClientLibraryStatement`
  * Reduced visibility of most state to private.
  * Implemented `execute` to complete the final row if necessary, and delegate actual query execution to abstract templated methods  `executeSingle()` and `executeMultiple()`.
* Added `runBatchDml()` method delegating to the client library's `TransactionContext.batchUpdateAsync()`.
   * Refactored most of `runDmlStatement()` into a helper method, to be reusable by `runBatchDml().
* Re-enabled two TCK tests that needed the multi-bind functionality.
* Added many tests.