### PR TITLE
Remove unneeded logging

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatement.java
@@ -23,8 +23,6 @@ import io.r2dbc.spi.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -34,9 +32,6 @@ import reactor.core.publisher.Mono;
  * <p>Supports parameter binding.
  */
 abstract class AbstractSpannerClientLibraryStatement implements Statement {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(AbstractSpannerClientLibraryStatement.class);
 
   protected final DatabaseClientReactiveAdapter clientLibraryAdapter;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -150,7 +150,6 @@ class DatabaseClientReactiveAdapter {
     // TODO: if txn is committed/rolled back and then connection closed, clearTransactionManager
     // will run twice, causing trace span to be closed twice. Introduce `closed` field.
     return Mono.fromRunnable(() -> {
-      LOGGER.debug("  shutting down executor service");
       this.txnManager.clearTransactionManager();
       this.executorService.shutdown();
     });

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
@@ -103,7 +103,6 @@ class DatabaseClientTransactionManager {
    * Closes the read/write transaction manager and clears its state.
    */
   void clearTransactionManager() {
-    LOGGER.debug("close transaction manager");
     this.txnContextFuture = null;
     this.lastStep = null;
     if (this.transactionManager != null) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -27,14 +27,9 @@ import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.ValidationDepth;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 public class SpannerClientLibraryConnection implements Connection {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(SpannerClientLibraryConnection.class);
 
   private final DatabaseClientReactiveAdapter clientLibraryAdapter;
 
@@ -92,10 +87,8 @@ public class SpannerClientLibraryConnection implements Connection {
     }
     StatementType type = StatementParser.getStatementType(query);
     if (type == StatementType.DDL) {
-      LOGGER.debug("DDL statement detected: " + query);
       return new SpannerClientLibraryDdlStatement(query, this.clientLibraryAdapter);
     } else if (type == StatementType.DML) {
-      LOGGER.debug("DML statement detected: " + query);
       return new SpannerClientLibraryDmlStatement(this.clientLibraryAdapter, query);
     }
     return new SpannerClientLibraryStatement(this.clientLibraryAdapter, query);

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -18,8 +18,6 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -27,9 +25,6 @@ import reactor.core.publisher.Mono;
  * Cloud Spanner implementation of R2DBC SPI for SELECT query statements.
  */
 public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatement {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(SpannerClientLibraryStatement.class);
 
   /**
    * Creates a ready-to-run Cloud Spanner statement.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -111,6 +111,7 @@ public class SpannerConnectionFactoryProviderTest {
             .option(DRIVER, DRIVER_NAME)
             .option(URL, "r2dbc:spanner://spanner.googleapis.com:443/projects/"
                 + "myproject/instances/myinstance/databases/mydatabase")
+            .option(GOOGLE_CREDENTIALS, this.mockCredentials)
             .build();
 
     ConnectionFactory spannerConnectionFactory =


### PR DESCRIPTION
This logging was useful during active development but does not serve an end-user purpose. Logging can be added back as needed.

This PR also injects mock credentials to keep unit test from interacting with environment

Fixes #261.