### PR TITLE
Sonar "critical" smells

### DIFF
--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/client/GrpcClient.java
@@ -88,6 +88,8 @@ public class GrpcClient implements Client {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcClient.class);
 
+  private static final String SESSION_NAME_MUST_NOT_BE_NULL = "Session name must not be null";
+
   private final ManagedChannel channel;
   private final SpannerStub spanner;
   private final DatabaseAdminStub databaseAdmin;
@@ -133,7 +135,7 @@ public class GrpcClient implements Client {
       String sessionName, TransactionOptions transactionOptions) {
 
     return Mono.defer(() -> {
-      Assert.requireNonNull(sessionName, "Session name must not be null");
+      Assert.requireNonNull(sessionName, SESSION_NAME_MUST_NOT_BE_NULL);
       BeginTransactionRequest beginTransactionRequest =
           BeginTransactionRequest.newBuilder()
               .setSession(sessionName)
@@ -148,7 +150,7 @@ public class GrpcClient implements Client {
   @Override
   public Mono<CommitResponse> commitTransaction(String sessionName, Transaction transaction) {
     return Mono.defer(() -> {
-      Assert.requireNonNull(sessionName, "Session name must not be null");
+      Assert.requireNonNull(sessionName, SESSION_NAME_MUST_NOT_BE_NULL);
       Assert.requireNonEmpty(transaction.getId(), "Transaction ID must not be empty");
 
       CommitRequest commitRequest =
@@ -165,7 +167,7 @@ public class GrpcClient implements Client {
   @Override
   public Mono<Void> rollbackTransaction(String sessionName, Transaction transaction) {
     return Mono.defer(() -> {
-      Assert.requireNonNull(sessionName, "Session name must not be null");
+      Assert.requireNonNull(sessionName, SESSION_NAME_MUST_NOT_BE_NULL);
       Assert.requireNonEmpty(transaction.getId(), "Transaction ID must not be empty");
 
       RollbackRequest rollbackRequest =
@@ -196,7 +198,7 @@ public class GrpcClient implements Client {
   @Override
   public Mono<Void> deleteSession(String sessionName) {
     return Mono.defer(() -> {
-      Assert.requireNonNull(sessionName, "Session name must not be null");
+      Assert.requireNonNull(sessionName, SESSION_NAME_MUST_NOT_BE_NULL);
 
       DeleteSessionRequest deleteSessionRequest =
           DeleteSessionRequest.newBuilder()
@@ -264,7 +266,7 @@ public class GrpcClient implements Client {
       Map<String, Type> types) {
 
     return Flux.defer(() -> {
-      Assert.requireNonNull(ctx.getSessionName(), "Session name must not be null");
+      Assert.requireNonNull(ctx.getSessionName(), SESSION_NAME_MUST_NOT_BE_NULL);
 
       ExecuteSqlRequest.Builder executeSqlRequest = buildSqlRequest(ctx, sql);
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -21,6 +21,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
+import com.google.cloud.spanner.AsyncResultSet.ReadyCallback;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -286,25 +287,36 @@ class DatabaseClientReactiveAdapter {
 
     return ars.setCallback(
         this.executorService,
-        resultSet -> {
-          // TODO: handle backpressure by asking callback to signal CallbackResponse.PAUSE
-          try {
-            switch (resultSet.tryNext()) {
-              case DONE:
-                sink.complete();
-                return CallbackResponse.DONE;
-              case OK:
-                sink.next(new SpannerClientLibraryRow(resultSet.getCurrentRowAsStruct()));
-                return CallbackResponse.CONTINUE;
-              default:
-                // ResultSet returning NOT_READY or null.
-                return CallbackResponse.CONTINUE;
-            }
-          } catch (Throwable t) {
-            sink.error(t);
+        new ResultSetReadyCallback(sink));
+  }
+
+  static class ResultSetReadyCallback implements ReadyCallback {
+    private FluxSink<SpannerClientLibraryRow> sink;
+
+    ResultSetReadyCallback(FluxSink<SpannerClientLibraryRow> sink) {
+      this.sink = sink;
+    }
+
+    @Override
+    public CallbackResponse cursorReady(AsyncResultSet resultSet) {
+      // TODO: handle backpressure by asking callback to signal CallbackResponse.PAUSE
+      try {
+        switch (resultSet.tryNext()) {
+          case DONE:
+            this.sink.complete();
             return CallbackResponse.DONE;
-          }
-        });
+          case OK:
+            this.sink.next(new SpannerClientLibraryRow(resultSet.getCurrentRowAsStruct()));
+            return CallbackResponse.CONTINUE;
+          default:
+            // ResultSet returning NOT_READY or null.
+            return CallbackResponse.CONTINUE;
+        }
+      } catch (Throwable t) {
+        this.sink.error(t);
+        return CallbackResponse.DONE;
+      }
+    }
   }
 
   private <T> Mono<T> convertFutureToMono(Supplier<ApiFuture<T>> futureSupplier) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -293,11 +293,11 @@ class DatabaseClientReactiveAdapter {
               case DONE:
                 sink.complete();
                 return CallbackResponse.DONE;
-              case NOT_READY:
-              default:
-                return CallbackResponse.CONTINUE;
               case OK:
                 sink.next(new SpannerClientLibraryRow(resultSet.getCurrentRowAsStruct()));
+                return CallbackResponse.CONTINUE;
+              default:
+                // ResultSet returning NOT_READY or null.
                 return CallbackResponse.CONTINUE;
             }
           } catch (Throwable t) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AsyncTransactionManager;
 import com.google.cloud.spanner.AsyncTransactionManager.AsyncTransactionStep;
 import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
@@ -117,7 +118,7 @@ class DatabaseClientTransactionManager {
    *
    * @return chainable {@link ApiFuture} for commit status.
    */
-  ApiFuture<? extends Object> commitTransaction() {
+  ApiFuture<Timestamp> commitTransaction() {
     if (isInReadWriteTransaction()) {
       if (this.lastStep == null) {
         LOGGER.warn("Read/Write transaction committing without any statements.");

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -142,7 +142,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void resultSetReadyCallbackStopsSinkOnCompletion() {
+  void resultSetReadyCallbackStopsSinkOnCompletion() {
     when(this.mockResultSet.tryNext()).thenReturn(CursorState.DONE);
 
     DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
@@ -155,7 +155,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void resultSetReadyCallbackEmitsOnOk() {
+  void resultSetReadyCallbackEmitsOnOk() {
     when(this.mockResultSet.tryNext()).thenReturn(CursorState.OK);
     Struct struct = Struct.newBuilder().add(Value.string("some result")).build();
     when(this.mockResultSet.getCurrentRowAsStruct()).thenReturn(struct);
@@ -174,7 +174,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void resultSetReadyCallbackWaitsOnNotReady() {
+  void resultSetReadyCallbackWaitsOnNotReady() {
     when(this.mockResultSet.tryNext()).thenReturn(CursorState.NOT_READY);
 
     DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
@@ -186,7 +186,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void resultSetReadyCallbackSendsErrorOnException() {
+  void resultSetReadyCallbackSendsErrorOnException() {
     Exception exception = new RuntimeException("boom");
     when(this.mockResultSet.tryNext()).thenThrow(exception);
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -22,20 +22,29 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spanner.AsyncResultSet;
+import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
+import com.google.cloud.spanner.AsyncResultSet.CursorState;
 import com.google.cloud.spanner.DatabaseAdminClient;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.v2.DatabaseClientReactiveAdapter.ResultSetReadyCallback;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 public class DatabaseClientReactiveAdapterTest {
@@ -47,6 +56,10 @@ public class DatabaseClientReactiveAdapterTest {
   private DatabaseAdminClient mockDbAdminClient;
   private DatabaseClientTransactionManager mockTxnManager;
   private ExecutorService executorService;
+
+  private FluxSink mockSink;
+  private AsyncResultSet mockResultSet;
+
 
   private DatabaseClientReactiveAdapter adapter;
 
@@ -71,6 +84,9 @@ public class DatabaseClientReactiveAdapterTest {
     this.adapter.setTxnManager(this.mockTxnManager);
 
     when(this.mockTxnManager.commitTransaction()).thenReturn(ApiFutures.immediateFuture(null));
+
+    this.mockSink =  mock(FluxSink.class);
+    this.mockResultSet = mock(AsyncResultSet.class);
   }
 
   @AfterEach
@@ -123,5 +139,63 @@ public class DatabaseClientReactiveAdapterTest {
     DatabaseClientReactiveAdapter adapter =
         new DatabaseClientReactiveAdapter(this.mockSpannerClient, config);
     assertEquals("2", adapter.getQueryOptions().getOptimizerVersion());
+  }
+
+  @Test
+  public void resultSetReadyCallbackStopsSinkOnCompletion() {
+    when(this.mockResultSet.tryNext()).thenReturn(CursorState.DONE);
+
+    DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
+        new ResultSetReadyCallback(this.mockSink);
+    CallbackResponse response = cb.cursorReady(this.mockResultSet);
+
+    assertThat(response).isSameAs(CallbackResponse.DONE);
+    verify(this.mockSink).complete();
+    verifyNoMoreInteractions(this.mockSink);
+  }
+
+  @Test
+  public void resultSetReadyCallbackEmitsOnOk() {
+    when(this.mockResultSet.tryNext()).thenReturn(CursorState.OK);
+    Struct struct = Struct.newBuilder().add(Value.string("some result")).build();
+    when(this.mockResultSet.getCurrentRowAsStruct()).thenReturn(struct);
+
+    DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
+        new ResultSetReadyCallback(this.mockSink);
+    CallbackResponse response = cb.cursorReady(this.mockResultSet);
+
+    assertThat(response).isSameAs(CallbackResponse.CONTINUE);
+    ArgumentCaptor<SpannerClientLibraryRow> arg =
+        ArgumentCaptor.forClass(SpannerClientLibraryRow.class);
+    verify(this.mockSink).next(arg.capture());
+    assertThat(arg.getValue().get(1)).isEqualTo("some result");
+
+    verifyNoMoreInteractions(this.mockSink);
+  }
+
+  @Test
+  public void resultSetReadyCallbackWaitsOnNotReady() {
+    when(this.mockResultSet.tryNext()).thenReturn(CursorState.NOT_READY);
+
+    DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
+        new ResultSetReadyCallback(this.mockSink);
+    CallbackResponse response = cb.cursorReady(this.mockResultSet);
+
+    assertThat(response).isSameAs(CallbackResponse.CONTINUE);
+    verifyNoMoreInteractions(this.mockSink);
+  }
+
+  @Test
+  public void resultSetReadyCallbackSendsErrorOnException() {
+    Exception exception = new RuntimeException("boom");
+    when(this.mockResultSet.tryNext()).thenThrow(exception);
+
+    DatabaseClientReactiveAdapter.ResultSetReadyCallback cb =
+        new ResultSetReadyCallback(this.mockSink);
+    CallbackResponse response = cb.cursorReady(this.mockResultSet);
+
+    assertThat(response).isSameAs(CallbackResponse.DONE);
+    verify(this.mockSink).error(exception);
+    verifyNoMoreInteractions(this.mockSink);
   }
 }

--- a/cloud-spanner-spring-data-r2dbc/pom.xml
+++ b/cloud-spanner-spring-data-r2dbc/pom.xml
@@ -29,12 +29,6 @@
       <version>${spring-data-r2dbc.version}</version>
     </dependency>
 
-    <!-- facilitate project ID discovery in integration tests -->
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
@@ -29,20 +29,22 @@ public class SpannerR2dbcDialect extends AbstractDialect implements R2dbcDialect
   private static final BindMarkersFactory NAMED =
       BindMarkersFactory.named("@", "val", 32);
 
+  public static final String LIMIT = "LIMIT ";
+
   private static final LimitClause LIMIT_CLAUSE = new LimitClause() {
     @Override
     public String getLimit(long limit) {
-      return "LIMIT " + limit;
+      return LIMIT + limit;
     }
 
     @Override
     public String getOffset(long offset) {
-      return "LIMIT " + Long.MAX_VALUE + " OFFSET " + offset;
+      return LIMIT + Long.MAX_VALUE + " OFFSET " + offset;
     }
 
     @Override
     public String getLimitOffset(long limit, long offset) {
-      return "LIMIT " + limit + " OFFSET " + offset;
+      return LIMIT + limit + " OFFSET " + offset;
     }
 
     @Override

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
@@ -29,22 +29,22 @@ public class SpannerR2dbcDialect extends AbstractDialect implements R2dbcDialect
   private static final BindMarkersFactory NAMED =
       BindMarkersFactory.named("@", "val", 32);
 
-  public static final String LIMIT = "LIMIT ";
+  public static final String SQL_LIMIT = "LIMIT ";
 
   private static final LimitClause LIMIT_CLAUSE = new LimitClause() {
     @Override
     public String getLimit(long limit) {
-      return LIMIT + limit;
+      return SQL_LIMIT + limit;
     }
 
     @Override
     public String getOffset(long offset) {
-      return LIMIT + Long.MAX_VALUE + " OFFSET " + offset;
+      return SQL_LIMIT + Long.MAX_VALUE + " OFFSET " + offset;
     }
 
     @Override
     public String getLimitOffset(long limit, long offset) {
-      return LIMIT + limit + " OFFSET " + offset;
+      return SQL_LIMIT + limit + " OFFSET " + offset;
     }
 
     @Override

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.springdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.r2dbc.dialect.BindMarkers;
+import org.springframework.data.relational.core.dialect.LimitClause;
+import org.springframework.data.relational.core.dialect.LimitClause.Position;
+
+public class SpannerR2dbcDialectTest {
+
+  @Test
+  void testLimitClause() {
+    LimitClause clause = new SpannerR2dbcDialect().limit();
+    assertThat(clause.getOffset(100)).isEqualTo("LIMIT 9223372036854775807 OFFSET 100");
+    assertThat(clause.getLimit(42)).isEqualTo("LIMIT 42");
+    assertThat(clause.getLimitOffset(42, 100)).isEqualTo("LIMIT 42 OFFSET 100");
+    assertThat(clause.getClausePosition()).isSameAs(Position.AFTER_ORDER_BY);
+  }
+
+  @Test
+  void testBindMarkersFactory() {
+    SpannerR2dbcDialect dialect = new SpannerR2dbcDialect();
+    BindMarkers bindMarkers = dialect.getBindMarkersFactory().create();
+    assertThat(bindMarkers).isNotNull();
+    assertThat(bindMarkers.next().getPlaceholder()).isEqualTo("@val0");
+    assertThat(bindMarkers.next().getPlaceholder()).isEqualTo("@val1");
+  }
+
+}

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
@@ -23,7 +23,7 @@ import org.springframework.data.r2dbc.dialect.BindMarkers;
 import org.springframework.data.relational.core.dialect.LimitClause;
 import org.springframework.data.relational.core.dialect.LimitClause.Position;
 
-public class SpannerR2dbcDialectTest {
+class SpannerR2dbcDialectTest {
 
   @Test
   void testLimitClause() {

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <google-cloud-bom.version>15.1.0</google-cloud-bom.version>
 
     <r2dbc.version>0.8.3.RELEASE</r2dbc.version>
-    <reactor.version>Dysprosium-SR12</reactor.version>
+    <reactor.version>Dysprosium-SR16</reactor.version>
 
     <mockito.version>3.3.0</mockito.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
* Extracting repeating string literals into constants
* Default must be at the end of the switch
* No generic wildcards in return (this required adding a `google-cloud-core` dependency at compile time to get access to `Timestamp` class; we've previously only had it for testing).