### PR TITLE
Inline formerly parameterized test

### DIFF
--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -49,12 +49,13 @@ class ClientLibraryTypeBindersTest {
 
   @Test
   void unsupportedTypeThrowsException() {
-    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", new Random()))
+    Random rand = new Random();
+    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", rand))
         .isInstanceOf(BindingFailureException.class)
         .hasMessageContaining("Can't find a binder for type: class java.util.Random");
 
-    assertThatThrownBy(() ->
-        ClientLibraryBinder.bind(this.statementBuilder, "a", new TypedNull(Random.class)))
+    TypedNull randNull = new TypedNull(Random.class);
+    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", randNull))
         .isInstanceOf(BindingFailureException.class)
         .hasMessageContaining("Can't find a binder for type: class java.util.Random");
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.ByteArray;
@@ -26,15 +27,12 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Statement.Builder;
 import com.google.cloud.spanner.ValueBinder;
+import com.google.cloud.spanner.r2dbc.BindingFailureException;
 import com.google.cloud.spanner.r2dbc.statement.TypedNull;
 import java.math.BigDecimal;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
+import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 class ClientLibraryTypeBindersTest {
@@ -49,74 +47,106 @@ class ClientLibraryTypeBindersTest {
     when(this.statementBuilder.bind(anyString())).thenReturn(this.valueBinder);
   }
 
-  /** Prepare parameters for parametrized test. */
-  static Stream<Arguments> data() {
-    return Stream.of(
-        arguments(
-            Long.class,
-            1L,
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((Long) val)),
-        arguments(
-            Double.class,
-            2.0d,
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((Double) val)),
-        arguments(
-            Boolean.class,
-            true,
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((Boolean) val)),
-        arguments(
-            ByteArray.class,
-            ByteArray.copyFrom("abc"),
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((ByteArray) val)),
-        arguments(
-            Date.class,
-            Date.fromYearMonthDay(1992, 12, 31),
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((Date) val)),
-        arguments(
-            String.class,
-            "abc",
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((String) val)),
-        arguments(
-            Timestamp.class,
-            Timestamp.ofTimeMicroseconds(123456),
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((Timestamp) val)),
-        arguments(
-            BigDecimal.class,
-            BigDecimal.TEN,
-            (BiConsumer<ValueBinder, Object>) (binder, val) -> binder.to((BigDecimal) val))
-    );
+  @Test
+  void unsupportedTypeThrowsException() {
+    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", new Random()))
+        .isInstanceOf(BindingFailureException.class)
+        .hasMessageContaining("Can't find a binder for type: class java.util.Random");
+
+    assertThatThrownBy(() ->
+        ClientLibraryBinder.bind(this.statementBuilder, "a", new TypedNull(Random.class)))
+        .isInstanceOf(BindingFailureException.class)
+        .hasMessageContaining("Can't find a binder for type: class java.util.Random");
   }
 
-  /** Validates that every supported type binds successfully. */
-  @ParameterizedTest
-  @MethodSource("data")
-  <T> void binderTest(Class<T> type, Object value, BiConsumer<ValueBinder, Object> verifyer) {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", value);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(type));
+  @Test
+  void longBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", 1L);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Long.class));
+    verify(this.valueBinder).to((Long) 1L);
+    verify(this.valueBinder).to((Long) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
 
-    ValueBinder instrumentedBinder = Mockito.verify(this.valueBinder, times(1));
-    verifyer.accept(instrumentedBinder, value);
+  @Test
+  void doubleBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", 2.0);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Double.class));
+    verify(this.valueBinder).to((Double) 2.0);
+    verify(this.valueBinder).to((Double) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
 
-    instrumentedBinder = Mockito.verify(this.valueBinder, times(1));
-    verifyer.accept(instrumentedBinder, null);
+  @Test
+  void booleanBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", true);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Boolean.class));
+    verify(this.valueBinder).to((Boolean) true);
+    verify(this.valueBinder).to((Boolean) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
 
-    Mockito.verifyNoMoreInteractions(this.valueBinder);
+  @Test
+  void byteArrayBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", ByteArray.copyFrom("abc"));
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(ByteArray.class));
+    verify(this.valueBinder).to(ByteArray.copyFrom("abc"));
+    verify(this.valueBinder).to((ByteArray) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void dateBinderTest() {
+    Date date = Date.fromYearMonthDay(1992, 12, 31);
+    ClientLibraryBinder.bind(this.statementBuilder, "a", date);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Date.class));
+    verify(this.valueBinder).to(date);
+    verify(this.valueBinder).to((Date) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void stringBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", "abc");
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(String.class));
+    verify(this.valueBinder).to("abc");
+    verify(this.valueBinder).to((String) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void timestampBinderTest() {
+    Timestamp ts = Timestamp.ofTimeMicroseconds(123456);
+    ClientLibraryBinder.bind(this.statementBuilder, "a", ts);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Timestamp.class));
+    verify(this.valueBinder).to(ts);
+    verify(this.valueBinder).to((Timestamp) null);
+    verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void bigDecimalBinderTest() {
+    ClientLibraryBinder.bind(this.statementBuilder, "a", BigDecimal.TEN);
+    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(BigDecimal.class));
+    verify(this.valueBinder).to(BigDecimal.TEN);
+    verify(this.valueBinder).to((BigDecimal) null);
+    verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   public void integerBindsAsLong() {
 
     ClientLibraryBinder.bind(this.statementBuilder, "a", 123);
-    Mockito.verify(this.valueBinder).to((Long) 123L);
-    Mockito.verifyNoMoreInteractions(this.valueBinder);
+    verify(this.valueBinder).to((Long) 123L);
+    verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   public void integerNullBindsAsLong() {
 
     ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Integer.class));
-    Mockito.verify(this.valueBinder).to((Long) null);
-    Mockito.verifyNoMoreInteractions(this.valueBinder);
+    verify(this.valueBinder).to((Long) null);
+    verifyNoMoreInteractions(this.valueBinder);
 
   }
 


### PR DESCRIPTION
Sonar got confused at whether `instrumentedBinder` ever got asserted. And I had to actually think about whether it did!
This was a cleverly done parameterized test, but the inlined basic tests are only a few more lines of code while being really easy to read.

I also added `unsupportedTypeThrowsException()`, which was a path not tested before. 