### PR TITLE
Add Autocommit Support

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -130,8 +130,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for committing a transaction
    */
-  public Publisher<Void> commitTransaction() {
-
+  public Mono<Void> commitTransaction() {
     return convertFutureToMono(() -> this.txnManager.commitTransaction())
         .doOnTerminate(this.txnManager::clearTransactionManager)
         .then();
@@ -201,7 +200,7 @@ class DatabaseClientReactiveAdapter {
       Mono<Void> result = Mono.empty();
       if (this.autoCommit != autoCommit && this.txnManager.isInTransaction()) {
         // If autocommit is changed, commit the existing transaction.
-        result = Mono.from(this.commitTransaction());
+        result = this.commitTransaction();
       }
       return result.doOnSuccess(empty -> this.autoCommit = autoCommit);
     });

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -30,6 +30,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -64,6 +65,8 @@ class DatabaseClientReactiveAdapter {
 
   private final DatabaseClientTransactionManager txnManager;
 
+  private boolean autoCommit = true;
+
   /**
    * Instantiates the adapter with given client library {@code DatabaseClient} and executor.
    *
@@ -80,6 +83,22 @@ class DatabaseClientReactiveAdapter {
     this.executorService = Executors.newFixedThreadPool(config.getThreadPoolSize());
     this.config = config;
     this.txnManager = new DatabaseClientTransactionManager(this.dbClient, this.executorService);
+  }
+
+  @VisibleForTesting
+  DatabaseClientReactiveAdapter(
+      SpannerConnectionConfiguration config,
+      Spanner spannerClient,
+      DatabaseClient dbClient,
+      DatabaseAdminClient dbAdminClient,
+      ExecutorService executorService,
+      DatabaseClientTransactionManager txnManager) {
+    this.config = config;
+    this.spannerClient = spannerClient;
+    this.dbClient = dbClient;
+    this.dbAdminClient = dbAdminClient;
+    this.executorService = executorService;
+    this.txnManager = txnManager;
   }
 
   /**
@@ -173,6 +192,23 @@ class DatabaseClientReactiveAdapter {
     return Mono.fromSupplier(() -> !this.executorService.isShutdown());
   }
 
+  public boolean isAutoCommit() {
+    return this.autoCommit;
+  }
+
+  public Publisher<Void> setAutoCommit(boolean autoCommit) {
+    return Mono.defer(() -> {
+      Mono<Void> result = Mono.empty();
+      if (this.autoCommit != autoCommit && this.txnManager.isInTransaction()) {
+        // If autocommit is changed, commit the existing transaction.
+        result = Mono.from(this.commitTransaction());
+      }
+
+      this.autoCommit = autoCommit;
+      return result;
+    });
+  }
+
   /**
    * Allows running a DML statement.
    *
@@ -197,16 +233,26 @@ class DatabaseClientReactiveAdapter {
 
   private <T> Mono<T> runBatchDmlInternal(
       Function<TransactionContext, ApiFuture<T>> asyncOperation) {
-    return convertFutureToMono(() -> {
-      if (this.txnManager.isInReadWriteTransaction()) {
-        return this.txnManager.runInTransaction(asyncOperation);
-      } else {
-        ApiFuture<T> rowCountFuture =
-            this.dbClient
-                .runAsync()
-                .runAsync(txn -> asyncOperation.apply(txn), this.executorService);
-        return rowCountFuture;
+    return Mono.defer(() -> {
+      if (this.txnManager.isInReadonlyTransaction()) {
+        return Mono.error(
+            new IllegalAccessException("Cannot run DML statements in a readonly transaction."));
+      } else if (!autoCommit && !this.txnManager.isInReadWriteTransaction()) {
+        return Mono.error(new IllegalAccessException(
+            "Cannot run DML statements outside of a transaction when autocommit is set to false."));
       }
+
+      return convertFutureToMono(() -> {
+        if (this.txnManager.isInReadWriteTransaction()) {
+          return this.txnManager.runInTransaction(asyncOperation);
+        } else {
+          ApiFuture<T> rowCountFuture =
+              this.dbClient
+                  .runAsync()
+                  .runAsync(txn -> asyncOperation.apply(txn), this.executorService);
+          return rowCountFuture;
+        }
+      });
     });
   }
 
@@ -215,18 +261,14 @@ class DatabaseClientReactiveAdapter {
     return Flux.create(
         sink -> {
           if (this.txnManager.isInReadWriteTransaction()) {
-
             this.txnManager.runInTransaction(ctx -> runSelectStatementAsFlux(ctx, statement, sink));
-
           } else {
-
             runSelectStatementAsFlux(this.txnManager.getReadContext(), statement, sink);
           }
         });
   }
 
   public Mono<Void> runDdlStatement(String query) {
-
     return convertFutureToMono(() -> this.dbAdminClient.updateDatabaseDdl(
         this.config.getInstanceName(),
         this.config.getDatabaseName(),

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -237,7 +237,7 @@ class DatabaseClientReactiveAdapter {
       if (this.txnManager.isInReadonlyTransaction()) {
         return Mono.error(
             new IllegalAccessException("Cannot run DML statements in a readonly transaction."));
-      } else if (!autoCommit && !this.txnManager.isInReadWriteTransaction()) {
+      } else if (!this.autoCommit && !this.txnManager.isInReadWriteTransaction()) {
         return Mono.error(new IllegalAccessException(
             "Cannot run DML statements outside of a transaction when autocommit is set to false."));
       }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -203,9 +203,7 @@ class DatabaseClientReactiveAdapter {
         // If autocommit is changed, commit the existing transaction.
         result = Mono.from(this.commitTransaction());
       }
-
-      this.autoCommit = autoCommit;
-      return result;
+      return result.doOnSuccess(empty -> this.autoCommit = autoCommit);
     });
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -38,8 +38,6 @@ public class SpannerClientLibraryConnection implements Connection {
 
   private final DatabaseClientReactiveAdapter clientLibraryAdapter;
 
-
-
   /**
    * Cloud Spanner implementation of R2DBC Connection SPI.
    * @param clientLibraryAdapter adapter to Cloud Spanner database client
@@ -105,7 +103,7 @@ public class SpannerClientLibraryConnection implements Connection {
 
   @Override
   public boolean isAutoCommit() {
-    return false;
+    return this.clientLibraryAdapter.isAutoCommit();
   }
 
   @Override
@@ -135,7 +133,7 @@ public class SpannerClientLibraryConnection implements Connection {
 
   @Override
   public Publisher<Void> setAutoCommit(boolean autoCommit) {
-    throw new UnsupportedOperationException();
+    return this.clientLibraryAdapter.setAutoCommit(autoCommit);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -424,26 +424,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Test
-  public void sameAutoCommitLeavesTransactionUnchanged() {
-    Mono.from(getConnectionFactory().create())
-        .flatMapMany(connection ->
-            Flux.from(connection.setAutoCommit(false))
-                .thenMany(connection.beginTransaction())
-                .thenMany(
-                    connection.createStatement(expand(TestStatement.INSERT_VALUE200)).execute())
-                .flatMap(Result::getRowsUpdated)
-                .thenMany(connection.setAutoCommit(false))
-                .thenMany(connection.rollbackTransaction())
-                .thenMany(connection.createStatement("SELECT value FROM test").execute())
-                .flatMap(it -> it.map((row, metadata) -> row.get("value")))
-                .concatWith(close(connection))
-        )
-        .as(StepVerifier::create)
-        .verifyComplete();
-  }
-
-  @Override
   public String expand(TestStatement statement, Object... args) {
     return SpannerTestKitStatements.expand(statement, args);
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -402,7 +402,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
 
   @Override
   @Test
-  @Disabled // TODO: GH-275
   public void changeAutoCommitCommitsTransaction() {
     Mono.from(getConnectionFactory().create())
         .flatMapMany(connection ->
@@ -426,7 +425,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
 
   @Override
   @Test
-  @Disabled // TODO: GH-275
   public void sameAutoCommitLeavesTransactionUnchanged() {
     Mono.from(getConnectionFactory().create())
         .flatMapMany(connection ->
@@ -443,12 +441,6 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
         )
         .as(StepVerifier::create)
         .verifyComplete();
-  }
-
-  @Override
-  @Disabled // TODO: GH-275
-  public void autoCommitByDefault() {
-
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spanner.r2dbc.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +47,7 @@ public class DatabaseClientReactiveAdapterTest {
   private DatabaseClientReactiveAdapter adapter;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     this.config = mock(SpannerConnectionConfiguration.class);
     this.spannerClient = mock(Spanner.class);
     this.dbClient = mock(DatabaseClient.class);
@@ -51,29 +67,29 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @AfterEach
-  public void shutdown() {
+  void shutdown() {
     this.executorService.shutdownNow();
   }
 
   @Test
   public void testChangeAutocommit() {
     when(this.txnManager.isInTransaction()).thenReturn(true);
-    assertThat(adapter.isAutoCommit()).isTrue();
+    assertThat(this.adapter.isAutoCommit()).isTrue();
 
     // Toggle autocommit setting.
-    Mono.from(adapter.setAutoCommit(false)).block();
-    assertThat(adapter.isAutoCommit()).isFalse();
+    Mono.from(this.adapter.setAutoCommit(false)).block();
+    assertThat(this.adapter.isAutoCommit()).isFalse();
     verify(this.txnManager, times(1)).commitTransaction();
   }
 
   @Test
   public void testChangeAutocommit_Noop() {
     when(this.txnManager.isInTransaction()).thenReturn(true);
-    assertThat(adapter.isAutoCommit()).isTrue();
+    assertThat(this.adapter.isAutoCommit()).isTrue();
 
     // Toggle autocommit setting.
-    Mono.from(adapter.setAutoCommit(true)).block();
-    assertThat(adapter.isAutoCommit()).isTrue();
+    Mono.from(this.adapter.setAutoCommit(true)).block();
+    assertThat(this.adapter.isAutoCommit()).isTrue();
     verify(this.txnManager, times(0)).commitTransaction();
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -53,7 +53,7 @@ public class DatabaseClientReactiveAdapterTest {
     this.dbClient = mock(DatabaseClient.class);
     this.dbAdminClient = mock(DatabaseAdminClient.class);
     this.txnManager = mock(DatabaseClientTransactionManager.class);
-    this.executorService = Executors.newFixedThreadPool(1);
+    this.executorService = Executors.newSingleThreadExecutor();
 
     this.adapter = new DatabaseClientReactiveAdapter(
         this.config,
@@ -72,7 +72,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void testChangeAutocommit() {
+  public void testChangeAutocommitCommitsCurrentTransaction() {
     when(this.txnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 
@@ -83,7 +83,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void testChangeAutocommit_Noop() {
+  public void testSameAutocommitNoop() {
     when(this.txnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -1,0 +1,79 @@
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+public class DatabaseClientReactiveAdapterTest {
+
+  // DatabaseClientReactiveAdapter dependencies
+  private SpannerConnectionConfiguration config;
+  private Spanner spannerClient;
+  private DatabaseClient dbClient;
+  private DatabaseAdminClient dbAdminClient;
+  private DatabaseClientTransactionManager txnManager;
+  private ExecutorService executorService;
+
+  private DatabaseClientReactiveAdapter adapter;
+
+  @BeforeEach
+  public void setup() {
+    this.config = mock(SpannerConnectionConfiguration.class);
+    this.spannerClient = mock(Spanner.class);
+    this.dbClient = mock(DatabaseClient.class);
+    this.dbAdminClient = mock(DatabaseAdminClient.class);
+    this.txnManager = mock(DatabaseClientTransactionManager.class);
+    this.executorService = Executors.newFixedThreadPool(1);
+
+    this.adapter = new DatabaseClientReactiveAdapter(
+        this.config,
+        this.spannerClient,
+        this.dbClient,
+        this.dbAdminClient,
+        this.executorService,
+        this.txnManager);
+
+    when(this.txnManager.commitTransaction()).thenReturn(ApiFutures.immediateFuture(null));
+  }
+
+  @AfterEach
+  public void shutdown() {
+    this.executorService.shutdownNow();
+  }
+
+  @Test
+  public void testChangeAutocommit() {
+    when(this.txnManager.isInTransaction()).thenReturn(true);
+    assertThat(adapter.isAutoCommit()).isTrue();
+
+    // Toggle autocommit setting.
+    Mono.from(adapter.setAutoCommit(false)).block();
+    assertThat(adapter.isAutoCommit()).isFalse();
+    verify(this.txnManager, times(1)).commitTransaction();
+  }
+
+  @Test
+  public void testChangeAutocommit_Noop() {
+    when(this.txnManager.isInTransaction()).thenReturn(true);
+    assertThat(adapter.isAutoCommit()).isTrue();
+
+    // Toggle autocommit setting.
+    Mono.from(adapter.setAutoCommit(true)).block();
+    assertThat(adapter.isAutoCommit()).isTrue();
+    verify(this.txnManager, times(0)).commitTransaction();
+  }
+}


### PR DESCRIPTION
Implements the `autoCommit` setting for the connection.

Fixes https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/275

Reference: https://github.com/r2dbc/r2dbc-spi/blob/main/r2dbc-spec/src/main/asciidoc/transactions.adoc#auto-commit-mode