### PR TITLE
remove public modifier in unit tests

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the sample application.
  */
-public class BookExampleAppIT {
+class BookExampleAppIT {
 
   private static final String TEST_INSTANCE =
       System.getProperty("spanner.instance", "reactivetest");
@@ -52,7 +52,7 @@ public class BookExampleAppIT {
   }
 
   @Test
-  public void testOutput() {
+  void testOutput() {
     BookExampleApp bookExampleApp = new BookExampleApp(TEST_INSTANCE, TEST_DATABASE, ServiceOptions
         .getDefaultProjectId());
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
@@ -29,13 +29,13 @@ import org.junit.jupiter.api.Test;
 public class SpannerColumnMetadataTest {
 
   @Test
-  public void testEmptyFieldName() {
+  void testEmptyFieldName() {
     SpannerColumnMetadata metadata = new SpannerColumnMetadata(Field.getDefaultInstance());
     assertThat(metadata.getName()).isEmpty();
   }
 
   @Test
-  public void testSpannerColumnCorrectMetadata() {
+  void testSpannerColumnCorrectMetadata() {
     Field rawColumnInfo =
         Field.newBuilder()
             .setName("firstColumn")

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerColumnMetadataTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerColumnMetadata}.
  */
-public class SpannerColumnMetadataTest {
+class SpannerColumnMetadataTest {
 
   @Test
   void testEmptyFieldName() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -45,7 +45,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void missingInstanceNameTriggersException() {
+  void missingInstanceNameTriggersException() {
     assertThatThrownBy(
         () -> {
           new SpannerConnectionConfiguration.Builder()
@@ -59,7 +59,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void missingDatabaseNameTriggersException() {
+  void missingDatabaseNameTriggersException() {
     assertThatThrownBy(
         () -> {
           new SpannerConnectionConfiguration.Builder()
@@ -73,7 +73,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void missingProjectIdTriggersException() {
+  void missingProjectIdTriggersException() {
     assertThatThrownBy(
         () -> {
           new SpannerConnectionConfiguration.Builder()
@@ -87,7 +87,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void passingCustomGoogleCredentials() {
+  void passingCustomGoogleCredentials() {
 
     SpannerConnectionConfiguration configuration = this.configurationBuilder
             .setProjectId("project")
@@ -99,7 +99,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void nonNullConstructorParametersPassPreconditions() {
+  void nonNullConstructorParametersPassPreconditions() {
     SpannerConnectionConfiguration config = this.configurationBuilder
         .setProjectId("project1")
         .setInstanceName("an-instance")
@@ -110,7 +110,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void partialResultSetFetchSize() {
+  void partialResultSetFetchSize() {
     SpannerConnectionConfiguration config = this.configurationBuilder
         .setPartialResultSetFetchSize(42)
         .setProjectId("project1")
@@ -121,7 +121,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void executorThreads() {
+  void executorThreads() {
     SpannerConnectionConfiguration config = this.configurationBuilder
         .setThreadPoolSize(42)
         .setProjectId("project1")
@@ -132,7 +132,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void executorThreadsNotSet() {
+  void executorThreadsNotSet() {
     SpannerConnectionConfiguration config = this.configurationBuilder
         .setProjectId("project1")
         .setInstanceName("an-instance")
@@ -143,7 +143,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void ddlOperationWaitSettings() {
+  void ddlOperationWaitSettings() {
     SpannerConnectionConfiguration config = this.configurationBuilder
         .setProjectId("project1")
         .setInstanceName("an-instance")
@@ -157,7 +157,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void databaseUrlMatchesPropertyConfiguration() {
+  void databaseUrlMatchesPropertyConfiguration() {
     SpannerConnectionConfiguration urlBased =
         this.configurationBuilder
             .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
@@ -174,7 +174,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void databaseUrlExtracting() {
+  void databaseUrlExtracting() {
     SpannerConnectionConfiguration config =
         this.configurationBuilder
             .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"
@@ -186,7 +186,7 @@ public class SpannerConnectionConfigurationTest {
   }
 
   @Test
-  public void invalidUrlFormats() {
+  void invalidUrlFormats() {
     assertThatThrownBy(() ->
         this.configurationBuilder
             .setUrl("r2dbc:spanner://spanner.googleapis.com:443/"

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -29,7 +29,7 @@ import org.mockito.Mockito;
 /**
  * Test for {@link SpannerConnectionConfiguration}.
  */
-public class SpannerConnectionConfigurationTest {
+class SpannerConnectionConfigurationTest {
 
   GoogleCredentials mockCredentials = Mockito.mock(GoogleCredentials.class);
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 public class SpannerConnectionFactoryMetadataTest {
 
   @Test
-  public void getNameReturnsCorrectValue() {
+  void getNameReturnsCorrectValue() {
     assertThat(SpannerConnectionFactoryMetadata.INSTANCE.getName()).isEqualTo("Cloud Spanner");
   }
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryMetadataTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerConnectionFactoryMetadata}.
  */
-public class SpannerConnectionFactoryMetadataTest {
+class SpannerConnectionFactoryMetadataTest {
 
   @Test
   void getNameReturnsCorrectValue() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -61,7 +61,7 @@ import reactor.test.publisher.TestPublisher;
 /**
  * Unit test for {@link SpannerConnectionFactoryProvider}.
  */
-public class SpannerConnectionFactoryProviderTest {
+class SpannerConnectionFactoryProviderTest {
 
   public static final ConnectionFactoryOptions SPANNER_OPTIONS =
       ConnectionFactoryOptions.builder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -97,7 +97,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void testCreate() {
+  void testCreate() {
     ConnectionFactory spannerConnectionFactory =
         this.spannerConnectionFactoryProvider.create(SPANNER_OPTIONS);
     assertThat(spannerConnectionFactory).isNotNull();
@@ -105,7 +105,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void testCreateFactoryWithUrl() {
+  void testCreateFactoryWithUrl() {
     ConnectionFactoryOptions optionsWithUrl =
         ConnectionFactoryOptions.builder()
             .option(DRIVER, DRIVER_NAME)
@@ -121,7 +121,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void testSupportsThrowsExceptionOnNullOptions() {
+  void testSupportsThrowsExceptionOnNullOptions() {
     assertThatThrownBy(() -> {
       this.spannerConnectionFactoryProvider.supports(null);
     }).isInstanceOf(IllegalArgumentException.class)
@@ -129,28 +129,28 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void testSupportsReturnsFalseWhenNoDriverInOptions() {
+  void testSupportsReturnsFalseWhenNoDriverInOptions() {
     assertFalse(this.spannerConnectionFactoryProvider.supports(
         ConnectionFactoryOptions.builder().build()));
   }
 
   @Test
-  public void testSupportsReturnsFalseWhenWrongDriverInOptions() {
+  void testSupportsReturnsFalseWhenWrongDriverInOptions() {
     assertFalse(this.spannerConnectionFactoryProvider.supports(buildOptions("not spanner")));
   }
 
   @Test
-  public void testSupportsReturnsTrueWhenCorrectDriverInOptions() {
+  void testSupportsReturnsTrueWhenCorrectDriverInOptions() {
     assertTrue(this.spannerConnectionFactoryProvider.supports(buildOptions("spanner")));
   }
 
   @Test
-  public void getDriverReturnsSpanner() {
+  void getDriverReturnsSpanner() {
     assertThat(this.spannerConnectionFactoryProvider.getDriver()).isEqualTo(DRIVER_NAME);
   }
 
   @Test
-  public void partialResultSetFetchSizePropagatesAsDemand() {
+  void partialResultSetFetchSizePropagatesAsDemand() {
     ConnectionFactoryOptions options =
         ConnectionFactoryOptions.builder()
             .option(PARTIAL_RESULT_SET_FETCH_SIZE, 4)
@@ -197,7 +197,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void testCreateFactoryWithClientLibraryClient() {
+  void testCreateFactoryWithClientLibraryClient() {
     SpannerConnectionFactoryProvider customSpannerConnectionFactoryProvider
         = new SpannerConnectionFactoryProvider();
 
@@ -219,7 +219,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void createFactoryFromUrlWithOauthCredentials() {
+  void createFactoryFromUrlWithOauthCredentials() {
 
     when(this.mockCredentialsHelper.getOauthCredentials(anyString()))
         .thenReturn(this.mockCredentials);
@@ -234,7 +234,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void createFactoryFromUrlWithGoogleCredentialsIncorrectType() {
+  void createFactoryFromUrlWithGoogleCredentialsIncorrectType() {
 
     ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(
         "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?google_credentials=ABC");
@@ -244,7 +244,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void createFactoryWithGoogleCredentialsRetainsThem() {
+  void createFactoryWithGoogleCredentialsRetainsThem() {
 
     ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
         .option(DATABASE, "projects/p/instances/i/databases/d")
@@ -260,7 +260,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void createFactoryWithFileCredentials() {
+  void createFactoryWithFileCredentials() {
 
     when(this.mockCredentialsHelper.getFileCredentials(anyString()))
         .thenReturn(this.mockCredentials);
@@ -276,7 +276,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void multipleAuthenticationMethodsDisallowed() {
+  void multipleAuthenticationMethodsDisallowed() {
     String prefix = "r2dbc:spanner://host:443/projects/p/instances/i/databases/d?";
 
     assertThatThrownBy(() -> this.spannerConnectionFactoryProvider.createConfiguration(
@@ -286,7 +286,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void multipleAuthenticationMethodsDisallowedProgrammatic() {
+  void multipleAuthenticationMethodsDisallowedProgrammatic() {
 
     ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
         .option(DATABASE, "projects/p/instances/i/databases/d")
@@ -301,7 +301,7 @@ public class SpannerConnectionFactoryProviderTest {
   }
 
   @Test
-  public void passOptimizerVersion() {
+  void passOptimizerVersion() {
     ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
         .option(DATABASE, "projects/p/instances/i/databases/d")
         .option(DRIVER, "spanner")

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -50,7 +50,7 @@ public class SpannerConnectionFactoryTest {
   }
 
   @Test
-  public void getMetadataReturnsSingleton() {
+  void getMetadataReturnsSingleton() {
     Client mockClient = Mockito.mock(Client.class);
     SpannerConnectionFactory factory = new SpannerConnectionFactory(mockClient, this.config);
 
@@ -58,7 +58,7 @@ public class SpannerConnectionFactoryTest {
   }
 
   @Test
-  public void createReturnsNewSpannerConnection() {
+  void createReturnsNewSpannerConnection() {
 
     Client mockClient = Mockito.mock(Client.class);
     Session session = Session.newBuilder().setName("jam session").build();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryTest.java
@@ -32,7 +32,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link SpannerConnectionFactory}.
  */
-public class SpannerConnectionFactoryTest {
+class SpannerConnectionFactoryTest {
 
   private SpannerConnectionConfiguration config;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerConnectionMetadata}.
  */
-public class SpannerConnectionMetadataTest {
+class SpannerConnectionMetadataTest {
 
   @Test
   void productNameIsCorrect() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionMetadataTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.Test;
 public class SpannerConnectionMetadataTest {
 
   @Test
-  public void productNameIsCorrect() {
+  void productNameIsCorrect() {
     SpannerConnectionMetadata spannerConnectionMetadata = SpannerConnectionMetadata.INSTANCE;
     assertThat(spannerConnectionMetadata.getDatabaseProductName()).isEqualTo("Cloud Spanner");
   }
 
   @Test
-  public void productVersionIrrelevant() {
+  void productVersionIrrelevant() {
     assertThat(SpannerConnectionMetadata.INSTANCE.getDatabaseVersion()).isEqualTo("n/a");
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -59,7 +59,7 @@ import reactor.test.publisher.PublisherProbe;
 /**
  * Test for {@link SpannerConnection}.
  */
-public class SpannerConnectionTest {
+class SpannerConnectionTest {
 
   static final String TEST_SESSION_NAME = "project/session/1234";
   static final Session TEST_SESSION =

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionTest.java
@@ -108,7 +108,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void executeStatementReturnsWorkingStatementWithCorrectQuery() {
+  void executeStatementReturnsWorkingStatementWithCorrectQuery() {
     SpannerConnection connection
         = new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
     String sql = "select book from library";
@@ -143,7 +143,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void executeDmlInTransactionStartingAfterCreationTest() {
+  void executeDmlInTransactionStartingAfterCreationTest() {
     SpannerConnection connection
         = new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
     String sql = "insert into books values (title) @title";
@@ -160,7 +160,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void noopCommitTransactionWhenTransactionNotStarted() {
+  void noopCommitTransactionWhenTransactionNotStarted() {
     SpannerConnection connection =
         new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
 
@@ -170,7 +170,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void beginAndCommitTransactions() {
+  void beginAndCommitTransactions() {
     SpannerConnection connection =
         new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
 
@@ -197,7 +197,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void rollbackTransactions() {
+  void rollbackTransactions() {
     SpannerConnection connection =
         new SpannerConnection(this.mockClient, TEST_SESSION, TEST_CONFIG);
 
@@ -225,7 +225,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void testCustomTransactionType() {
+  void testCustomTransactionType() {
     SpannerConnection connection = new SpannerConnection(
         this.mockClient, TEST_SESSION, TEST_CONFIG);
 
@@ -244,20 +244,20 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void executionContextHasCorrectSessionName() {
+  void executionContextHasCorrectSessionName() {
     SpannerConnection connection = new SpannerConnection(
         this.mockClient, Session.newBuilder().setName("session-name").build(), null);
     assertThat(connection.getSessionName()).isEqualTo("session-name");
   }
 
   @Test
-  public void executionContextDoesNotHaveTransactionWhenInitialized() {
+  void executionContextDoesNotHaveTransactionWhenInitialized() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     assertThat(connection.getTransactionId()).isNull();
   }
 
   @Test
-  public void executionContextHasCorrectTransactionIdWhenTransactionSet() {
+  void executionContextHasCorrectTransactionIdWhenTransactionSet() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     ByteString transactionId = ByteString.copyFrom("transaction-id".getBytes());
 
@@ -274,7 +274,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void nextSeqNumIsSequential() {
+  void nextSeqNumIsSequential() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     long prevNum = connection.nextSeqNum();
 
@@ -289,13 +289,13 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void autocommitOnByDefault() {
+  void autocommitOnByDefault() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     assertThat(connection.isAutoCommit()).isTrue();
   }
 
   @Test
-  public void turningAutocommitOnIsNoopWhenAlreadyOn() {
+  void turningAutocommitOnIsNoopWhenAlreadyOn() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(connection.setAutoCommit(true))
         .verifyComplete();
@@ -304,7 +304,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void turningAutocommitOffIsNoopWhenAlreadyOff() {
+  void turningAutocommitOffIsNoopWhenAlreadyOff() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(
         Mono.from(connection.setAutoCommit(false))
@@ -316,7 +316,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void turningAutocommitOffWorksLocally() {
+  void turningAutocommitOffWorksLocally() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(connection.setAutoCommit(false))
         .verifyComplete();
@@ -325,7 +325,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void startingTransactionTurnsOffAutocommit() {
+  void startingTransactionTurnsOffAutocommit() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(
         Mono.from(connection.beginTransaction())
@@ -336,7 +336,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void turningAutocommitOnCommitsExistingTransaction() {
+  void turningAutocommitOnCommitsExistingTransaction() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(
         Mono.from(connection.setAutoCommit(false))
@@ -350,7 +350,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void turningAutocommitOnDoesNotAffectNonReadwriteTransaction() {
+  void turningAutocommitOnDoesNotAffectNonReadwriteTransaction() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     TransactionOptions readonlyTransaction =
         TransactionOptions.newBuilder().setReadOnly(ReadOnly.getDefaultInstance()).build();
@@ -367,7 +367,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void localValidatePassesOnNewConnection() {
+  void localValidatePassesOnNewConnection() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     StepVerifier.create(connection.validate(ValidationDepth.LOCAL))
         .expectNext(true)
@@ -376,7 +376,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void localValidateFailsOnClosedConnection() {
+  void localValidateFailsOnClosedConnection() {
     when(this.mockClient.commitTransaction(any(), any()))
         .thenReturn(Mono.just(CommitResponse.getDefaultInstance()));
     when(this.mockClient.deleteSession(any())).thenReturn(Mono.empty());
@@ -392,7 +392,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void remoteValidateCallsServerHealthcheck() {
+  void remoteValidateCallsServerHealthcheck() {
     when(this.mockClient.healthcheck(any())).thenReturn(Mono.just(true));
 
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
@@ -403,7 +403,7 @@ public class SpannerConnectionTest {
   }
 
   @Test
-  public void getConnectionMetadata() {
+  void getConnectionMetadata() {
     SpannerConnection connection = new SpannerConnection(this.mockClient, TEST_SESSION, null);
     assertThat(connection.getMetadata().getDatabaseProductName()).isEqualTo("Cloud Spanner");
     assertThat(connection.getMetadata().getDatabaseVersion()).isEqualTo("n/a");

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
@@ -34,7 +34,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link SpannerResult}.
  */
-public class SpannerResultTest {
+class SpannerResultTest {
 
   private Flux<SpannerRow> resultSet;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerResultTest.java
@@ -66,7 +66,7 @@ public class SpannerResultTest {
   }
 
   @Test
-  public void getRowsUpdatedTest() {
+  void getRowsUpdatedTest() {
     StepVerifier.create(
         ((Mono) new SpannerResult(this.resultSet,Mono.just(2)).getRowsUpdated()))
         .expectNext(2)
@@ -74,19 +74,19 @@ public class SpannerResultTest {
   }
 
   @Test
-  public void nullResultSetTest() {
+  void nullResultSetTest() {
     assertThatThrownBy(() -> new SpannerResult(null, Mono.empty()))
         .hasMessage("A non-null flux of rows is required.");
   }
 
   @Test
-  public void nullRowsTest() {
+  void nullRowsTest() {
     assertThatThrownBy(() -> new SpannerResult(Flux.empty(),null))
         .hasMessage("A non-null mono of rows updated is required.");
   }
 
   @Test
-  public void mapTest() {
+  void mapTest() {
 
     String columnName = this.resultSetMetadata
         .getRowType()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class SpannerRowMetadataTest {
 
   @Test
-  public void testHandleMissingColumn() {
+  void testHandleMissingColumn() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.newBuilder().build());
     assertThatThrownBy(() -> metadata.getColumnMetadata("columnName"))
         .isInstanceOf(IllegalArgumentException.class)
@@ -41,21 +41,21 @@ public class SpannerRowMetadataTest {
   }
 
   @Test
-  public void testHandleOutOfBoundsIndex() {
+  void testHandleOutOfBoundsIndex() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.newBuilder().build());
     assertThatThrownBy(() -> metadata.getColumnMetadata(4))
         .isInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test
-  public void testEmptyResultSetMetadata() {
+  void testEmptyResultSetMetadata() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.newBuilder().build());
     assertThat(metadata.getColumnMetadatas()).isEmpty();
     assertThat(metadata.getColumnNames()).isEmpty();
   }
 
   @Test
-  public void testSpannerRowMetadataRetrieval() {
+  void testSpannerRowMetadataRetrieval() {
     ResultSetMetadata resultSetMetadata = buildResultSetMetadata(
         TypeCode.INT64,
         TypeCode.STRING,
@@ -74,7 +74,7 @@ public class SpannerRowMetadataTest {
   }
 
   @Test
-  public void getColumnNamesReturnsCorrectNamesWhenColumnsPresent() {
+  void getColumnNamesReturnsCorrectNamesWhenColumnsPresent() {
     ResultSetMetadata resultSetMetadata
         = buildResultSetMetadata(TypeCode.INT64, TypeCode.STRING, TypeCode.BOOL);
     SpannerRowMetadata metadata = new SpannerRowMetadata(resultSetMetadata);
@@ -83,7 +83,7 @@ public class SpannerRowMetadataTest {
   }
 
   @Test
-  public void getColumnNamesReturnsEmptyCollectionWhenNoColumns() {
+  void getColumnNamesReturnsEmptyCollectionWhenNoColumns() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance());
 
     assertThat(metadata.getColumnNames()).isEmpty();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowMetadataTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerRowMetadata}.
  */
-public class SpannerRowMetadataTest {
+class SpannerRowMetadataTest {
 
   @Test
   void testHandleMissingColumn() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -41,7 +41,7 @@ public class SpannerRowTest {
       = new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance());
 
   @Test
-  public void testOutOfBoundsIndex() {
+  void testOutOfBoundsIndex() {
     SpannerRow row = new SpannerRow(
         new ArrayList<>(), this.rowMetadata);
 
@@ -50,7 +50,7 @@ public class SpannerRowTest {
   }
 
   @Test
-  public void testInvalidColumnLabel() {
+  void testInvalidColumnLabel() {
     SpannerRow row = new SpannerRow(
         new ArrayList<>(), this.rowMetadata);
 
@@ -60,7 +60,7 @@ public class SpannerRowTest {
   }
 
   @Test
-  public void testIndexingIntoColumns() {
+  void testIndexingIntoColumns() {
     SpannerRowMetadata rowMetadata =
         createRowMetadata(TypeCode.STRING, TypeCode.INT64, TypeCode.BOOL);
     List<Value> rawSpannerRow = createRawSpannerRow("Hello", 25L, true);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerRowTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerRow}.
  */
-public class SpannerRowTest {
+class SpannerRowTest {
 
   private static final Codecs codecs = new DefaultCodecs();
   private final SpannerRowMetadata rowMetadata

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -57,7 +57,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link SpannerStatement}.
  */
-public class SpannerStatementTest {
+class SpannerStatementTest {
 
   private static final SpannerConnectionConfiguration TEST_CONFIG =
       new SpannerConnectionConfiguration.Builder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerStatementTest.java
@@ -93,7 +93,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void executeDummyImplementation() {
+  void executeDummyImplementation() {
     String sql = "select book from library";
     PartialResultSet partialResultSet = PartialResultSet.newBuilder()
         .setMetadata(ResultSetMetadata.newBuilder().setRowType(StructType.newBuilder()
@@ -121,7 +121,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void executeDummyImplementationBind() {
+  void executeDummyImplementationBind() {
     //set up mock results
     PartialResultSet partialResultSet1 = PartialResultSet.newBuilder()
         .setMetadata(ResultSetMetadata.newBuilder().setRowType(StructType.newBuilder()
@@ -176,7 +176,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void readOneResultSetQueryTest() {
+  void readOneResultSetQueryTest() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
     ).setChunkedValue(false)
@@ -202,7 +202,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void readMultiResultSetQueryTest() {
+  void readMultiResultSetQueryTest() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
     ).setChunkedValue(false)
@@ -224,7 +224,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void readDmlQueryTest() {
+  void readDmlQueryTest() {
     ResultSet resultSet = ResultSet.newBuilder()
         .setStats(ResultSetStats.newBuilder().setRowCountExact(555).build())
         .build();
@@ -241,7 +241,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void batchDmlQueryWithinTransactionTest() {
+  void batchDmlQueryWithinTransactionTest() {
     batchDmlQueryTest(ByteString.copyFromUtf8("abc"), 0, 0);
   }
 
@@ -276,7 +276,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void batchDmlExceptionTest() {
+  void batchDmlExceptionTest() {
     assertThatThrownBy(() ->
         new SpannerBatch(this.mockClient, null)
         .add("select * from books"))
@@ -285,7 +285,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void runDdlQueryTest() {
+  void runDdlQueryTest() {
     when(this.mockClient.executeDdl(any(), any(), any(), any()))
         .thenReturn(Mono.just(Operation.getDefaultInstance()));
 
@@ -306,7 +306,7 @@ public class SpannerStatementTest {
   }
 
   @Test
-  public void noopMapOnUpdateQueriesWhenNoRowsAffected() {
+  void noopMapOnUpdateQueriesWhenNoRowsAffected() {
     String sql = "delete from Books where true";
 
     ResultSet resultSet = ResultSet.newBuilder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -77,7 +77,7 @@ public class GrpcClientTest {
   }
 
   @Test
-  public void testCreateSession() throws IOException {
+  void testCreateSession() throws IOException {
 
     SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
           @Override
@@ -99,7 +99,7 @@ public class GrpcClientTest {
   }
 
   @Test
-  public void testExecuteStreamingSql() throws IOException {
+  void testExecuteStreamingSql() throws IOException {
     ExecuteSqlRequest request = ExecuteSqlRequest.newBuilder().build();
 
     String sql = "select book from library";
@@ -125,7 +125,7 @@ public class GrpcClientTest {
 
 
   @Test
-  public void testBatchDmlErrorPropagation() throws IOException {
+  void testBatchDmlErrorPropagation() throws IOException {
     ResultSet expectedResultSet =
         ResultSet.newBuilder()
             .setStats(ResultSetStats.newBuilder().setRowCountExact(20))
@@ -158,14 +158,14 @@ public class GrpcClientTest {
   }
 
   @Test
-  public void testHostPortConfig() {
+  void testHostPortConfig() {
     assertEquals("spanner.googleapis.com:443",
         new GrpcClient(NoCredentials.getInstance()).getSpanner().getChannel()
             .authority());
   }
 
   @Test
-  public void testUserAgentConfig()
+  void testUserAgentConfig()
       throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
     GrpcClient grpcClient = new GrpcClient(NoCredentials.getInstance());
     Channel channel = grpcClient.getSpanner().getChannel();
@@ -182,7 +182,7 @@ public class GrpcClientTest {
   }
 
   @Test
-  public void testHealthcheck() throws IOException {
+  void testHealthcheck() throws IOException {
     String sql = "SELECT 1";
     SpannerImplBase spannerSpy = doTest(new SpannerImplBase() {
       @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/client/GrpcClientTest.java
@@ -58,7 +58,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link GrpcClient}.
  */
-public class GrpcClientTest {
+class GrpcClientTest {
 
   static String SESSION_NAME = "/session/1234";
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
@@ -32,7 +32,7 @@ public class DefaultCodecsNegativeTest {
   private Codecs codecs = new DefaultCodecs();
 
   @Test
-  public void encodeException() {
+  void encodeException() {
 
     assertThrows(IllegalArgumentException.class,
         () -> this.codecs.encode(BigDecimal.valueOf(100)),
@@ -40,7 +40,7 @@ public class DefaultCodecsNegativeTest {
   }
 
   @Test
-  public void decodeException() {
+  void decodeException() {
 
     assertThrows(IllegalArgumentException.class,
         () -> {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsNegativeTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link DefaultCodecs}.
  */
-public class DefaultCodecsNegativeTest {
+class DefaultCodecsNegativeTest {
 
   private Codecs codecs = new DefaultCodecs();
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecsTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 /**
  * Test for {@link DefaultCodecs}.
  */
-public class DefaultCodecsTest {
+class DefaultCodecsTest {
 
   private Codecs codecs = new DefaultCodecs();
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -54,7 +54,7 @@ import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class ClientLibraryBasedIT {
+class ClientLibraryBasedIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ClientLibraryBasedIT.class);
 
@@ -128,7 +128,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testValidate() {
+  void testValidate() {
     Connection conn = Mono.from(connectionFactory.create()).block();
     boolean result = Mono.from(conn.validate(ValidationDepth.REMOTE)).block();
     assertThat(result).isTrue();
@@ -139,7 +139,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testReadQuery() {
+  void testReadQuery() {
 
     Connection conn = Mono.from(connectionFactory.create()).block();
 
@@ -156,7 +156,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testMetadata() {
+  void testMetadata() {
 
     Connection conn = Mono.from(connectionFactory.create()).block();
 
@@ -189,7 +189,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testErrorPropagation() {
+  void testErrorPropagation() {
 
     Connection conn = Mono.from(connectionFactory.create()).block();
 
@@ -201,7 +201,7 @@ public class ClientLibraryBasedIT {
 
 
   @Test
-  public void testDmlInsert() {
+  void testDmlInsert() {
     Connection conn = Mono.from(connectionFactory.create()).block();
 
     String id = "abc123-" + this.random.nextInt();
@@ -239,7 +239,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testTransactionSingleStatementCommitted() {
+  void testTransactionSingleStatementCommitted() {
 
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
 
@@ -267,7 +267,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testTransactionMultipleStatementsCommitted() {
+  void testTransactionMultipleStatementsCommitted() {
 
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
     String uuid2 = "transaction1-commit2-" + this.random.nextInt();
@@ -306,7 +306,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testTransactionFollowedByStandaloneStatementCommitted() {
+  void testTransactionFollowedByStandaloneStatementCommitted() {
 
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
     String uuid2 = "transaction1-commit2-" + this.random.nextInt();
@@ -331,7 +331,7 @@ public class ClientLibraryBasedIT {
 
 
   @Test
-  public void testTransactionRolledBack() {
+  void testTransactionRolledBack() {
     String uuid = "transaction2-abort" + this.random.nextInt();
 
     StepVerifier.create(
@@ -357,7 +357,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void selectQueryReturnsUpdatedDataDuringAndAfterTransactionCommit() {
+  void selectQueryReturnsUpdatedDataDuringAndAfterTransactionCommit() {
 
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
 
@@ -380,7 +380,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void selectQueryReturnsUpdatedDataDuringTransactionButNotAfterTransactionRollback() {
+  void selectQueryReturnsUpdatedDataDuringTransactionButNotAfterTransactionRollback() {
 
     String uuid1 = "transaction1-commit1-" + this.random.nextInt();
 
@@ -404,7 +404,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void ddlCreateAndDrop() {
+  void ddlCreateAndDrop() {
     String listTables = "SELECT COUNT(*) FROM information_schema.tables WHERE table_name=@table";
     String tableName = "test_table_" + this.random.nextInt(100000);
 
@@ -444,7 +444,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void selectMultipleBoundParameterSetsNoTransaction() {
+  void selectMultipleBoundParameterSetsNoTransaction() {
 
     String uuid1 = "params-no-transaction-" + this.random.nextInt();
     String uuid2 = "params-no-transaction-" + this.random.nextInt();
@@ -488,7 +488,7 @@ public class ClientLibraryBasedIT {
   2) omits the final add() for the last bound row.
   */
   @Test
-  public void selectMultipleBoundParameterSetsInTransaction() {
+  void selectMultipleBoundParameterSetsInTransaction() {
 
     String uuid1 = "params-no-transaction-" + this.random.nextInt();
     String uuid2 = "params-no-transaction-" + this.random.nextInt();
@@ -533,7 +533,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void insertMultipleBoundParameterSetsNoTransaction() {
+  void insertMultipleBoundParameterSetsNoTransaction() {
 
     String uuid1 = "params-no-transaction-" + this.random.nextInt();
     String uuid2 = "params-no-transaction-" + this.random.nextInt();
@@ -566,7 +566,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void insertMultipleBoundParameterSetsInTransaction() {
+  void insertMultipleBoundParameterSetsInTransaction() {
 
     String uuid1 = "params-no-transaction-" + this.random.nextInt();
     String uuid2 = "params-no-transaction-" + this.random.nextInt();
@@ -601,7 +601,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testStaleRead() throws InterruptedException {
+  void testStaleRead() throws InterruptedException {
 
     // Prevent a stale read from 1 second ago from seeing a nonexistent table.
     Thread.sleep(1000);
@@ -635,7 +635,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testStrongReadFromSubclassedConnection() throws InterruptedException {
+  void testStrongReadFromSubclassedConnection() throws InterruptedException {
 
     String uuid1 = "transaction1-strong-read" + this.random.nextInt();
     String sql = "SELECT count(*) from BOOKS WHERE UUID='" + uuid1 + "'";
@@ -666,7 +666,7 @@ public class ClientLibraryBasedIT {
   }
 
   @Test
-  public void testConnectingThroughUrl() {
+  void testConnectingThroughUrl() {
     ConnectionFactory urlBasedConnectionFactory =
         ConnectionFactories.get(DatabaseProperties.URL + "?client-implementation=client-library");
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDdlIT.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
-public class SpannerDdlIT {
+class SpannerDdlIT {
 
   private static final Logger logger = LoggerFactory.getLogger(SpannerDdlIT.class);
 
@@ -59,7 +59,7 @@ public class SpannerDdlIT {
   }
 
   @Test
-  public void testDdlErrorPropagation() {
+  void testDdlErrorPropagation() {
     assertThat(listTables()).doesNotContain("PRESIDENTS");
 
     assertThatThrownBy(() ->
@@ -71,7 +71,7 @@ public class SpannerDdlIT {
   }
 
   @Test
-  public void testCreateAndDrop() {
+  void testCreateAndDrop() {
     assertThat(listTables()).doesNotContain("PRESIDENTS");
 
     Mono.from(connectionFactory.create())

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerIT.java
@@ -68,7 +68,7 @@ import reactor.test.StepVerifier;
 /**
  * Integration test for connecting to a real Spanner instance.
  */
-public class SpannerIT {
+class SpannerIT {
 
   private static final ConnectionFactory connectionFactory =
       ConnectionFactories.get(ConnectionFactoryOptions.builder()
@@ -136,7 +136,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testLargeReadWrite() {
+  void testLargeReadWrite() {
     // string size must be below 10 MB
     int maxStringLength = 100000;
 
@@ -205,7 +205,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testSessionManagement() {
+  void testSessionManagement() {
     assertThat(this.connectionFactory).isInstanceOf(SpannerConnectionFactory.class);
 
     Mono<Connection> connection = (Mono<Connection>) this.connectionFactory.create();
@@ -222,7 +222,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testRunDmlAfterTransaction() {
+  void testRunDmlAfterTransaction() {
     SpannerConnection connection =
         Mono.from(this.connectionFactory.create())
             .cast(SpannerConnection.class)
@@ -252,7 +252,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testDmlExceptions() {
+  void testDmlExceptions() {
     StepVerifier.create(
         Mono.from(connectionFactory.create())
             .flatMapMany(conn -> conn.createStatement("INSERT BOOKS asdfasdfasdf").execute()))
@@ -261,7 +261,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testMultipleDmlExceptions() {
+  void testMultipleDmlExceptions() {
     StepVerifier.create(
         Mono.from(connectionFactory.create())
             .flatMapMany(conn ->
@@ -280,7 +280,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testDataIntegrityExceptions() {
+  void testDataIntegrityExceptions() {
     StepVerifier.create(
         Mono.from(connectionFactory.create())
             .flatMapMany(conn ->
@@ -298,7 +298,7 @@ public class SpannerIT {
 
 
   @Test
-  public void testSingleUseDml() {
+  void testSingleUseDml() {
     long count = executeReadQuery(
         connectionFactory,
         "Select count(1) as count FROM books",
@@ -348,7 +348,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testQuerying() {
+  void testQuerying() {
     long count = executeReadQuery(
         connectionFactory,
         "Select count(1) as count FROM books",
@@ -459,7 +459,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testNoopUpdate() {
+  void testNoopUpdate() {
     Result result = Mono.from(connectionFactory.create())
         .delayUntil(c -> c.beginTransaction())
         .flatMap(c -> Mono.from(c.createStatement(
@@ -477,7 +477,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testEmptySelect() {
+  void testEmptySelect() {
     List<String> results = executeReadQuery(
         connectionFactory,
         "SELECT title, author FROM books where author = 'Nobody P. Smith'",
@@ -487,7 +487,7 @@ public class SpannerIT {
   }
 
   @Test
-  public void testMultiTransactionType() {
+  void testMultiTransactionType() {
     Mono.from(this.connectionFactory.create())
         .delayUntil(c -> c.beginTransaction())
         .delayUntil(c -> Flux.from(c.createStatement(

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
@@ -64,7 +64,7 @@ public class PartialResultRowExtractorTest {
   ).build();
 
   @Test
-  public void assembleRowsTest() {
+  void assembleRowsTest() {
     // The values above will be split across several partial result sets.
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
@@ -118,7 +118,7 @@ public class PartialResultRowExtractorTest {
   }
 
   @Test
-  public void singleResultSetTest() {
+  void singleResultSetTest() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
     ).setChunkedValue(false)
@@ -136,7 +136,7 @@ public class PartialResultRowExtractorTest {
   }
 
   @Test
-  public void neatRowsResultSetTest() {
+  void neatRowsResultSetTest() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
     ).setChunkedValue(false)
@@ -159,7 +159,7 @@ public class PartialResultRowExtractorTest {
   }
 
   @Test
-  public void interRowWholeChunkTest() {
+  void interRowWholeChunkTest() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setMetadata(
         this.resultSetMetadata
     ).setChunkedValue(false)
@@ -182,7 +182,7 @@ public class PartialResultRowExtractorTest {
   }
 
   @Test
-  public void handleEmptyPartialResultSet() {
+  void handleEmptyPartialResultSet() {
     PartialResultSet emptyResultSet =
         PartialResultSet.newBuilder().setMetadata(this.resultSetMetadata).build();
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/result/PartialResultRowExtractorTest.java
@@ -36,7 +36,7 @@ import reactor.test.StepVerifier;
 /**
  * Tests the partial result flux converter.
  */
-public class PartialResultRowExtractorTest {
+class PartialResultRowExtractorTest {
 
   // These are the expected final rows' values
   final Value a1 = Value.newBuilder().setBoolValue(false).build();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
@@ -26,7 +26,7 @@ import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
 import org.junit.jupiter.api.Test;
 
-public class StatementBindingsTest {
+class StatementBindingsTest {
 
   @Test
   void addBasicBinding() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementBindingsTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 public class StatementBindingsTest {
 
   @Test
-  public void addBasicBinding() {
+  void addBasicBinding() {
     StatementBindings statementBindings = new StatementBindings();
     statementBindings.createBind("name", "John");
     statementBindings.createBind("age", 50);
@@ -56,7 +56,7 @@ public class StatementBindingsTest {
   }
 
   @Test
-  public void testNoopAddBinding() {
+  void testNoopAddBinding() {
     StatementBindings statementBindings = new StatementBindings();
     statementBindings.completeBinding();
     statementBindings.completeBinding();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -23,13 +23,13 @@ import org.junit.jupiter.api.Test;
 public class StatementParserTest {
 
   @Test
-  public void parsesSelectQueries() {
+  void parsesSelectQueries() {
     String sql = "SELECT * from blahblahblah";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);
   }
 
   @Test
-  public void parsesDmlQueries() {
+  void parsesDmlQueries() {
     String sql = "InSeRt INTO TABLE_NAME VALUES (value1, value2, value3,...valueN)";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DML);
 
@@ -43,7 +43,7 @@ public class StatementParserTest {
   }
 
   @Test
-  public void parsesDdlQueries() {
+  void parsesDdlQueries() {
     String sql = "drop table Blarg";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.DDL);
 
@@ -55,13 +55,13 @@ public class StatementParserTest {
   }
 
   @Test
-  public void parseUnknownQuery() {
+  void parseUnknownQuery() {
     String sql = "int number = 5";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.UNKNOWN);
   }
 
   @Test
-  public void parseQueryWithOptionsPrefix() {
+  void parseQueryWithOptionsPrefix() {
     String sql = "@{FORCE_INDEX=index_name} @{JOIN_METHOD=HASH_JOIN} SELECT * FROM blahblah";
     assertThat(StatementParser.getStatementType(sql)).isEqualTo(StatementType.SELECT);
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/statement/StatementParserTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class StatementParserTest {
+class StatementParserTest {
 
   @Test
   void parsesSelectQueries() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 public class AssertTest {
 
   @Test
-  public void assertNotNullThrowsExceptionWhenNull() {
+  void assertNotNullThrowsExceptionWhenNull() {
     assertThatThrownBy(() -> {
       Assert.requireNonNull(null, "oh no");
     }).isInstanceOf(IllegalArgumentException.class)
@@ -35,7 +35,7 @@ public class AssertTest {
   }
 
   @Test
-  public void assertNotNullNoopWhenNotNull() {
+  void assertNotNullNoopWhenNotNull() {
     String value = Assert.requireNonNull("definitely not null", "oh no");
     assertThat(value).isEqualTo("definitely not null");
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/AssertTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Assert}.
  */
-public class AssertTest {
+class AssertTest {
 
   @Test
   void assertNotNullThrowsExceptionWhenNull() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class CollectionsBuilderTest {
 
   @Test
-  public void testSetCreation() {
+  void testSetCreation() {
     Set<String> items = CollectionsBuilder.setOf("Hello", "bob", "world");
     assertThat(items).containsExactlyInAnyOrder("Hello", "bob", "world");
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/CollectionsBuilderTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-public class CollectionsBuilderTest {
+class CollectionsBuilderTest {
 
   @Test
   void testSetCreation() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -34,7 +34,7 @@ import reactor.test.StepVerifier;
 public class ObservableReactiveUtilTest {
 
   @Test
-  public void unaryCallReturnsSingleValue() {
+  void unaryCallReturnsSingleValue() {
     Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
       observer.onNext(42);
       observer.onCompleted();
@@ -45,7 +45,7 @@ public class ObservableReactiveUtilTest {
   }
 
   @Test
-  public void unaryCallForwardsError() {
+  void unaryCallForwardsError() {
     Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> {
       observer.onError(new IllegalArgumentException("oh no"));
     });
@@ -57,7 +57,7 @@ public class ObservableReactiveUtilTest {
   }
 
   @Test
-  public void unaryCallThrowsExceptionIfCompletedWithNoValue() {
+  void unaryCallThrowsExceptionIfCompletedWithNoValue() {
     Mono<Integer> mono = ObservableReactiveUtil.unaryCall(observer -> observer.onCompleted());
 
     StepVerifier.create(mono)
@@ -68,7 +68,7 @@ public class ObservableReactiveUtilTest {
   }
 
   @Test
-  public void propagateTransientErrorUnaryCall() {
+  void propagateTransientErrorUnaryCall() {
     StatusRuntimeException retryableException =
         new StatusRuntimeException(
             Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"));
@@ -84,7 +84,7 @@ public class ObservableReactiveUtilTest {
   }
 
   @Test
-  public void propagateNonRetryableError() {
+  void propagateNonRetryableError() {
     Mono<Void> result =
         ObservableReactiveUtil.unaryCall(
             observer -> observer.onError(new IllegalArgumentException()));
@@ -97,7 +97,7 @@ public class ObservableReactiveUtilTest {
   }
 
   @Test
-  public void propagateTransientErrorStreamingCall() {
+  void propagateTransientErrorStreamingCall() {
     StatusRuntimeException retryableException =
         new StatusRuntimeException(
             Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"));

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtilTest.java
@@ -31,7 +31,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link ObservableReactiveUtil}.
  */
-public class ObservableReactiveUtilTest {
+class ObservableReactiveUtilTest {
 
   @Test
   void unaryCallReturnsSingleValue() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
@@ -34,7 +34,7 @@ import io.r2dbc.spi.R2dbcTransientResourceException;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
-public class SpannerExceptionUtilTest {
+class SpannerExceptionUtilTest {
 
   @Test
   void testCreateR2dbcException() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtilTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 public class SpannerExceptionUtilTest {
 
   @Test
-  public void testCreateR2dbcException() {
+  void testCreateR2dbcException() {
     R2dbcException exception = SpannerExceptionUtil.createR2dbcException(
         Code.ALREADY_EXISTS_VALUE, "test");
 
@@ -46,7 +46,7 @@ public class SpannerExceptionUtilTest {
   }
 
   @Test
-  public void testNonRetryableException() {
+  void testNonRetryableException() {
     assertThat(createR2dbcException(new IllegalArgumentException()))
         .isInstanceOf(R2dbcNonTransientResourceException.class);
     assertThat(createR2dbcException((new IOException())))
@@ -59,7 +59,7 @@ public class SpannerExceptionUtilTest {
   }
 
   @Test
-  public void testRetryableInternalException() {
+  void testRetryableInternalException() {
     StatusRuntimeException retryableException =
         new StatusRuntimeException(
             Status.INTERNAL.withDescription("HTTP/2 error code: INTERNAL_ERROR"), null);
@@ -69,7 +69,7 @@ public class SpannerExceptionUtilTest {
   }
 
   @Test
-  public void testRetryableExceptionWithDelay() {
+  void testRetryableExceptionWithDelay() {
     RetryInfo retryInfo =
         RetryInfo.newBuilder()
             .setRetryDelay(Duration.newBuilder().setSeconds(22L))

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -51,7 +51,7 @@ public class AbstractSpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void noParametersSendsSingleStatement() {
+  void noParametersSendsSingleStatement() {
     String query = "SELECT * FROM tbl";
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 
@@ -68,7 +68,7 @@ public class AbstractSpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void singleSetOfParametersWithNoAddSendsOneStatement() {
+  void singleSetOfParametersWithNoAddSendsOneStatement() {
     String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 
@@ -93,7 +93,7 @@ public class AbstractSpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void singleSetOfParametersWithAddTriggersBatchWithOneStatement() {
+  void singleSetOfParametersWithAddTriggersBatchWithOneStatement() {
     String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 
@@ -121,7 +121,7 @@ public class AbstractSpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void twoParameterSetsWithNoTrailingAddSendsTwoStatements() {
+  void twoParameterSetsWithNoTrailingAddSendsTwoStatements() {
     String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 
@@ -156,7 +156,7 @@ public class AbstractSpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void twoParameterSetsWithTrailingAddSendsTwoStatements() {
+  void twoParameterSetsWithTrailingAddSendsTwoStatements() {
     String query = "SELECT * FROM tbl WHERE col1=@one AND col2=@two AND col3=@three";
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -36,7 +36,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class AbstractSpannerClientLibraryStatementTest {
+class AbstractSpannerClientLibraryStatementTest {
 
   DatabaseClientReactiveAdapter mockAdapter;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -135,7 +135,7 @@ class ClientLibraryTypeBindersTest {
   }
 
   @Test
-  public void integerBindsAsLong() {
+  void integerBindsAsLong() {
 
     ClientLibraryBinder.bind(this.statementBuilder, "a", 123);
     verify(this.valueBinder).to((Long) 123L);
@@ -143,7 +143,7 @@ class ClientLibraryTypeBindersTest {
   }
 
   @Test
-  public void integerNullBindsAsLong() {
+  void integerNullBindsAsLong() {
 
     ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Integer.class));
     verify(this.valueBinder).to((Long) null);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -95,7 +95,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void testChangeAutocommitCommitsCurrentTransaction() {
+  void testChangeAutocommitCommitsCurrentTransaction() {
     when(this.mockTxnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 
@@ -106,7 +106,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void testSameAutocommitNoop() {
+  void testSameAutocommitNoop() {
     when(this.mockTxnManager.isInTransaction()).thenReturn(true);
     assertThat(this.adapter.isAutoCommit()).isTrue();
 
@@ -117,7 +117,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void unsetQueryOptimizerResultsInDefaultQueryOptions() {
+  void unsetQueryOptimizerResultsInDefaultQueryOptions() {
     SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
         .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
         .setCredentials(mock(GoogleCredentials.class))
@@ -129,7 +129,7 @@ public class DatabaseClientReactiveAdapterTest {
   }
 
   @Test
-  public void queryOptimizerPropagatesToQueryOptions() {
+  void queryOptimizerPropagatesToQueryOptions() {
     SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
         .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
         .setCredentials(mock(GoogleCredentials.class))

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -47,7 +47,7 @@ import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
-public class DatabaseClientReactiveAdapterTest {
+class DatabaseClientReactiveAdapterTest {
 
   // DatabaseClientReactiveAdapter dependencies
   private SpannerConnectionConfiguration config;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class DatabaseClientTransactionManagerTest {
+class DatabaseClientTransactionManagerTest {
 
   DatabaseClientTransactionManager transactionManager;
   DatabaseClient mockDbClient;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManagerTest.java
@@ -79,7 +79,7 @@ public class DatabaseClientTransactionManagerTest {
   }
 
   @Test
-  public void testReadonlyTransactionStartedWhileReadWriteInProgressFails() {
+  void testReadonlyTransactionStartedWhileReadWriteInProgressFails() {
 
     this.transactionManager.beginTransaction();
     assertThatThrownBy(() ->
@@ -89,7 +89,7 @@ public class DatabaseClientTransactionManagerTest {
   }
 
   @Test
-  public void testReadWriteTransactionStartedWhileReadonlyInProgressFails() {
+  void testReadWriteTransactionStartedWhileReadonlyInProgressFails() {
 
     this.transactionManager.beginReadonlyTransaction(TimestampBound.strong());
     assertThatThrownBy(() ->
@@ -99,7 +99,7 @@ public class DatabaseClientTransactionManagerTest {
   }
 
   @Test
-  public void testReadonlyTransactionStartedWhileReadonlyInProgressFails() {
+  void testReadonlyTransactionStartedWhileReadonlyInProgressFails() {
 
     this.transactionManager.beginReadonlyTransaction(TimestampBound.strong());
     assertThatThrownBy(() ->
@@ -109,7 +109,7 @@ public class DatabaseClientTransactionManagerTest {
   }
 
   @Test
-  public void testReadWriteTransactionStartedWhileReadwriteInProgressFails() {
+  void testReadWriteTransactionStartedWhileReadwriteInProgressFails() {
 
     this.transactionManager.beginTransaction();
     assertThatThrownBy(() ->
@@ -119,7 +119,7 @@ public class DatabaseClientTransactionManagerTest {
   }
 
   @Test
-  public void testCommitWithNoStatementsLogsWarning() {
+  void testCommitWithNoStatementsLogsWarning() {
     this.transactionManager.beginTransaction();
     this.transactionManager.commitTransaction();
     assertThat(redirectedOutput.toString())

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -35,7 +35,7 @@ public class SpannerClientLibraryConnectionFactoryTest {
         .setCredentials(NoCredentials.getInstance());
 
   @Test
-  public void testProjectId() {
+  void testProjectId() {
 
     SpannerConnectionConfiguration config = this.configBuilder
         .setProjectId("custom-project")
@@ -46,7 +46,7 @@ public class SpannerClientLibraryConnectionFactoryTest {
   }
 
   @Test
-  public void testUserAgentString() {
+  void testUserAgentString() {
 
     SpannerConnectionConfiguration config = this.configBuilder.build();
 
@@ -57,7 +57,7 @@ public class SpannerClientLibraryConnectionFactoryTest {
   }
 
   @Test
-  public void testSessionCreation() {
+  void testSessionCreation() {
     SpannerClientLibraryConnectionFactory cf =
         new SpannerClientLibraryConnectionFactory(this.configBuilder.build());
     Connection conn = Mono.from(cf.create()).block();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -25,7 +25,7 @@ import io.r2dbc.spi.Connection;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
-public class SpannerClientLibraryConnectionFactoryTest {
+class SpannerClientLibraryConnectionFactoryTest {
 
   SpannerConnectionConfiguration.Builder configBuilder =
       new SpannerConnectionConfiguration.Builder()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -44,7 +44,7 @@ public class SpannerClientLibraryConnectionTest {
   }
 
   @Test
-  public void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
+  void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
 
     when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class SpannerClientLibraryConnectionTest {
+class SpannerClientLibraryConnectionTest {
 
   SpannerConnectionConfiguration mockConfig;
   DatabaseClientReactiveAdapter mockAdapter;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
@@ -37,7 +37,7 @@ public class SpannerClientLibraryDmlStatementTest {
   }
 
   @Test
-  public void executeSingleNoRowsUpdated() {
+  void executeSingleNoRowsUpdated() {
     when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(0L));
 
     SpannerClientLibraryDmlStatement dmlStatement =
@@ -50,7 +50,7 @@ public class SpannerClientLibraryDmlStatementTest {
   }
 
   @Test
-  public void executeMultiple() {
+  void executeMultiple() {
     when(this.mockAdapter.runDmlStatement(any(Statement.class))).thenReturn(Mono.just(0L));
 
     SpannerClientLibraryDmlStatement dmlStatement =

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-public class SpannerClientLibraryDmlStatementTest {
+class SpannerClientLibraryDmlStatementTest {
 
   DatabaseClientReactiveAdapter mockAdapter;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadataTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link SpannerClientLibraryRowMetadata}.
  */
-public class SpannerClientLibraryRowMetadataTest {
+class SpannerClientLibraryRowMetadataTest {
 
   @Test
   void testHandleMissingColumn() {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadataTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadataTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class SpannerClientLibraryRowMetadataTest {
 
   @Test
-  public void testHandleMissingColumn() {
+  void testHandleMissingColumn() {
     SpannerClientLibraryRowMetadata metadata =
         new SpannerClientLibraryRowMetadata(Collections.emptyList());
 
@@ -45,7 +45,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void testHandleOutOfBoundsIndex() {
+  void testHandleOutOfBoundsIndex() {
     SpannerClientLibraryRowMetadata metadata =
         new SpannerClientLibraryRowMetadata(Collections.emptyList());
 
@@ -54,7 +54,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void testEmptyResultSetMetadata() {
+  void testEmptyResultSetMetadata() {
     SpannerClientLibraryRowMetadata metadata =
         new SpannerClientLibraryRowMetadata(Collections.emptyList());
 
@@ -63,7 +63,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void testSpannerRowMetadataRetrieval() {
+  void testSpannerRowMetadataRetrieval() {
 
     List<StructField> structFields =
         buildResultSetMetadata(Type.int64(), Type.string(), Type.bool());
@@ -79,7 +79,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void testSpannerRowMetadataCaseInsensitivity() {
+  void testSpannerRowMetadataCaseInsensitivity() {
     List<StructField> structFields =
         buildResultSetMetadata(Type.int64(), Type.string(), Type.bool());
 
@@ -95,7 +95,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void getColumnNamesReturnsCorrectNamesWhenColumnsPresent() {
+  void getColumnNamesReturnsCorrectNamesWhenColumnsPresent() {
     SpannerClientLibraryRowMetadata metadata =
         new SpannerClientLibraryRowMetadata(
             buildResultSetMetadata(Type.int64(), Type.string(), Type.bool()));
@@ -104,7 +104,7 @@ public class SpannerClientLibraryRowMetadataTest {
   }
 
   @Test
-  public void getColumnNamesReturnsEmptyCollectionWhenNoColumns() {
+  void getColumnNamesReturnsEmptyCollectionWhenNoColumns() {
     SpannerRowMetadata metadata = new SpannerRowMetadata(ResultSetMetadata.getDefaultInstance());
 
     assertThat(metadata.getColumnNames()).isEmpty();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
@@ -34,7 +34,7 @@ import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-public class SpannerClientLibraryStatementTest {
+class SpannerClientLibraryStatementTest {
 
   DatabaseClientReactiveAdapter mockAdapter;
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
@@ -47,7 +47,7 @@ public class SpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void executeSingleNoRowsUpdated() {
+  void executeSingleNoRowsUpdated() {
     when(this.mockAdapter.runSelectStatement(any(Statement.class)))
         .thenReturn(Flux.just(new SpannerClientLibraryRow(SINGLE_COLUMN_STRUCT1)));
 
@@ -67,7 +67,7 @@ public class SpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void executeMultipleReturnsExpectedValuesAndCallsAdapterForEachParameterizedSelect() {
+  void executeMultipleReturnsExpectedValuesAndCallsAdapterForEachParameterizedSelect() {
 
     String query = "SELECT * from table WHERE column=%col1";
     Statement expectedSpannerStatement1 = Statement.newBuilder(query)
@@ -98,7 +98,7 @@ public class SpannerClientLibraryStatementTest {
   }
 
   @Test
-  public void optimizerVersionPassedThroughToQuery() {
+  void optimizerVersionPassedThroughToQuery() {
     QueryOptions queryOptions = QueryOptions.newBuilder().setOptimizerVersion("2").build();
     when(this.mockAdapter.getQueryOptions()).thenReturn(queryOptions);
     SpannerClientLibraryRow mockRow = mock(SpannerClientLibraryRow.class);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
@@ -48,7 +48,7 @@ public class SpannerResultTest {
   }
 
   @Test
-  public void getRowsUpdatedTest() {
+  void getRowsUpdatedTest() {
     StepVerifier.create(
         ((Mono) new SpannerClientLibraryResult(this.resultSet,Mono.just(2)).getRowsUpdated()))
         .expectNext(2)
@@ -56,19 +56,19 @@ public class SpannerResultTest {
   }
 
   @Test
-  public void nullResultSetTest() {
+  void nullResultSetTest() {
     assertThatThrownBy(() -> new SpannerResult(null, Mono.empty()))
         .hasMessage("A non-null flux of rows is required.");
   }
 
   @Test
-  public void nullRowsTest() {
+  void nullRowsTest() {
     assertThatThrownBy(() -> new SpannerResult(Flux.empty(),null))
         .hasMessage("A non-null mono of rows updated is required.");
   }
 
   @Test
-  public void mapTest() {
+  void mapTest() {
 
     Publisher<String> result = new SpannerClientLibraryResult(this.resultSet, Mono.just(0))
         .map((row, metadata) ->

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
@@ -30,7 +30,7 @@ import reactor.test.StepVerifier;
 /**
  * Test for {@link SpannerResult}.
  */
-public class SpannerResultTest {
+class SpannerResultTest {
 
   private Flux<SpannerClientLibraryRow> resultSet;
 

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/it/SpannerR2dbcDialectIT.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/it/SpannerR2dbcDialectIT.java
@@ -45,7 +45,7 @@ import reactor.test.StepVerifier;
  * `testdb` database. This can be configured by overriding the `spanner.instance` and
  * `spanner.database` system properties.
  */
-public class SpannerR2dbcDialectIT {
+class SpannerR2dbcDialectIT {
 
   private static final Logger logger = LoggerFactory.getLogger(SpannerR2dbcDialectIT.class);
 
@@ -94,7 +94,7 @@ public class SpannerR2dbcDialectIT {
   }
 
   @Test
-  public void testReadWrite() {
+  void testReadWrite() {
     insertPresident(new President("Bill Clinton", 1992));
 
     this.databaseClient.select()
@@ -109,7 +109,7 @@ public class SpannerR2dbcDialectIT {
   }
 
   @Test
-  public void testLimitOffsetSupport() {
+  void testLimitOffsetSupport() {
     insertPresident(new President("Bill Clinton", 1992));
     insertPresident(new President("Joe Smith", 1996));
     insertPresident(new President("Bob", 2000));
@@ -130,7 +130,7 @@ public class SpannerR2dbcDialectIT {
   }
 
   @Test
-  public void testRowMap() {
+  void testRowMap() {
     insertPresident(new President("Bill Clinton", 1992));
     insertPresident(new President("Joe Smith", 1996));
     insertPresident(new President("Bob", 2000));


### PR DESCRIPTION
Sonar rule: "JUnit5 test classes and methods should have default package visibility"

Search: `@Test\npublic `
Replace: `@Test\n  `

Search: `public class`
Replace: `class`