### PR TITLE
Add reason to disabled tests

### DIFF
--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -60,6 +60,9 @@ import reactor.test.StepVerifier;
  */
 public class SpannerClientLibraryTestKit implements TestKit<String> {
 
+  private static final String DISABLE_UNSUPPORTED_FUNCTIONALITY =
+      "Functionality not supported in Cloud Spanner";
+
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(
           ConnectionFactoryOptions.builder()
@@ -184,7 +187,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
     return jdbcOperations;
   }
 
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Override
   @Test
   public void transactionRollback() {
@@ -197,7 +200,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
      */
   }
 
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Override
   @Test
   public void bindFails() {
@@ -230,7 +233,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void returnGeneratedValues() {
     /*
@@ -239,7 +242,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void clobInsert() {
     /*
@@ -248,7 +251,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void blobInsert() {
     /*
@@ -257,7 +260,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void blobSelect() {
     /*
@@ -266,7 +269,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void clobSelect() {
     /*
@@ -275,7 +278,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void batch() {
     /*
@@ -284,7 +287,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void savePoint() {
     /*
@@ -293,7 +296,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void savePointStartsTransaction() {
     /*
@@ -302,7 +305,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void prepareStatementWithIncompleteBindingFails() {
     /*
@@ -311,7 +314,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void prepareStatementWithIncompleteBatchFails() {
     /*
@@ -361,7 +364,7 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void compoundStatement() {
     /*

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerTestKit.java
@@ -62,6 +62,9 @@ import reactor.test.StepVerifier;
  */
 public class SpannerTestKit implements TestKit<String> {
 
+  private static final String DISABLE_UNSUPPORTED_FUNCTIONALITY =
+      "Functionality not supported in Cloud Spanner";
+
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(ConnectionFactoryOptions.builder()
           .option(Option.valueOf("project"), ServiceOptions.getDefaultProjectId())
@@ -185,7 +188,7 @@ public class SpannerTestKit implements TestKit<String> {
     return jdbcOperations;
   }
 
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Override
   @Test
   public void transactionRollback() {
@@ -198,7 +201,7 @@ public class SpannerTestKit implements TestKit<String> {
      */
   }
 
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Override
   @Test
   public void bindFails() {
@@ -264,7 +267,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void returnGeneratedValues() {
     /*
@@ -273,7 +276,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void clobInsert() {
     /*
@@ -291,7 +294,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void blobSelect() {
     /*
@@ -300,7 +303,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void clobSelect() {
     /*
@@ -309,7 +312,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void batch() {
     /*
@@ -318,7 +321,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void savePoint() {
     /*
@@ -327,7 +330,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void savePointStartsTransaction() {
     /*
@@ -336,7 +339,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void prepareStatementWithIncompleteBindingFails() {
     /*
@@ -345,7 +348,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void prepareStatementWithIncompleteBatchFails() {
     /*
@@ -354,7 +357,7 @@ public class SpannerTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled
+  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void compoundStatement() {
     /*


### PR DESCRIPTION
Creating an independent constant in each TestKit class because the v1 TestKit will go away.

Sonar rule: "Either add an explanation about why this test is skipped or remove the "@Disabled" annotation."