### PR TITLE
Restrict visibility of public V2 implementation classes

### DIFF
--- a/cloud-spanner-r2dbc/README_v2.adoc
+++ b/cloud-spanner-r2dbc/README_v2.adoc
@@ -85,14 +85,14 @@ Mono.from(connectionFactory.create())
 ```
 
 ### Read-Only Transactions
-Read-only transactions, including stale transactions, can be used by downcasting the `Connection` object to `SpannerClientLibraryConnection` and calling `beginReadonlyTransaction()` on it.
+Read-only transactions, including stale transactions, can be used by downcasting the `Connection` object to `com.google.cloud.spanner.r2dbc.api.SpannerConnection` and calling `beginReadonlyTransaction()` on it.
 Invoking `beginReadonlyTransaction()` without parameters will begin a new strongly consistent readonly transaction.
 To customize staleness, pass in a `TimestampBound` parameter.
 ```java
 Mono.from(connectionFactory.create())
             .flatMapMany(c ->
                 Flux.concat(
-                          conn.beginReadonlyTransaction(TimestampBound.ofExactStaleness(1, TimeUnit.SECONDS)),
+                          ((SpannerConnection) conn).beginReadonlyTransaction(TimestampBound.ofExactStaleness(1, TimeUnit.SECONDS)),
                             ...
                           conn.commitTransaction(),
                     )

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/BindingFailureException.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/BindingFailureException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spanner.r2dbc.v2;
+package com.google.cloud.spanner.r2dbc;
 
 import io.r2dbc.spi.R2dbcNonTransientException;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/ConversionFailureException.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/ConversionFailureException.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spanner.r2dbc.v2.conversion;
+package com.google.cloud.spanner.r2dbc;
 
-public interface SpannerClientLibrariesConverter<T> {
+import io.r2dbc.spi.R2dbcNonTransientException;
 
-  boolean canConvert(Class<?> inputClass, Class<?> resultClass);
+public class ConversionFailureException extends R2dbcNonTransientException {
 
-  T convert(Object input);
-
+  public ConversionFailureException(String message) {
+    super(message);
+  }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/TransactionInProgressException.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/TransactionInProgressException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 Google LLC
+ * Copyright 2020-2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spanner.r2dbc.v2;
+package com.google.cloud.spanner.r2dbc;
 
 import io.r2dbc.spi.R2dbcNonTransientException;
 
-public class ConversionFailureException extends R2dbcNonTransientException {
+public class TransactionInProgressException extends R2dbcNonTransientException {
 
-  public ConversionFailureException(String message) {
-    super(message);
+  public static final String MSG_READONLY =
+      "Cannot begin a new transaction because a readonly transaction is already in progress.";
+  public static final String MSG_READWRITE =
+      "Cannot begin a new transaction because a read/write transaction is already in progress.";
+
+  public TransactionInProgressException(boolean isReadwrite) {
+    super(isReadwrite ? MSG_READWRITE : MSG_READONLY);
   }
+
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
@@ -19,6 +19,13 @@ package com.google.cloud.spanner.r2dbc.api;
 import com.google.cloud.spanner.TimestampBound;
 import reactor.core.publisher.Mono;
 
+/**
+ * Interface representing custom Cloud Spanner Connection transaction options that do not fit the
+ * current R2DBC SPI model.
+ *
+ * <p>Cast a Cloud Spanner-provided `Connection` object to this interface to take advantage of the
+ * readonly transaction types: read-only strongly consistent and read-only stale.
+ */
 public interface SpannerConnection {
   /**
    * Allows starting a readonly Cloud Spanner transaction with given staleness settings.

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.api;
+
+import com.google.cloud.spanner.TimestampBound;
+import reactor.core.publisher.Mono;
+
+public interface SpannerConnection {
+  /**
+   * Allows starting a readonly Cloud Spanner transaction with given staleness settings.
+   * @param timestampBound staleness settings
+   * @return {@link Mono} signaling readonly transaction is ready for use
+   */
+  Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound);
+
+  /**
+   * Allows starting a readonly Cloud Spanner transaction with strong consistency.
+   * @return {@link Mono} signaling readonly transaction is ready for use
+   */
+  Mono<Void> beginReadonlyTransaction();
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
@@ -20,6 +20,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.r2dbc.BindingFailureException;
 import com.google.cloud.spanner.r2dbc.statement.TypedNull;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import java.math.BigDecimal;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoder.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-public class ClientLibraryDecoder {
+class ClientLibraryDecoder {
   private static final Map<Type, BiFunction<Struct, Integer, Object>> decodersMap =
       createDecoders();
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
@@ -18,7 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement.Builder;
 
-public interface ClientLibraryTypeBinder<T> {
+interface ClientLibraryTypeBinder<T> {
 
   /**
    * Indicates if the binder can bind a value of a given type.

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinderImpl.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinderImpl.java
@@ -21,7 +21,7 @@ import com.google.cloud.spanner.ValueBinder;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import java.util.function.BiConsumer;
 
-public class ClientLibraryTypeBinderImpl<T> implements ClientLibraryTypeBinder<T> {
+class ClientLibraryTypeBinderImpl<T> implements ClientLibraryTypeBinder<T> {
 
   private Class<T> type;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -76,7 +76,7 @@ class DatabaseClientReactiveAdapter {
    * @param spannerClient Cloud Spanner client used to run queries and manage transactions
    * @param config User-provided connection configuration options
    */
-  public DatabaseClientReactiveAdapter(
+  DatabaseClientReactiveAdapter(
       Spanner spannerClient,
       SpannerConnectionConfiguration config) {
     this.spannerClient = spannerClient;
@@ -99,7 +99,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for starting a transaction
    */
-  public Mono<Void> beginTransaction() {
+  Mono<Void> beginTransaction() {
     return convertFutureToMono(() -> this.txnManager.beginTransaction()).then();
   }
 
@@ -108,7 +108,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for starting a transaction
    */
-  public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
+  Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
 
     return Mono.defer(() -> {
       this.txnManager.beginReadonlyTransaction(timestampBound);
@@ -123,7 +123,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for committing a transaction
    */
-  public Mono<Void> commitTransaction() {
+  Mono<Void> commitTransaction() {
     return convertFutureToMono(() -> this.txnManager.commitTransaction())
         .doOnTerminate(this.txnManager::clearTransactionManager)
         .then();
@@ -134,7 +134,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for rolling back a transaction
    */
-  public Publisher<Void> rollback() {
+  Publisher<Void> rollback() {
     return convertFutureToMono(() -> this.txnManager.rollbackTransaction())
         .doOnTerminate(this.txnManager::clearTransactionManager);
   }
@@ -146,7 +146,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for closing the connection.
    */
-  public Mono<Void> close() {
+  Mono<Void> close() {
     // TODO: if txn is committed/rolled back and then connection closed, clearTransactionManager
     // will run twice, causing trace span to be closed twice. Introduce `closed` field.
     return Mono.fromRunnable(() -> {
@@ -160,7 +160,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return true if the connection is working, false if not.
    */
-  public Mono<Boolean> healthCheck() {
+  Mono<Boolean> healthCheck() {
     return Mono.defer(() -> {
       if (this.executorService.isShutdown() || this.spannerClient.isClosed()) {
         return Mono.just(false);
@@ -183,11 +183,11 @@ class DatabaseClientReactiveAdapter {
     return Mono.fromSupplier(() -> !this.executorService.isShutdown());
   }
 
-  public boolean isAutoCommit() {
+  boolean isAutoCommit() {
     return this.autoCommit;
   }
 
-  public Publisher<Void> setAutoCommit(boolean autoCommit) {
+  Publisher<Void> setAutoCommit(boolean autoCommit) {
     return Mono.defer(() -> {
       Mono<Void> result = Mono.empty();
       if (this.autoCommit != autoCommit && this.txnManager.isInTransaction()) {
@@ -205,7 +205,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for running a DML statement
    */
-  public Mono<Long> runDmlStatement(com.google.cloud.spanner.Statement statement) {
+  Mono<Long> runDmlStatement(com.google.cloud.spanner.Statement statement) {
     return runBatchDmlInternal(ctx -> ctx.executeUpdateAsync(statement));
   }
 
@@ -216,7 +216,7 @@ class DatabaseClientReactiveAdapter {
    *
    * @return reactive pipeline for running the provided DML statements
    */
-  public Mono<long[]> runBatchDml(List<Statement> statements) {
+  Mono<long[]> runBatchDml(List<Statement> statements) {
     return runBatchDmlInternal(ctx -> ctx.batchUpdateAsync(statements));
   }
 
@@ -245,7 +245,7 @@ class DatabaseClientReactiveAdapter {
     });
   }
 
-  public Flux<SpannerClientLibraryRow> runSelectStatement(
+  Flux<SpannerClientLibraryRow> runSelectStatement(
       com.google.cloud.spanner.Statement statement) {
     return Flux.create(
         sink -> {
@@ -257,7 +257,7 @@ class DatabaseClientReactiveAdapter {
         });
   }
 
-  public Mono<Void> runDdlStatement(String query) {
+  Mono<Void> runDdlStatement(String query) {
     return convertFutureToMono(() -> this.dbAdminClient.updateDatabaseDdl(
         this.config.getInstanceName(),
         this.config.getDatabaseName(),
@@ -329,7 +329,7 @@ class DatabaseClientReactiveAdapter {
         });
   }
 
-  public QueryOptions getQueryOptions() {
+  QueryOptions getQueryOptions() {
     return this.queryOptions;
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
@@ -26,6 +26,7 @@ import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.r2dbc.TransactionInProgressException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import org.slf4j.Logger;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/LongIntegerConverter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/LongIntegerConverter.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spanner.r2dbc.v2.conversion;
+package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.r2dbc.v2.ConversionFailureException;
+import com.google.cloud.spanner.r2dbc.ConversionFailureException;
 
-public class LongIntegerConverter implements SpannerClientLibrariesConverter<Integer> {
+class LongIntegerConverter implements SpannerClientLibrariesConverter<Integer> {
 
   @Override
   public boolean canConvert(Class<?> inputClass, Class<?> resultClass) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibrariesConverter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibrariesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 Google LLC
+ * Copyright 2019-2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,10 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import io.r2dbc.spi.R2dbcNonTransientException;
+public interface SpannerClientLibrariesConverter<T> {
 
-public class TransactionInProgressException extends R2dbcNonTransientException {
+  boolean canConvert(Class<?> inputClass, Class<?> resultClass);
 
-  public static final String MSG_READONLY =
-      "Cannot begin a new transaction because a readonly transaction is already in progress.";
-  public static final String MSG_READWRITE =
-      "Cannot begin a new transaction because a read/write transaction is already in progress.";
-
-  public TransactionInProgressException(boolean isReadwrite) {
-    super(isReadwrite ? MSG_READWRITE : MSG_READONLY);
-  }
+  T convert(Object input);
 
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryColumnMetadata.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryColumnMetadata.java
@@ -24,11 +24,11 @@ import java.util.Objects;
 /**
  * {@link ColumnMetadata} implementation for Cloud Spanner.
  */
-public class SpannerClientLibraryColumnMetadata implements ColumnMetadata {
+class SpannerClientLibraryColumnMetadata implements ColumnMetadata {
 
   private final StructField structField;
 
-  public SpannerClientLibraryColumnMetadata(StructField structField) {
+  SpannerClientLibraryColumnMetadata(StructField structField) {
     this.structField = structField;
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.api.SpannerConnection;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
 import io.r2dbc.spi.Batch;
@@ -29,7 +30,7 @@ import io.r2dbc.spi.ValidationDepth;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
-public class SpannerClientLibraryConnection implements Connection {
+class SpannerClientLibraryConnection implements Connection, SpannerConnection {
 
   private final DatabaseClientReactiveAdapter clientLibraryAdapter;
 
@@ -48,19 +49,12 @@ public class SpannerClientLibraryConnection implements Connection {
     return this.clientLibraryAdapter.beginTransaction();
   }
 
-  /**
-   * Allows starting a readonly Cloud Spanner transaction with given staleness settings.
-   * @param timestampBound staleness settings
-   * @return {@link Mono} signaling readonly transaction is ready for use
-   */
+  @Override
   public Mono<Void> beginReadonlyTransaction(TimestampBound timestampBound) {
     return this.clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
   }
 
-  /**
-   * Allows starting a readonly Cloud Spanner transaction with strong consistency.
-   * @return {@link Mono} signaling readonly transaction is ready for use
-   */
+  @Override
   public Mono<Void> beginReadonlyTransaction() {
     return this.clientLibraryAdapter.beginReadonlyTransaction(TimestampBound.strong());
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConverters.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConverters.java
@@ -16,8 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import com.google.cloud.spanner.r2dbc.v2.conversion.LongIntegerConverter;
-import com.google.cloud.spanner.r2dbc.v2.conversion.SpannerClientLibrariesConverter;
+import com.google.cloud.spanner.r2dbc.ConversionFailureException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatement.java
@@ -22,7 +22,7 @@ import io.r2dbc.spi.Statement;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class SpannerClientLibraryDdlStatement implements Statement {
+class SpannerClientLibraryDdlStatement implements Statement {
 
   private String query;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
 /**
  * Cloud Spanner implementation of R2DBC SPI for DML statements.
  */
-public class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryStatement {
+class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryStatement {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SpannerClientLibraryDmlStatement.class);

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-public class SpannerClientLibraryResult implements Result {
+class SpannerClientLibraryResult implements Result {
 
   private final Flux<SpannerClientLibraryRow> resultRows;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRow.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRow.java
@@ -21,7 +21,7 @@ import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
 
-public class SpannerClientLibraryRow implements Row {
+class SpannerClientLibraryRow implements Row {
   private Struct rowFields;
 
   public SpannerClientLibraryRow(Struct rowFields) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadata.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadata.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * {@link RowMetadata} implementation for Cloud Spanner.
  */
-public class SpannerClientLibraryRowMetadata implements RowMetadata {
+class SpannerClientLibraryRowMetadata implements RowMetadata {
 
   private final List<ColumnMetadata> columnMetadatas;
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 /**
  * Cloud Spanner implementation of R2DBC SPI for SELECT query statements.
  */
-public class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatement {
+class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatement {
 
   /**
    * Creates a ready-to-run Cloud Spanner statement.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoderTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.r2dbc.ConversionFailureException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.r2dbc.TransactionInProgressException;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import io.r2dbc.spi.Connection;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 public class SpannerClientLibraryConnectionFactoryTest {
 
@@ -52,5 +54,14 @@ public class SpannerClientLibraryConnectionFactoryTest {
 
     // The version suffix is not available until code is packaged as a JAR.
     assertThat(options.getUserAgent()).startsWith("cloud-spanner-r2dbc/");
+  }
+
+  @Test
+  public void testSessionCreation() {
+    SpannerClientLibraryConnectionFactory cf =
+        new SpannerClientLibraryConnectionFactory(this.configBuilder.build());
+    Connection conn = Mono.from(cf.create()).block();
+
+    assertThat(conn).isInstanceOf(SpannerClientLibraryConnection.class);
   }
 }


### PR DESCRIPTION
This PR restricts visibility of most v2 implementation classes because in the future, `.v2` package contents will move one level up, so nobody should be relying on the `.v2` classes directly. I moved type conversion classes up a level into `.v2` package to be able to reduce their visibility, too.

The only public class left is `SpannerClientLibraryConnectionFactory`, which needs to be visible to `SpannerConnectionFactoryProvider`. 

I moved all V2 exceptions up a level, since those have a legit reason to being referenced by end users.

Since we need to give users access to custom `SpannerClientLibraryConnection` methods for creating readonly transactions, `com.google.cloud.spanner.r2dbc.api.SpannerConnection` is a new interface allowing access to those methods without exposing `SpannerClientLibraryConnection` itself.

There are also a couple of integration tests that were referring to internal implementation details, so I moved one to become a unit test, and refactored the other to rely on SPI methods instead.

