### PR TITLE
Add config options to mirror JDBC driver

### DIFF
--- a/cloud-spanner-r2dbc/README_v2.adoc
+++ b/cloud-spanner-r2dbc/README_v2.adoc
@@ -15,6 +15,7 @@ ConnectionFactories.get(
 ## Authentication
 
 The driver allows the following options for authentication:
+
 * a `String` property `credentials` containing the local file location of the JSON credentials file.
 * a `Credentials` object provided as `google_credentials`. This will only work with programmatically constructed `ConnectionFactoryOptions`.
 * a `String` OAuth token provided as `oauthToken`.

--- a/cloud-spanner-r2dbc/README_v2.adoc
+++ b/cloud-spanner-r2dbc/README_v2.adoc
@@ -22,6 +22,53 @@ The driver allows the following options for authentication:
 If no authentication options are provided, Application Default Credentials will be automatically determined.
 The only exception is when the connection is in plain-text, indicating the use of Cloud Spanner emulator, in which case no credentials will be used.
 
+## Supported connection options
+
+All connection options of primitive and String type can be passed through the connection URL in the `?key1=value1&key2=value2` format.
+Object-typed options can only be passed in programmatically.
+
+|===
+|Property name |Type |Allowed in URL connection |Default |Comments
+
+|`credentials`
+|String
+|Yes
+|null
+|The location of the credentials file to use for this connection
+
+|`oauthToken`
+|String
+|Yes
+|null
+|A valid pre-existing OAuth token to use for authentication
+
+|`google_credentials`
+|com.google.auth.oauth2.OAuth2Credentials
+|No
+|null
+|A pre-authenticated authentication object that can only be supplied with programmatic connection options
+
+|`thread_pool_size`
+|int
+|Yes
+|Equal to the number of available processors
+|Determines the size of thread pool used to process `Future` callbacks
+
+|`usePlainText`
+|boolean
+|Yes
+|false
+|Turns off SSL and credentials use (only valid when using Cloud Spanner emulator)
+
+|optimizerVersion
+|String
+|Yes
+|null
+= ``|``Determines version of Cloud Spanner https://cloud.google.com/spanner/docs/query-optimizer/query-optimizer-versions[optimizer] to use in queries
+
+|===
+
+
 ## Transactions
 
 ### Read-Write Transactions

--- a/cloud-spanner-r2dbc/README_v2.adoc
+++ b/cloud-spanner-r2dbc/README_v2.adoc
@@ -12,6 +12,16 @@ ConnectionFactories.get(
               .build());
 ```
 
+## Authentication
+
+The driver allows the following options for authentication:
+* a `String` property `credentials` containing the local file location of the JSON credentials file.
+* a `Credentials` object provided as `google_credentials`. This will only work with programmatically constructed `ConnectionFactoryOptions`.
+* a `String` OAuth token provided as `oauthToken`.
+
+If no authentication options are provided, Application Default Credentials will be automatically determined.
+The only exception is when the connection is in plain-text, indicating the use of Cloud Spanner emulator, in which case no credentials will be used.
+
 ## Transactions
 
 ### Read-Write Transactions

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/CredentialsHelper.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/CredentialsHelper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Credential instantiation service that can interact with the filesystem.
+ */
+class CredentialsHelper {
+
+  GoogleCredentials getOauthCredentials(String oauthToken) {
+    return new GoogleCredentials(new AccessToken(oauthToken, null));
+  }
+
+  GoogleCredentials getDefaultCredentials() {
+    try {
+      return GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("Error loading default credentials", e));
+    }
+  }
+
+
+  GoogleCredentials getFileCredentials(String filePath) {
+    File credentialsFile = new File(filePath);
+    if (!credentialsFile.isFile()) {
+      throw new IllegalArgumentException(
+          String.format("Error reading credential file %s: File does not exist", filePath));
+    }
+    try (InputStream credentialsStream = new FileInputStream(credentialsFile)) {
+      return GoogleCredentials.fromStream(credentialsStream);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(
+          String.format("Error reading credential file %s", filePath), e);
+    }
+  }
+
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -68,26 +68,6 @@ public class SpannerConnectionConfiguration {
   private int threadPoolSize;
 
   /**
-   * Constructor which initializes the configuration from an Cloud Spanner R2DBC url.
-
-  private SpannerConnectionConfiguration(String url, OAuth2Credentials credentials) {
-    String databaseString =
-        ConnectionFactoryOptions.parse(url).getValue(ConnectionFactoryOptions.DATABASE);
-
-    if (!databaseString.matches(DB_NAME_VALIDATE_PATTERN)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Malformed Cloud Spanner Database String: %s. The url must have the format: %s",
-              databaseString,
-              FULLY_QUALIFIED_DB_NAME_PATTERN));
-    }
-
-    this.fullyQualifiedDbName = databaseString;
-    this.credentials = credentials;
-  }
-   */
-
-  /**
    * Basic property initializing constructor.
    *
    * @param projectId GCP project that contains the database.
@@ -242,6 +222,12 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
+    /**
+     * Sets fully qualified database name.
+     * @param databaseName fully qualified database name in the format of
+     *                     "projects/%s/instances/%s/databases/%s"
+     * @return builder for chaining
+     */
     public Builder setFullyQualifiedDatabaseName(String databaseName) {
       validateFullyQualifiedDatabaseName(databaseName);
       this.fullyQualifiedDatabaseName = databaseName;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -69,6 +69,8 @@ public class SpannerConnectionConfiguration {
 
   private boolean usePlainText;
 
+  private String optimizerVersion;
+
   /**
    * Basic property initializing constructor.
    *
@@ -138,6 +140,10 @@ public class SpannerConnectionConfiguration {
 
   public boolean isUsePlainText() {
     return this.usePlainText;
+  }
+
+  public String getOptimizerVersion() {
+    return this.optimizerVersion;
   }
 
   @Override
@@ -214,6 +220,8 @@ public class SpannerConnectionConfiguration {
     private Integer threadPoolSize;
 
     private boolean usePlainText = false;
+
+    private String optimizerVersion;
 
     /**
      * R2DBC SPI does not provide the full URL to drivers after parsing the connection string.
@@ -298,6 +306,11 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
+    public Builder setOptimizerVersion(String optimizerVersion) {
+      this.optimizerVersion = optimizerVersion;
+      return this;
+    }
+
     /**
      * Constructs an instance of the {@link SpannerConnectionConfiguration}.
      *
@@ -337,6 +350,7 @@ public class SpannerConnectionConfiguration {
               ? this.threadPoolSize
               : Runtime.getRuntime().availableProcessors();
       configuration.usePlainText = this.usePlainText;
+      configuration.optimizerVersion = this.optimizerVersion;
 
       return configuration;
     }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -67,6 +67,8 @@ public class SpannerConnectionConfiguration {
 
   private int threadPoolSize;
 
+  private boolean usePlainText;
+
   /**
    * Basic property initializing constructor.
    *
@@ -134,6 +136,10 @@ public class SpannerConnectionConfiguration {
     return this.threadPoolSize;
   }
 
+  public boolean isUsePlainText() {
+    return this.usePlainText;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -181,6 +187,7 @@ public class SpannerConnectionConfiguration {
     optionsBuilder.setHeaderProvider(() ->
         Collections.singletonMap(USER_AGENT_KEY, USER_AGENT_LIBRARY_NAME + "/" + PACKAGE_VERSION));
 
+    // usePlainText is not currently used in the client library.
     // TODO (GH-200): allow customizing emulator with optionsBuilder.setEmulatorHost()
 
     return optionsBuilder.build();
@@ -205,6 +212,8 @@ public class SpannerConnectionConfiguration {
     private Duration ddlOperationPollInterval = Duration.ofSeconds(5);
 
     private Integer threadPoolSize;
+
+    private boolean usePlainText = false;
 
     /**
      * R2DBC SPI does not provide the full URL to drivers after parsing the connection string.
@@ -284,6 +293,11 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
+    public Builder setUsePlainText(boolean usePlainText) {
+      this.usePlainText = true;
+      return this;
+    }
+
     /**
      * Constructs an instance of the {@link SpannerConnectionConfiguration}.
      *
@@ -322,6 +336,7 @@ public class SpannerConnectionConfiguration {
           this.threadPoolSize != null
               ? this.threadPoolSize
               : Runtime.getRuntime().availableProcessors();
+      configuration.usePlainText = this.usePlainText;
 
       return configuration;
     }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -26,18 +26,20 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Configurable properties for Cloud Spanner.
  */
 public class SpannerConnectionConfiguration {
 
-  private static final String FULLY_QUALIFIED_DB_NAME_PATTERN =
+  public static final String FQDN_PATTERN_GENERATE =
       "projects/%s/instances/%s/databases/%s";
 
   /** Pattern used to validate that the user input database string is in the right format. */
-  private static final String DB_NAME_VALIDATE_PATTERN =
-      "projects\\/[\\w\\-]+\\/instances\\/[\\w\\-]+\\/databases\\/[\\w\\-]+$";
+  public static final Pattern FQDN_PATTERN_PARSE = Pattern.compile(
+      "projects\\/([\\w\\-]+)\\/instances\\/([\\w\\-]+)\\/databases\\/([\\w\\-]+)$");
 
   private static final String USER_AGENT_LIBRARY_NAME = "cloud-spanner-r2dbc";
 
@@ -67,7 +69,7 @@ public class SpannerConnectionConfiguration {
 
   /**
    * Constructor which initializes the configuration from an Cloud Spanner R2DBC url.
-   */
+
   private SpannerConnectionConfiguration(String url, OAuth2Credentials credentials) {
     String databaseString =
         ConnectionFactoryOptions.parse(url).getValue(ConnectionFactoryOptions.DATABASE);
@@ -83,6 +85,7 @@ public class SpannerConnectionConfiguration {
     this.fullyQualifiedDbName = databaseString;
     this.credentials = credentials;
   }
+   */
 
   /**
    * Basic property initializing constructor.
@@ -107,7 +110,7 @@ public class SpannerConnectionConfiguration {
     this.databaseName = databaseName;
 
     this.fullyQualifiedDbName = String.format(
-        FULLY_QUALIFIED_DB_NAME_PATTERN, projectId, instanceName, databaseName);
+        FQDN_PATTERN_GENERATE, projectId, instanceName, databaseName);
     this.credentials = credentials;
   }
 
@@ -205,7 +208,7 @@ public class SpannerConnectionConfiguration {
 
   public static class Builder {
 
-    private String url;
+    private String fullyQualifiedDatabaseName;
 
     private String projectId;
 
@@ -223,9 +226,36 @@ public class SpannerConnectionConfiguration {
 
     private Integer threadPoolSize;
 
+    /**
+     * R2DBC SPI does not provide the full URL to drivers after parsing the connection string.
+     * Therefore, this usecase is only possible if the client application provides a URL property
+     * directly through the programmatic configuration with
+     * {@code ConnectionFactories.get(ConnectionFactoryOptions)}.
+     */
+    @Deprecated
     public Builder setUrl(String url) {
-      this.url = url;
+      String databaseString =
+          ConnectionFactoryOptions.parse(url).getValue(ConnectionFactoryOptions.DATABASE);
+
+      validateFullyQualifiedDatabaseName(databaseString);
+      this.fullyQualifiedDatabaseName = databaseString;
       return this;
+    }
+
+    public Builder setFullyQualifiedDatabaseName(String databaseName) {
+      validateFullyQualifiedDatabaseName(databaseName);
+      this.fullyQualifiedDatabaseName = databaseName;
+      return this;
+    }
+
+    private void validateFullyQualifiedDatabaseName(String databaseString) {
+      if (!FQDN_PATTERN_PARSE.matcher(databaseString).matches()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Malformed Cloud Spanner Database String: %s. The url must have the format: %s",
+                databaseString,
+                FQDN_PATTERN_GENERATE));
+      }
     }
 
     public Builder setProjectId(String projectId) {
@@ -283,13 +313,21 @@ public class SpannerConnectionConfiguration {
             "Could not acquire default application credentials", e);
       }
 
-      SpannerConnectionConfiguration configuration;
-      if (this.url != null) {
-        configuration = new SpannerConnectionConfiguration(this.url, this.credentials);
-      } else {
-        configuration = new SpannerConnectionConfiguration(
-            this.projectId, this.instanceName, this.databaseName, this.credentials);
+      if (this.fullyQualifiedDatabaseName != null) {
+        Matcher matcher = FQDN_PATTERN_PARSE.matcher(this.fullyQualifiedDatabaseName);
+        if (matcher.find()) {
+          this.projectId = matcher.group(1);
+          this.instanceName = matcher.group(2);
+          this.databaseName = matcher.group(3);
+        } else {
+          // should not happen, as database names are pre-validated in the setters.
+          throw new IllegalArgumentException(
+              "Invalid database name: " + this.fullyQualifiedDatabaseName);
+        }
       }
+
+      SpannerConnectionConfiguration configuration = new SpannerConnectionConfiguration(
+            this.projectId, this.instanceName, this.databaseName, this.credentials);
 
       configuration.partialResultSetFetchSize = this.partialResultSetFetchSize;
       configuration.ddlOperationTimeout = this.ddlOperationTimeout;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration.FQDN_PATTERN_PARSE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
@@ -116,9 +117,15 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
     SpannerConnectionConfiguration.Builder config = new SpannerConnectionConfiguration.Builder();
 
+    // Directly passed URL is supported for backwards compatibility. R2DBC SPI does not provide
+    // the original URL when creating connection through ConnectionFactories.get(String).
     if (options.hasOption(URL)) {
       config.setUrl(options.getValue(URL));
+    } else if (options.hasOption(DATABASE) && FQDN_PATTERN_PARSE.matcher(options.getValue(DATABASE)).matches()) {
+      // URL-based connection configuration
+      config.setFullyQualifiedDatabaseName(options.getValue(DATABASE));
     } else {
+      // Programmatic connection configuration.
       config.setProjectId(options.getRequiredValue(PROJECT))
           .setInstanceName(options.getRequiredValue(INSTANCE))
           .setDatabaseName(options.getRequiredValue(DATABASE));

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -73,6 +73,9 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   public static final Option<Duration> DDL_OPERATION_POLL_INTERVAL =
       Option.valueOf("ddl_operation_poll_interval");
 
+  // TODO: GH-292
+  public static final Option<String> OPTIMIZER_VERSION =
+      Option.valueOf("optimizerVersion");
   /**
    * Option specifying the already-instantiated credentials object.
    */
@@ -84,6 +87,7 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
    */
   public static final Option<String> CREDENTIALS = Option.valueOf(CREDENTIALS_PROPERTY_NAME);
 
+  // TODO: GH-292
   /** Plain-text option used to connect to the emulator. */
   public static final Option<Boolean> USE_PLAIN_TEXT = Option.valueOf("usePlainText");
 
@@ -177,6 +181,10 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
 
     if (options.hasOption(USE_PLAIN_TEXT)) {
       config.setUsePlainText(true);
+    }
+
+    if (options.hasOption(OPTIMIZER_VERSION)) {
+      config.setOptimizerVersion(options.getValue(OPTIMIZER_VERSION));
     }
 
     return config.build();

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner.r2dbc;
 
-import static com.google.cloud.spanner.connection.ConnectionOptions.CREDENTIALS_PROPERTY_NAME;
-import static com.google.cloud.spanner.connection.ConnectionOptions.OAUTH_TOKEN_PROPERTY_NAME;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration.FQDN_PATTERN_PARSE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
@@ -82,17 +80,18 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   public static final Option<GoogleCredentials> GOOGLE_CREDENTIALS =
       Option.valueOf("google_credentials");
 
-  /** Option specifying the location of the GCP credentials file. Same as GOOGLE_CREDENTIALS,
+  /**
+   * Option specifying the location of the GCP credentials file. Same as GOOGLE_CREDENTIALS,
    * but consistent with the JDBC driver option.
    */
-  public static final Option<String> CREDENTIALS = Option.valueOf(CREDENTIALS_PROPERTY_NAME);
+  public static final Option<String> CREDENTIALS = Option.valueOf("credentials");
 
   // TODO: GH-292
   /** Plain-text option used to connect to the emulator. */
   public static final Option<Boolean> USE_PLAIN_TEXT = Option.valueOf("usePlainText");
 
   /** OAuth token to use for authentication. */
-  public static final Option<String> OAUTH_TOKEN = Option.valueOf(OAUTH_TOKEN_PROPERTY_NAME);
+  public static final Option<String> OAUTH_TOKEN = Option.valueOf("oauthToken");
 
   private static final Option[] SECURITY_OPTIONS =
       new Option[] { OAUTH_TOKEN, CREDENTIALS, GOOGLE_CREDENTIALS};

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -121,7 +121,8 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
     // the original URL when creating connection through ConnectionFactories.get(String).
     if (options.hasOption(URL)) {
       config.setUrl(options.getValue(URL));
-    } else if (options.hasOption(DATABASE) && FQDN_PATTERN_PARSE.matcher(options.getValue(DATABASE)).matches()) {
+    } else if (options.hasOption(DATABASE)
+        && FQDN_PATTERN_PARSE.matcher(options.getValue(DATABASE)).matches()) {
       // URL-based connection configuration
       config.setFullyQualifiedDatabaseName(options.getValue(DATABASE));
     } else {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -55,8 +55,17 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
   public AbstractSpannerClientLibraryStatement(
       DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
     this.clientLibraryAdapter = clientLibraryAdapter;
-    this.currentStatementBuilder = com.google.cloud.spanner.Statement.newBuilder(query);
     this.query = query;
+    this.currentStatementBuilder = createStatementBuilder();
+  }
+
+  private com.google.cloud.spanner.Statement.Builder createStatementBuilder() {
+    com.google.cloud.spanner.Statement.Builder builder =
+        com.google.cloud.spanner.Statement.newBuilder(this.query);
+    if (this.clientLibraryAdapter.getQueryOptions() != null) {
+      builder = builder.withQueryOptions(this.clientLibraryAdapter.getQueryOptions());
+    }
+    return builder;
   }
 
   @Override
@@ -66,7 +75,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
     }
 
     this.statements.add(this.currentStatementBuilder.build());
-    this.currentStatementBuilder = com.google.cloud.spanner.Statement.newBuilder(this.query);
+    this.currentStatementBuilder = createStatementBuilder();
     this.startedBinding = false;
 
     return this;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.r2dbc.statement.TypedNull;
+import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import java.util.ArrayList;
@@ -47,6 +48,8 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
 
   private final String query;
 
+  private final QueryOptions queryOptions;
+
   /**
    * Creates a ready-to-run Cloud Spanner statement.
    * @param clientLibraryAdapter client library implementation of core functionality
@@ -56,14 +59,18 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
       DatabaseClientReactiveAdapter clientLibraryAdapter, String query) {
     this.clientLibraryAdapter = clientLibraryAdapter;
     this.query = query;
-    this.currentStatementBuilder = createStatementBuilder();
+    this.queryOptions = this.clientLibraryAdapter.getQueryOptions();
+
+    this.currentStatementBuilder = createStatementBuilder(this.query, this.queryOptions);
   }
 
-  private com.google.cloud.spanner.Statement.Builder createStatementBuilder() {
+  private static com.google.cloud.spanner.Statement.Builder createStatementBuilder(
+      String query, QueryOptions options) {
+
     com.google.cloud.spanner.Statement.Builder builder =
-        com.google.cloud.spanner.Statement.newBuilder(this.query);
-    if (this.clientLibraryAdapter.getQueryOptions() != null) {
-      builder = builder.withQueryOptions(this.clientLibraryAdapter.getQueryOptions());
+        com.google.cloud.spanner.Statement.newBuilder(query);
+    if (options != null) {
+      builder = builder.withQueryOptions(options);
     }
     return builder;
   }
@@ -75,7 +82,7 @@ abstract class AbstractSpannerClientLibraryStatement implements Statement {
     }
 
     this.statements.add(this.currentStatementBuilder.build());
-    this.currentStatementBuilder = createStatementBuilder();
+    this.currentStatementBuilder = createStatementBuilder(this.query, this.queryOptions);
     this.startedBinding = false;
 
     return this;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -20,6 +20,7 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.CR
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.GOOGLE_CREDENTIALS;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.OPTIMIZER_VERSION;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PARTIAL_RESULT_SET_FETCH_SIZE;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PROJECT;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.URL;
@@ -299,7 +300,20 @@ public class SpannerConnectionFactoryProviderTest {
         .hasMessageContaining("Please provide at most one authentication option");
   }
 
+  @Test
+  public void passOptimizerVersion() {
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DATABASE, "projects/p/instances/i/databases/d")
+        .option(DRIVER, "spanner")
+        .option(GOOGLE_CREDENTIALS, this.mockCredentials)
+        .option(OPTIMIZER_VERSION, "2")
+        .build();
 
+    SpannerConnectionConfiguration config =
+        this.spannerConnectionFactoryProvider.createConfiguration(options);
+
+    assertEquals("2", config.getOptimizerVersion());
+  }
 
   private PartialResultSet makeBook(String odyssey) {
     return PartialResultSet.newBuilder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.CREDENTIALS;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.DRIVER_NAME;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.GOOGLE_CREDENTIALS;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.INSTANCE;
@@ -26,10 +27,14 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -70,6 +75,10 @@ public class SpannerConnectionFactoryProviderTest {
 
   Client mockClient;
 
+  CredentialsHelper mockCredentialsHelper;
+
+  GoogleCredentials mockCredentials;
+
   /**
    * Initializes unit under test with a mock {@link Client}.
    */
@@ -78,6 +87,12 @@ public class SpannerConnectionFactoryProviderTest {
     this.mockClient =  mock(Client.class);
     this.spannerConnectionFactoryProvider = new SpannerConnectionFactoryProvider();
     this.spannerConnectionFactoryProvider.setClient(this.mockClient);
+
+    this.mockCredentialsHelper = mock(CredentialsHelper.class);
+    this.spannerConnectionFactoryProvider.setCredentialsHelper(this.mockCredentialsHelper);
+
+    this.mockCredentials = mock(GoogleCredentials.class);
+
   }
 
   @Test
@@ -200,6 +215,91 @@ public class SpannerConnectionFactoryProviderTest {
     assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
 
   }
+
+  @Test
+  public void createFactoryFromUrlWithOauthCredentials() {
+
+    when(this.mockCredentialsHelper.getOauthCredentials(anyString()))
+        .thenReturn(this.mockCredentials);
+
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(
+        "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?oauthToken=ABC");
+    SpannerConnectionConfiguration config =
+        this.spannerConnectionFactoryProvider.createConfiguration(options);
+
+    assertEquals(this.mockCredentials, config.getCredentials());
+    verify(this.mockCredentialsHelper).getOauthCredentials("ABC");
+  }
+
+  @Test
+  public void createFactoryFromUrlWithGoogleCredentialsIncorrectType() {
+
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(
+        "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?google_credentials=ABC");
+    assertThatThrownBy(() -> this.spannerConnectionFactoryProvider.createConfiguration(options))
+        .isInstanceOf(ClassCastException.class)
+        .hasMessageContaining("class java.lang.String cannot be cast to class "
+            + "com.google.auth.oauth2.OAuth2Credentials");
+  }
+
+  @Test
+  public void createFactoryWithGoogleCredentialsRetainsThem() {
+
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DATABASE, "projects/p/instances/i/databases/d")
+        .option(DRIVER, "spanner")
+        .option(GOOGLE_CREDENTIALS, this.mockCredentials)
+        .build();
+
+    SpannerConnectionConfiguration config =
+        this.spannerConnectionFactoryProvider.createConfiguration(options);
+
+    assertEquals(this.mockCredentials, config.getCredentials());
+    verifyNoInteractions(this.mockCredentialsHelper);
+  }
+
+  @Test
+  public void createFactoryWithFileCredentials() {
+
+    when(this.mockCredentialsHelper.getFileCredentials(anyString()))
+        .thenReturn(this.mockCredentials);
+
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(
+        "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?credentials=ABCD");
+
+    SpannerConnectionConfiguration config =
+        this.spannerConnectionFactoryProvider.createConfiguration(options);
+
+    assertEquals(this.mockCredentials, config.getCredentials());
+    verify(this.mockCredentialsHelper).getFileCredentials("ABCD");
+  }
+
+  @Test
+  public void multipleAuthenticationMethodsDisallowed() {
+    String prefix = "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?";
+
+    assertThatThrownBy(() -> this.spannerConnectionFactoryProvider.createConfiguration(
+        ConnectionFactoryOptions.parse(prefix + "credentials=A&oauthToken=B")
+    )).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please provide at most one authentication option");
+  }
+
+  @Test
+  public void multipleAuthenticationMethodsDisallowedProgrammatic() {
+
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DATABASE, "projects/p/instances/i/databases/d")
+        .option(DRIVER, "spanner")
+        .option(GOOGLE_CREDENTIALS, this.mockCredentials)
+        .option(CREDENTIALS, "ABC")
+        .build();
+
+    assertThatThrownBy(() -> this.spannerConnectionFactoryProvider.createConfiguration(options)
+    ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please provide at most one authentication option");
+  }
+
+
 
   private PartialResultSet makeBook(String odyssey) {
     return PartialResultSet.newBuilder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -239,8 +239,7 @@ public class SpannerConnectionFactoryProviderTest {
         "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?google_credentials=ABC");
     assertThatThrownBy(() -> this.spannerConnectionFactoryProvider.createConfiguration(options))
         .isInstanceOf(ClassCastException.class)
-        .hasMessageContaining("class java.lang.String cannot be cast to class "
-            + "com.google.auth.oauth2.OAuth2Credentials");
+        .hasMessageContaining("com.google.auth.oauth2.OAuth2Credentials");
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryColumnMetadata;
 import com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryConnection;
+import com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryConnectionFactory;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
@@ -641,6 +642,15 @@ public class ClientLibraryBasedIT {
         .expectNext(1L)
         .as("strong read returns the inserted row after stale-read transaction terminates")
         .verifyComplete();
+  }
+
+  @Test
+  public void testConnectingThroughUrl() {
+    ConnectionFactory urlBasedConnectionFactory =
+        ConnectionFactories.get(DatabaseProperties.URL + "?client-implementation=client-library");
+
+    StepVerifier.create(urlBasedConnectionFactory.create())
+        .expectNextMatches(cf -> cf instanceof SpannerClientLibraryConnectionFactory);
   }
 
   private Publisher<Long> getFirstNumber(Result result) {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -20,12 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Value;
+import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import java.util.List;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,7 @@ public class AbstractSpannerClientLibraryStatementTest {
     when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(19L));
 
     when(this.mockAdapter.runBatchDml(anyList())).thenReturn(Mono.just(new long[] {7L, 11L, 13L}));
+    when(this.mockAdapter.getQueryOptions()).thenReturn(QueryOptions.getDefaultInstance());
   }
 
   @Test
@@ -61,7 +63,8 @@ public class AbstractSpannerClientLibraryStatementTest {
     verify(this.mockAdapter).runDmlStatement(capturedStatement.capture());
     assertThat(capturedStatement.getValue().getSql()).isEqualTo(query);
     assertThat(capturedStatement.getValue().getParameters()).isEmpty();
-    verifyNoMoreInteractions(this.mockAdapter);
+    verify(this.mockAdapter, times(0)).runSelectStatement(any());
+    verify(this.mockAdapter, times(0)).runBatchDml(any());
   }
 
   @Test
@@ -85,7 +88,8 @@ public class AbstractSpannerClientLibraryStatementTest {
         .containsEntry("one", Value.string("111"))
         .containsEntry("two", Value.string("222"))
         .containsEntry("three", Value.string("333"));
-    verifyNoMoreInteractions(this.mockAdapter);
+    verify(this.mockAdapter, times(0)).runSelectStatement(any());
+    verify(this.mockAdapter, times(0)).runBatchDml(any());
   }
 
   @Test
@@ -112,7 +116,8 @@ public class AbstractSpannerClientLibraryStatementTest {
         .containsEntry("two", Value.string("222"))
         .containsEntry("three", Value.string("333"));
 
-    verifyNoMoreInteractions(this.mockAdapter);
+    verify(this.mockAdapter, times(0)).runSelectStatement(any());
+    verify(this.mockAdapter, times(0)).runDmlStatement(any());
   }
 
   @Test
@@ -146,7 +151,8 @@ public class AbstractSpannerClientLibraryStatementTest {
         .containsEntry("two", Value.string("B222"))
         .containsEntry("three", Value.string("B333"));
 
-    verifyNoMoreInteractions(this.mockAdapter);
+    verify(this.mockAdapter, times(0)).runSelectStatement(any());
+    verify(this.mockAdapter, times(0)).runDmlStatement(any());
   }
 
   @Test
@@ -181,7 +187,8 @@ public class AbstractSpannerClientLibraryStatementTest {
         .containsEntry("two", Value.string("B222"))
         .containsEntry("three", Value.string("B333"));
 
-    verifyNoMoreInteractions(this.mockAdapter);
+    verify(this.mockAdapter, times(0)).runSelectStatement(any());
+    verify(this.mockAdapter, times(0)).runDmlStatement(any());
   }
 
   /* Exercises the mock `DatabaseClientReactiveAdapter`; return values don't matter */

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -17,16 +17,20 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
@@ -38,32 +42,35 @@ public class DatabaseClientReactiveAdapterTest {
 
   // DatabaseClientReactiveAdapter dependencies
   private SpannerConnectionConfiguration config;
-  private Spanner spannerClient;
-  private DatabaseClient dbClient;
-  private DatabaseAdminClient dbAdminClient;
-  private DatabaseClientTransactionManager txnManager;
+  private Spanner mockSpannerClient;
+  private DatabaseClient mockDbClient;
+  private DatabaseAdminClient mockDbAdminClient;
+  private DatabaseClientTransactionManager mockTxnManager;
   private ExecutorService executorService;
 
   private DatabaseClientReactiveAdapter adapter;
 
   @BeforeEach
   void setup() {
-    this.config = mock(SpannerConnectionConfiguration.class);
-    this.spannerClient = mock(Spanner.class);
-    this.dbClient = mock(DatabaseClient.class);
-    this.dbAdminClient = mock(DatabaseAdminClient.class);
-    this.txnManager = mock(DatabaseClientTransactionManager.class);
+    this.config =
+        new SpannerConnectionConfiguration.Builder()
+            .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
+            .setCredentials(mock(GoogleCredentials.class))
+            .build();
+
+    this.mockSpannerClient = mock(Spanner.class);
+    this.mockDbClient = mock(DatabaseClient.class);
+    this.mockDbAdminClient = mock(DatabaseAdminClient.class);
+    this.mockTxnManager = mock(DatabaseClientTransactionManager.class);
     this.executorService = Executors.newSingleThreadExecutor();
 
-    this.adapter = new DatabaseClientReactiveAdapter(
-        this.config,
-        this.spannerClient,
-        this.dbClient,
-        this.dbAdminClient,
-        this.executorService,
-        this.txnManager);
+    when(this.mockSpannerClient.getDatabaseClient(any())).thenReturn(this.mockDbClient);
+    when(this.mockSpannerClient.getDatabaseAdminClient()).thenReturn(this.mockDbAdminClient);
 
-    when(this.txnManager.commitTransaction()).thenReturn(ApiFutures.immediateFuture(null));
+    this.adapter = new DatabaseClientReactiveAdapter(this.mockSpannerClient, this.config);
+    this.adapter.setTxnManager(this.mockTxnManager);
+
+    when(this.mockTxnManager.commitTransaction()).thenReturn(ApiFutures.immediateFuture(null));
   }
 
   @AfterEach
@@ -73,23 +80,48 @@ public class DatabaseClientReactiveAdapterTest {
 
   @Test
   public void testChangeAutocommitCommitsCurrentTransaction() {
-    when(this.txnManager.isInTransaction()).thenReturn(true);
+    when(this.mockTxnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 
     // Toggle autocommit setting.
     Mono.from(this.adapter.setAutoCommit(false)).block();
     assertThat(this.adapter.isAutoCommit()).isFalse();
-    verify(this.txnManager, times(1)).commitTransaction();
+    verify(this.mockTxnManager, times(1)).commitTransaction();
   }
 
   @Test
   public void testSameAutocommitNoop() {
-    when(this.txnManager.isInTransaction()).thenReturn(true);
+    when(this.mockTxnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 
     // Toggle autocommit setting.
     Mono.from(this.adapter.setAutoCommit(true)).block();
     assertThat(this.adapter.isAutoCommit()).isTrue();
-    verify(this.txnManager, times(0)).commitTransaction();
+    verify(this.mockTxnManager, times(0)).commitTransaction();
+  }
+
+  @Test
+  public void unsetQueryOptimizerResultsInDefaultQueryOptions() {
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+        .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
+        .setCredentials(mock(GoogleCredentials.class))
+        .build();
+
+    DatabaseClientReactiveAdapter adapter =
+        new DatabaseClientReactiveAdapter(this.mockSpannerClient, this.config);
+    assertEquals(QueryOptions.getDefaultInstance(), adapter.getQueryOptions());
+  }
+
+  @Test
+  public void queryOptimizerPropagatesToQueryOptions() {
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+        .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
+        .setCredentials(mock(GoogleCredentials.class))
+        .setOptimizerVersion("2")
+        .build();
+
+    DatabaseClientReactiveAdapter adapter =
+        new DatabaseClientReactiveAdapter(this.mockSpannerClient, config);
+    assertEquals("2", adapter.getQueryOptions().getOptimizerVersion());
   }
 }


### PR DESCRIPTION
Getting this absolutely cursed (by Murphy's law, life, and random rabbitholes) PR out.

I still need to add `autocommit` and `readonly`.

Some properties are duplicated with the client library Connection API; those can be addressed incrementally. I'll also look to refactor a bit of Connection API's property initialization to avoid duplicate work of parsing with R2DBC SPI and then re-parsing in Connection API. But non of these is blocking for V2 release, seeing as Connection API is something of a nice-to-have.

Fixes #248. 