### PR TITLE
V2 extended transactions

### DIFF
--- a/checkstyle/java.header
+++ b/checkstyle/java.header
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 2019-20\d\d Google LLC$
+^ \* Copyright 20\d\d-20\d\d Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/cloud-spanner-r2dbc/README_v2.adoc
+++ b/cloud-spanner-r2dbc/README_v2.adoc
@@ -1,0 +1,49 @@
+# Cloud Spanner R2DBC Driver V2 (Client Library-based)
+
+The original version of Cloud Spanner R2DBC driver was based on direct communication to Cloud Spanner gRPC endpoints.
+V2 is built on top of the Cloud Spanner client library, allowing for consistent behavior between JDBC and R2DBC drivers.
+
+To activate V2, provide an option named `client-implementation` with the value of `client-library`, as in the example below.
+```java
+ConnectionFactories.get(
+          ConnectionFactoryOptions.builder()
+              ...
+              .option(Option.valueOf("client-implementation"), "client-library")
+              .build());
+```
+
+## Transactions
+
+### Read-Write Transactions
+Read-write transactions are supported natively through R2DBC SPI.
+
+```java
+Mono.from(connectionFactory.create())
+            .flatMapMany(c -> Flux.concat(
+                c.beginTransaction(),
+                ...
+                c.commitTransaction(),
+                c.close()))
+```
+
+### Read-Only Transactions
+Read-only transactions, including stale transactions, can be used by downcasting the `Connection` object to `SpannerClientLibraryConnection` and calling `beginReadonlyTransaction()` on it.
+Invoking `beginReadonlyTransaction()` without parameters will begin a new strongly consistent readonly transaction.
+To customize staleness, pass in a `TimestampBound` parameter.
+```java
+Mono.from(connectionFactory.create())
+            .flatMapMany(c ->
+                Flux.concat(
+                          conn.beginReadonlyTransaction(TimestampBound.ofExactStaleness(1, TimeUnit.SECONDS)),
+                            ...
+                          conn.commitTransaction(),
+                    )
+```
+NOTE: Readonly transactions must be closed by calling `commit()` before starting a new read-write or a read-only transaction.
+
+### Partitioned DML transactions
+Partitioned DML transactions are not supported at this time.
+
+### Nesting transactions
+Cloud Spanner does not support nested transactions, so each transaction must be either committed or rolled back.
+For readonly transactions, either committing or rolling back will result in closing of the readonly transaction.

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -21,21 +21,15 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
-import com.google.cloud.spanner.AsyncTransactionManager;
-import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
-import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.ReadContext;
-import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
-import com.google.spanner.v1.TransactionOptions;
-import com.google.spanner.v1.TransactionOptions.ReadWrite;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -67,15 +61,7 @@ class DatabaseClientReactiveAdapter {
 
   private final ExecutorService executorService;
 
-  // transaction context
-
-  private AsyncTransactionManager transactionManager;
-
-  private TransactionContextFuture txnContextFuture;
-
-  private ReadOnlyTransaction readOnlyTransaction;
-
-  private AsyncTransactionStep<?, ? extends Object> lastStep;
+  private final DatabaseClientTransactionManager txnManager;
 
   /**
    * Instantiates the adapter with given client library {@code DatabaseClient} and executor.
@@ -93,12 +79,7 @@ class DatabaseClientReactiveAdapter {
     this.dbAdminClient = spannerClient.getDatabaseAdminClient();
     this.executorService = executorService;
     this.config = config;
-  }
-
-  private boolean isInReadWriteTransaction() {
-    // TODO: do we need to close a read-only transaction?
-
-    return this.txnContextFuture != null;
+    this.txnManager = new DatabaseClientTransactionManager(this.dbClient, this.executorService);
   }
 
   /**
@@ -107,23 +88,22 @@ class DatabaseClientReactiveAdapter {
    * @return reactive pipeline for starting a transaction
    */
   public Mono<Void> beginTransaction() {
-    return convertFutureToMono(() -> {
-      LOGGER.debug("begin readwrite transaction");
-      this.transactionManager = this.dbClient.transactionManagerAsync();
-      this.txnContextFuture = this.transactionManager.beginAsync();
-      return this.txnContextFuture;
-    }).then();
+    return convertFutureToMono(() -> this.txnManager.beginTransaction()).then();
   }
 
+  /**
+   * Allows starting a Cloud Spanner readonly transaction with custom staleness.
+   *
+   * @return reactive pipeline for starting a transaction
+   */
   public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
 
-    // TODO: what if another transaction is in progress?
-    return Mono.defer(
-        () -> {
-            System.out.println("********* READONLY TRANSACTION detected");
-            this.readOnlyTransaction = this.dbClient.readOnlyTransaction(timestampBound);
-            return Mono.empty();
-        });
+    return Mono.defer(() -> {
+      this.txnManager.beginReadonlyTransaction(timestampBound);
+      // TODO: it would be good for client library to signal when a session is ready for this
+      // transaction, so a meaningful mono is returned.
+      return Mono.empty();
+    });
   }
 
   /**
@@ -133,38 +113,9 @@ class DatabaseClientReactiveAdapter {
    */
   public Publisher<Void> commitTransaction() {
 
-    return Mono.defer(() -> {
-      if (isInReadWriteTransaction()) {
-        return convertFutureToMono(() -> {
-          LOGGER.debug("commit transaction");
-
-          if (this.lastStep == null) {
-            // TODO: replace by a better non-retryable;
-            //  consider not throwing at all and no-oping with warning.
-            throw new RuntimeException("Nothing was executed in this transaction");
-          }
-          return this.lastStep.commitAsync();
-          });
-      } else if (this.readOnlyTransaction != null) {
-        // TODO: does transaction need to be closed to release it back to the pool?
-        this.readOnlyTransaction = null;
-        return Mono.empty();
-      } else {
-        // TODO: log warning that commit was called without begin? or check sPI for expected behavior
-        return Mono.empty();
-      }
-
-    }).doOnTerminate(this::clearTransactionManager).then();
-  }
-
-  private void clearTransactionManager() {
-    LOGGER.debug("close transaction manager");
-    this.txnContextFuture = null;
-    this.lastStep = null;
-    if (this.transactionManager != null) {
-      this.transactionManager.close();
-      this.transactionManager = null;
-    }
+    return convertFutureToMono(() -> this.txnManager.commitTransaction())
+        .doOnTerminate(this.txnManager::clearTransactionManager)
+        .then();
   }
 
   /**
@@ -173,17 +124,8 @@ class DatabaseClientReactiveAdapter {
    * @return reactive pipeline for rolling back a transaction
    */
   public Publisher<Void> rollback() {
-    return convertFutureToMono(() -> {
-      LOGGER.debug("roll back");
-      if (this.lastStep == null) {
-        // TODO: replace by a better non-retryable;
-        //  consider not throwing at all and no-oping with warning.
-        throw new RuntimeException(
-            "No statements were executed in this transaction; no-op rollback");
-      }
-      return this.transactionManager.rollbackAsync();
-
-    }).doOnTerminate(this::clearTransactionManager);
+    return convertFutureToMono(() -> this.txnManager.rollbackTransaction())
+        .doOnTerminate(this.txnManager::clearTransactionManager);
   }
 
   /**
@@ -196,7 +138,7 @@ class DatabaseClientReactiveAdapter {
   public Mono<Void> close() {
     // TODO: if txn is committed/rolled back and then connection closed, clearTransactionManager
     // will run twice, causing trace span to be closed twice. Introduce `closed` field.
-    return Mono.fromRunnable(this::clearTransactionManager);
+    return Mono.fromRunnable(this.txnManager::clearTransactionManager);
   }
 
   /**
@@ -212,8 +154,7 @@ class DatabaseClientReactiveAdapter {
         return Flux.<SpannerClientLibraryRow>create(sink -> {
           com.google.cloud.spanner.Statement statement =
               Statement.newBuilder("SELECT 1").build();
-          runSelectStatementAsFlux(
-              () -> this.dbClient.singleUseReadOnlyTransaction(), statement, sink);
+          runSelectStatementAsFlux(this.dbClient.singleUse(), statement, sink);
         })
         .then(Mono.just(true))
         .onErrorResume(error -> {
@@ -249,22 +190,8 @@ class DatabaseClientReactiveAdapter {
   private <T> Mono<T> runBatchDmlInternal(
       Function<TransactionContext, ApiFuture<T>> asyncOperation) {
     return convertFutureToMono(() -> {
-      if (this.isInReadWriteTransaction()) {
-
-        // The first statement in a transaction has no input, hence Void input type.
-        // The subsequent statements take the previous statements' return (affected row count)
-        // as input.
-        AsyncTransactionStep<? extends Object, T> updateStatementFuture =
-            this.lastStep == null
-                ? this.txnContextFuture.then(
-                    (ctx, unusedVoid) -> asyncOperation.apply(ctx), this.executorService)
-                : this.lastStep.then(
-                    (ctx, unusedPreviousResult) -> asyncOperation.apply(ctx),
-                    this.executorService);
-
-        this.lastStep = updateStatementFuture;
-        return updateStatementFuture;
-
+      if (this.txnManager.isInReadWriteTransaction()) {
+        return this.txnManager.runInTransaction(asyncOperation);
       } else {
         ApiFuture<T> rowCountFuture =
             this.dbClient
@@ -279,32 +206,13 @@ class DatabaseClientReactiveAdapter {
       com.google.cloud.spanner.Statement statement) {
     return Flux.create(
         sink -> {
-          if (this.isInReadWriteTransaction()) {
+          if (this.txnManager.isInReadWriteTransaction()) {
 
-            LOGGER.debug("  chaining SELECT statement in transaction: " + statement.getSql());
-            // The first statement in a transaction has no input, hence Void input type.
-            // The subsequent statements take the previous statement's return value as input.
-            this.lastStep =
-                this.lastStep == null
-                    ? this.txnContextFuture.then(
-                        (ctx, unusedVoid) -> runSelectStatementAsFlux(() -> ctx, statement, sink),
-                        this.executorService)
-                    : this.lastStep.then(
-                        (ctx, unusedPreviousResult) ->
-                            runSelectStatementAsFlux(() -> ctx, statement, sink),
-                        this.executorService);
+            this.txnManager.runInTransaction(ctx -> runSelectStatementAsFlux(ctx, statement, sink));
 
           } else {
-            LOGGER.debug("  running standalone SELECT statement: " + statement.getSql());
-            runSelectStatementAsFlux(
-                () -> {
-                  if (this.readOnlyTransaction == null) {
-                    return this.dbClient.singleUse();
-                  } else {
-                    return this.readOnlyTransaction;
-                  }
-                },
-                statement, sink);
+
+            runSelectStatementAsFlux(this.txnManager.getReadContext(), statement, sink);
           }
         });
   }
@@ -325,16 +233,16 @@ class DatabaseClientReactiveAdapter {
    * ApiFuture} returned by `transactionManager.beginAsync()` resolves. In practice, this means
    * always invoking this method in a chained `.then()` lambda * when running in transaction.
    *
-   * @param ctxSupplier Non-blocking supplier of read context (transactional or not).
+   * @param readContext Cloud Spanner read context (plain or transactional)
    * @param statement query to run
    * @param sink output Flux sink
    * @return future suitable for transactional step chaining
    */
   private ApiFuture<Void> runSelectStatementAsFlux(
-      Supplier<ReadContext> ctxSupplier,
+      ReadContext readContext,
       com.google.cloud.spanner.Statement statement,
       FluxSink<SpannerClientLibraryRow> sink) {
-    AsyncResultSet ars = ctxSupplier.get().executeQueryAsync(statement);
+    AsyncResultSet ars = readContext.executeQueryAsync(statement);
     sink.onCancel(ars::cancel);
 
     return ars.setCallback(

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.spanner.AsyncTransactionManager;
+import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
+import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.ReadOnlyTransaction;
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.TransactionContext;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class encapsulating read/write and readonly transaction management for client library
+ * based interaction with Cloud Spanner.
+ * Partitioned DML is out of scope for transaction handling, as they are not atomic.
+ */
+class DatabaseClientTransactionManager {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DatabaseClientTransactionManager.class);
+
+  private final DatabaseClient dbClient;
+
+  private AsyncTransactionManager transactionManager;
+
+  private TransactionContextFuture txnContextFuture;
+
+  private ReadOnlyTransaction readOnlyTransaction;
+
+  private AsyncTransactionStep<?, ? extends Object> lastStep;
+
+  private final ExecutorService executorService;
+
+  public DatabaseClientTransactionManager(
+      DatabaseClient dbClient, ExecutorService executorService) {
+    this.dbClient = dbClient;
+    this.executorService = executorService;
+  }
+
+  boolean isInReadWriteTransaction() {
+    return this.txnContextFuture != null;
+  }
+
+  /**
+   * Starts a Cloud Spanner Read/Write transaction.
+   *
+   * @return chainable {@link TransactionContextFuture} for the current transaction.
+   */
+  TransactionContextFuture beginTransaction() {
+    this.transactionManager = this.dbClient.transactionManagerAsync();
+    this.txnContextFuture = this.transactionManager.beginAsync();
+    return this.txnContextFuture;
+  }
+
+  /**
+   * Starts a Cloud Spanner Read-only transaction with specified staleness.
+   *
+   * @param timestampBound staleness settings
+   * @return chainable {@link TransactionContextFuture} for the current transaction.
+   */
+  void beginReadonlyTransaction(TimestampBound timestampBound) {
+    if (this.readOnlyTransaction != null) {
+      this.readOnlyTransaction.close();
+    }
+    this.readOnlyTransaction = this.dbClient.readOnlyTransaction(timestampBound);
+  }
+
+  /**
+   * Closes the read/write transaction manager and clears its state.
+   */
+  void clearTransactionManager() {
+    LOGGER.debug("close transaction manager");
+    this.txnContextFuture = null;
+    this.lastStep = null;
+    if (this.transactionManager != null) {
+      this.transactionManager.close();
+      this.transactionManager = null;
+    }
+  }
+
+  /**
+   * Commits the current transaction (if read/write) or closes it (if read-only).
+   *
+   * @return chainable {@link ApiFuture} for commit status.
+   */
+  ApiFuture<? extends Object> commitTransaction() {
+    if (isInReadWriteTransaction()) {
+      if (this.lastStep == null) {
+        LOGGER.warn("Read/Write transaction committing without any statements.");
+      }
+      return this.lastStep.commitAsync();
+
+    } else if (this.readOnlyTransaction != null) {
+      this.readOnlyTransaction.close();
+      this.readOnlyTransaction = null;
+    } else {
+      LOGGER.warn("Commit called outside of an active transaction.");
+    }
+    return ApiFutures.immediateFuture(null);
+  }
+
+  /**
+   * Rolls back the current read/write transaction.
+   *
+   * @return chainable {@link ApiFuture} for rollback status.
+   */
+  ApiFuture<Void> rollbackTransaction() {
+
+    if (isInReadWriteTransaction()) {
+      if (this.lastStep == null) {
+        LOGGER.warn("Read/Write transaction rolling back without any statements.");
+      }
+      return this.transactionManager.rollbackAsync();
+    }
+    LOGGER.warn("Rollback called outside of an active read/write transaction.");
+    return ApiFutures.immediateFuture(null);
+  }
+
+  /**
+   * Runs provided operation, managing the client library transactional future chaining.
+   * @param operation a function executing either streaming SQL or DML.
+   *     The function accepts ReadContext for SELECT queries, and TransactionContext for DML.
+   * @param <T> Type of object wrapped by the {@link ApiFuture} returned by the operation
+   * @return {@link ApiFuture} result of the provided operation
+   */
+  <T> ApiFuture<T> runInTransaction(Function<? super TransactionContext, ApiFuture<T>> operation) {
+
+    // The first statement in a transaction has no input, hence Void input type.
+    // The subsequent statements take the previous statements' return (affected row count)
+    // as input.
+    AsyncTransactionStep<? extends Object, T> updateStatementFuture =
+        this.lastStep == null
+            ? this.txnContextFuture.then(
+                (ctx, unusedVoid) -> operation.apply(ctx), this.executorService)
+            : this.lastStep.then(
+                (ctx, unusedPreviousResult) -> operation.apply(ctx), this.executorService);
+
+    this.lastStep = updateStatementFuture;
+    return updateStatementFuture;
+  }
+
+  ReadContext getReadContext() {
+    return this.readOnlyTransaction == null ? this.dbClient.singleUse() : this.readOnlyTransaction;
+  }
+
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
@@ -27,8 +26,6 @@ import io.r2dbc.spi.ConnectionMetadata;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.ValidationDepth;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,18 +38,16 @@ public class SpannerClientLibraryConnection implements Connection {
 
   private final DatabaseClientReactiveAdapter clientLibraryAdapter;
 
-  private ExecutorService executorService;
+
 
   /**
    * Cloud Spanner implementation of R2DBC Connection SPI.
-   * @param spanner Cloud Spanner spanner library database client
+   * @param clientLibraryAdapter adapter to Cloud Spanner database client
    * @param config driver configuration extracted from URL or passed directly to connection factory.
    */
-  public SpannerClientLibraryConnection(Spanner spanner, SpannerConnectionConfiguration config) {
-    this.executorService = Executors.newFixedThreadPool(config.getThreadPoolSize());
-    this.clientLibraryAdapter =
-        new DatabaseClientReactiveAdapter(spanner, this.executorService, config);
-
+  public SpannerClientLibraryConnection(DatabaseClientReactiveAdapter clientLibraryAdapter,
+      SpannerConnectionConfiguration config) {
+    this.clientLibraryAdapter = clientLibraryAdapter;
   }
 
   @Override
@@ -67,6 +62,14 @@ public class SpannerClientLibraryConnection implements Connection {
    */
   public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
     return this.clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
+  }
+
+  /**
+   * Allows starting a readonly Cloud Spanner transaction with strong consistency.
+   * @return {@link Mono} signaling readonly transaction is ready for use
+   */
+  public Mono<Void> beginReadonlyTransaction() {
+    return this.clientLibraryAdapter.beginReadonlyTransaction(TimestampBound.strong());
   }
 
   @Override
@@ -143,7 +146,7 @@ public class SpannerClientLibraryConnection implements Connection {
   @Override
   public Publisher<Boolean> validate(ValidationDepth depth) {
     if (depth == ValidationDepth.LOCAL) {
-      return Mono.fromSupplier(() -> !this.executorService.isShutdown());
+      return this.clientLibraryAdapter.localHealthcheck();
     } else {
       return this.clientLibraryAdapter.healthCheck();
     }
@@ -151,10 +154,6 @@ public class SpannerClientLibraryConnection implements Connection {
 
   @Override
   public Publisher<Void> close() {
-    return this.clientLibraryAdapter.close()
-        .then(Mono.fromRunnable(() -> {
-          LOGGER.debug("  shutting down executor service");
-          this.executorService.shutdown();
-        }));
+    return this.clientLibraryAdapter.close();
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -21,7 +21,6 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
-import com.google.spanner.v1.TransactionOptions;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionMetadata;
@@ -61,7 +60,11 @@ public class SpannerClientLibraryConnection implements Connection {
     return this.clientLibraryAdapter.beginTransaction();
   }
 
-  // TODO: javadoc custom transaction method requiring downcasting connection object
+  /**
+   * Allows starting a readonly Cloud Spanner transaction with given staleness settings.
+   * @param timestampBound staleness settings
+   * @return {@link Mono} signaling readonly transaction is ready for use
+   */
   public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
     return this.clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -17,9 +17,11 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
+import com.google.spanner.v1.TransactionOptions;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionMetadata;
@@ -57,6 +59,11 @@ public class SpannerClientLibraryConnection implements Connection {
   @Override
   public Publisher<Void> beginTransaction() {
     return this.clientLibraryAdapter.beginTransaction();
+  }
+
+  // TODO: javadoc custom transaction method requiring downcasting connection object
+  public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
+    return this.clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -44,7 +44,11 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory 
 
   @Override
   public Publisher<? extends Connection> create() {
-    return Mono.just(new SpannerClientLibraryConnection(this.spannerClient, this.config));
+
+    return Mono.just(
+        new SpannerClientLibraryConnection(
+          new DatabaseClientReactiveAdapter(this.spannerClient, this.config),
+          this.config));
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/TransactionInProgressException.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/TransactionInProgressException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import io.r2dbc.spi.R2dbcNonTransientException;
+
+public class TransactionInProgressException extends R2dbcNonTransientException {
+
+  public static final String MSG_READONLY =
+      "Cannot begin a new transaction because a readonly transaction is already in progress.";
+  public static final String MSG_READWRITE =
+      "Cannot begin a new transaction because a read/write transaction is already in progress.";
+
+  public TransactionInProgressException(boolean isReadwrite) {
+    super(isReadwrite ? MSG_READWRITE : MSG_READONLY);
+  }
+
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -36,7 +36,6 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Row;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.ValidationDepth;
 import java.math.BigDecimal;
@@ -645,10 +644,6 @@ public class ClientLibraryBasedIT {
         .expectNext(1L)
         .as("strong read returns the inserted row after stale-read transaction terminates")
         .verifyComplete();
-  }
-
-  private String concatRow(Row row) {
-    return row.get(1) + ", " + row.get(2) + ", " + row.get(3);
   }
 
   private Publisher<Long> getFirstNumber(Result result) {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.AsyncTransactionManager;
+import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.ReadOnlyTransaction;
+import com.google.cloud.spanner.TimestampBound;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DatabaseClientTransactionManagerTest {
+
+  DatabaseClientTransactionManager transactionManager;
+  DatabaseClient mockDbClient;
+  AsyncTransactionManager mockClientLibraryTransactionManager;
+  TransactionContextFuture mockTransactionFuture;
+  ReadOnlyTransaction mockReadOnlyTransaction;
+
+  /** Sets up mocks. */
+  @BeforeEach
+  public void setUp() {
+    this.mockDbClient = mock(DatabaseClient.class);
+    this.mockClientLibraryTransactionManager = mock(AsyncTransactionManager.class);
+    this.mockTransactionFuture = mock(TransactionContextFuture.class);
+    this.mockReadOnlyTransaction = mock(ReadOnlyTransaction.class);
+
+    when(this.mockDbClient.transactionManagerAsync())
+        .thenReturn(this.mockClientLibraryTransactionManager);
+    when(this.mockClientLibraryTransactionManager.beginAsync())
+        .thenReturn(this.mockTransactionFuture);
+    when(this.mockDbClient.readOnlyTransaction(TimestampBound.strong()))
+        .thenReturn(this.mockReadOnlyTransaction);
+
+    this.transactionManager =
+        new DatabaseClientTransactionManager(
+            this.mockDbClient, Executors.newSingleThreadExecutor());
+  }
+
+  @Test
+  public void testReadonlyTransactionStartedWhileReadWriteInProgressFails() {
+
+    this.transactionManager.beginTransaction();
+    assertThatThrownBy(() ->
+        this.transactionManager.beginReadonlyTransaction(TimestampBound.strong())
+    ).isInstanceOf(TransactionInProgressException.class)
+        .hasMessage(TransactionInProgressException.MSG_READWRITE);
+  }
+
+  @Test
+  public void testReadWriteTransactionStartedWhileReadonlyInProgressFails() {
+
+    this.transactionManager.beginReadonlyTransaction(TimestampBound.strong());
+    assertThatThrownBy(() ->
+        this.transactionManager.beginTransaction()
+    ).isInstanceOf(TransactionInProgressException.class)
+        .hasMessage(TransactionInProgressException.MSG_READONLY);
+  }
+
+  @Test
+  public void testReadonlyTransactionStartedWhileReadonlyInProgressFails() {
+
+    this.transactionManager.beginReadonlyTransaction(TimestampBound.strong());
+    assertThatThrownBy(() ->
+        this.transactionManager.beginReadonlyTransaction(TimestampBound.strong())
+    ).isInstanceOf(TransactionInProgressException.class)
+        .hasMessage(TransactionInProgressException.MSG_READONLY);
+  }
+
+  @Test
+  public void testReadWriteTransactionStartedWhileReadwriteInProgressFails() {
+
+    this.transactionManager.beginTransaction();
+    assertThatThrownBy(() ->
+        this.transactionManager.beginTransaction()
+    ).isInstanceOf(TransactionInProgressException.class)
+        .hasMessage(TransactionInProgressException.MSG_READWRITE);
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -23,23 +23,35 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 public class SpannerClientLibraryConnectionTest {
 
-  SpannerConnectionConfiguration mockConfig = mock(SpannerConnectionConfiguration.class);
-  DatabaseClientReactiveAdapter mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+  SpannerConnectionConfiguration mockConfig;
+  DatabaseClientReactiveAdapter mockAdapter;
+
+  SpannerClientLibraryConnection connection;
+
+  /** Sets up mocks. */
+  @BeforeEach
+  public void setUpMocks() {
+    this.mockConfig = mock(SpannerConnectionConfiguration.class);
+    this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+    this.connection = new SpannerClientLibraryConnection(this.mockAdapter, this.mockConfig);
+  }
 
   @Test
   public void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
-    SpannerClientLibraryConnection conn =
-        new SpannerClientLibraryConnection(this.mockAdapter, this.mockConfig);
+
     when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
 
-    StepVerifier.create(conn.beginReadonlyTransaction()).verifyComplete();
+    StepVerifier.create(this.connection.beginReadonlyTransaction())
+        .verifyComplete();
 
     verify(this.mockAdapter).beginReadonlyTransaction(TimestampBound.strong());
   }
+
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class SpannerClientLibraryConnectionTest {
+
+  SpannerConnectionConfiguration mockConfig = mock(SpannerConnectionConfiguration.class);
+  DatabaseClientReactiveAdapter mockAdapter = mock(DatabaseClientReactiveAdapter.class);
+
+  @Test
+  public void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
+    SpannerClientLibraryConnection conn =
+        new SpannerClientLibraryConnection(this.mockAdapter, this.mockConfig);
+    when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
+
+    StepVerifier.create(conn.beginReadonlyTransaction()).verifyComplete();
+
+    verify(this.mockAdapter).beginReadonlyTransaction(TimestampBound.strong());
+  }
+}


### PR DESCRIPTION
Read/write and readonly transactions use completely different concepts in client library (`TransactionManager` is only for read/write transactions), so I created `DatabaseClientTransactionManager` to encapsulate all the random bits of transactional state.

All forms of stale readonly transactions are supported with this PR.

Partitioned DML is out of scope, since it does not fit into beginTransaction-runQueries-commitTransaction pattern, and it's not atomic anyway. It also does not happen to be supported asynchronously in the client library (although it is in Connection API, but more as a wrap-this-in-a-thread workaround). 

cc/ @olavloite

Fixes #249 .