### PR TITLE
upgrade google BOM to pull in unpropagated failure fix

### DIFF
--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -250,8 +250,7 @@ public class ClientLibraryBasedIT {
 
   @Test
   public void testTransactionSingleStatementCommitted() {
-    // TODO: introduce timeouts; when there is an issue in apifuture conversion,
-    // test never completes
+
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
 
     StepVerifier.create(
@@ -295,8 +294,6 @@ public class ClientLibraryBasedIT {
                     .execute()
                 ).flatMap(r -> r.getRowsUpdated()),
 
-                // TODO: garble SQL below and watch the publisher hang. Troubleshoot how to surface
-                // exception insead of hanging.
                 Flux.from(c.createStatement(
                     "UPDATE BOOKS SET CATEGORY=200 WHERE CATEGORY = 100").execute())
                     .flatMap(r -> r.getRowsUpdated()),

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <google-cloud-bom.version>13.1.0</google-cloud-bom.version>
+    <google-cloud-bom.version>15.1.0</google-cloud-bom.version>
 
     <r2dbc.version>0.8.3.RELEASE</r2dbc.version>
     <reactor.version>Dysprosium-SR12</reactor.version>


### PR DESCRIPTION
Bring in the latest client library, with the fix for googleapis/java-spanner#514.

Fixes #282.