### PR TITLE
Upgrade client library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <google-cloud-bom.version>10.0.0</google-cloud-bom.version>
+    <google-cloud-bom.version>13.1.0</google-cloud-bom.version>
 
     <r2dbc.version>0.8.1.RELEASE</r2dbc.version>
     <reactor.version>Dysprosium-SR5</reactor.version>
@@ -98,12 +98,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- override to snapshot until Connection API released -->
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-spanner</artifactId>
-        <version>1.59.0</version>
-      </dependency>
 
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Upgraded `libraries-bom` to the latest.
Spanner client library override is no longer needed, since the client library released async API, and the BOM had time to update.

