### PR TITLE
Customize project ID, user-agent string from configuration

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -17,11 +17,14 @@
 package com.google.cloud.spanner.r2dbc;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -36,6 +39,13 @@ public class SpannerConnectionConfiguration {
   private static final String DB_NAME_VALIDATE_PATTERN =
       "projects\\/[\\w\\-]+\\/instances\\/[\\w\\-]+\\/databases\\/[\\w\\-]+$";
 
+  private static final String USER_AGENT_LIBRARY_NAME = "cloud-spanner-r2dbc";
+
+  private static final String PACKAGE_VERSION =
+      SpannerConnectionConfiguration.class.getPackage().getImplementationVersion();
+
+  public static final String USER_AGENT_KEY = "User-Agent";
+
   // TODO: check how to handle full URL (it gets parsed by SPI, we only get pieces)
   private final String fullyQualifiedDbName;
 
@@ -45,7 +55,7 @@ public class SpannerConnectionConfiguration {
 
   private String databaseName;
 
-  private final GoogleCredentials credentials;
+  private final OAuth2Credentials credentials;
 
   private int partialResultSetFetchSize;
 
@@ -58,7 +68,7 @@ public class SpannerConnectionConfiguration {
   /**
    * Constructor which initializes the configuration from an Cloud Spanner R2DBC url.
    */
-  private SpannerConnectionConfiguration(String url, GoogleCredentials credentials) {
+  private SpannerConnectionConfiguration(String url, OAuth2Credentials credentials) {
     String databaseString =
         ConnectionFactoryOptions.parse(url).getValue(ConnectionFactoryOptions.DATABASE);
 
@@ -86,7 +96,7 @@ public class SpannerConnectionConfiguration {
       String projectId,
       String instanceName,
       String databaseName,
-      GoogleCredentials credentials) {
+      OAuth2Credentials credentials) {
 
     Assert.requireNonNull(projectId, "projectId must not be null");
     Assert.requireNonNull(instanceName, "instanceName must not be null");
@@ -121,7 +131,7 @@ public class SpannerConnectionConfiguration {
     return this.fullyQualifiedDbName;
   }
 
-  public GoogleCredentials getCredentials() {
+  public OAuth2Credentials getCredentials() {
     return this.credentials;
   }
 
@@ -167,6 +177,32 @@ public class SpannerConnectionConfiguration {
             this.ddlOperationPollInterval);
   }
 
+  /**
+   * Converts current custom configuration object into client library {@link SpannerOptions}.
+   *
+   * <p>Supports customizable project ID, credentials and UserAgent header.
+   *
+   * @return configured spanner options.
+   */
+  public SpannerOptions buildSpannerOptions() {
+    SpannerOptions.Builder optionsBuilder = SpannerOptions.newBuilder();
+
+    if (this.projectId != null) {
+      optionsBuilder.setProjectId(this.projectId);
+    }
+
+    if (this.credentials != null) {
+      optionsBuilder.setCredentials(this.credentials);
+    }
+
+    optionsBuilder.setHeaderProvider(() ->
+        Collections.singletonMap(USER_AGENT_KEY, USER_AGENT_LIBRARY_NAME + "/" + PACKAGE_VERSION));
+
+    // TODO (GH-200): allow customizing emulator with optionsBuilder.setEmulatorHost()
+
+    return optionsBuilder.build();
+  }
+
   public static class Builder {
 
     private String url;
@@ -177,7 +213,7 @@ public class SpannerConnectionConfiguration {
 
     private String databaseName;
 
-    private GoogleCredentials credentials;
+    private OAuth2Credentials credentials;
 
     private int partialResultSetFetchSize = 1;
 
@@ -207,7 +243,7 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
-    public Builder setCredentials(GoogleCredentials credentials) {
+    public Builder setCredentials(OAuth2Credentials credentials) {
       this.credentials = credentials;
       return this;
     }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -44,7 +44,7 @@ public class SpannerConnectionConfiguration {
   private static final String PACKAGE_VERSION =
       SpannerConnectionConfiguration.class.getPackage().getImplementationVersion();
 
-  public static final String USER_AGENT_KEY = "User-Agent";
+  private static final String USER_AGENT_KEY = "User-Agent";
 
   // TODO: check how to handle full URL (it gets parsed by SPI, we only get pieces)
   private final String fullyQualifiedDbName;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc.client;
 
-import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.spanner.r2dbc.StatementExecutionContext;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import com.google.cloud.spanner.r2dbc.util.ObservableReactiveUtil;
@@ -99,7 +99,7 @@ public class GrpcClient implements Client {
    *
    * @param credentials the Google Cloud Platform credentials used to authenticate with Spanner.
    */
-  public GrpcClient(GoogleCredentials credentials) {
+  public GrpcClient(OAuth2Credentials credentials) {
     // Create blocking and async stubs using the channel
     CallCredentials callCredentials = MoreCallCredentials.from(credentials);
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -17,8 +17,8 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Spanner;
-import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -35,14 +35,11 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory 
 
   private Spanner spannerClient;
 
-  /** TODO: add proper javadoc. */
+  /** R2DBC ConnectionFactory based on the Cloud Spanner Client Library. */
   public SpannerClientLibraryConnectionFactory(SpannerConnectionConfiguration config) {
-    this.config = config;
+    this.config = Assert.requireNonNull(config, "Spanner configuration must not be null");
 
-    SpannerOptions options = SpannerOptions.newBuilder().build();
-    // TODO: allow customizing project ID.
-
-    this.spannerClient = options.getService();
+    this.spannerClient = config.buildSpannerOptions().getService();
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class SpannerClientLibraryConnectionFactoryTest {
+
+  SpannerConnectionConfiguration.Builder configBuilder =
+      new SpannerConnectionConfiguration.Builder()
+        .setProjectId("test-project")
+        .setInstanceName("test-instance")
+        .setDatabaseName("test-database")
+        .setCredentials(NoCredentials.getInstance());
+
+  @Test
+  public void testProjectId() {
+
+    SpannerConnectionConfiguration config = this.configBuilder
+        .setProjectId("custom-project")
+        .build();
+
+    SpannerOptions options = config.buildSpannerOptions();
+    assertThat(options.getProjectId()).isEqualTo("custom-project");
+  }
+
+  @Test
+  public void testUserAgentString() {
+
+    SpannerConnectionConfiguration config = this.configBuilder.build();
+
+    SpannerOptions options = config.buildSpannerOptions();
+
+    // The version suffix is not available until code is packaged as a JAR.
+    assertThat(options.getUserAgent()).startsWith("cloud-spanner-r2dbc/");
+  }
+}


### PR DESCRIPTION
`DatabaseClientReactiveAdapter` was already passing the configured project ID when creating `SpannerClient`. The project ID set in `SpannerOptions` is technically unused, but it seems worth explicitly setting it to the same value, so we don't have to wonder what value it is.

This PR also, since it's in the same configuration code:
* reintroduces User-Agent string for V2 (it was in a gRPC-specific implementation class in V1).
* propagates credentials. This required a small refactoring -- previously the code assumed GoogleCredentials, which precluded testing with NoCredentials.


Fixes #257.