### PR TITLE
Parameterize most generics

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/Codec.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/Codec.java
@@ -38,7 +38,7 @@ public interface Codec<T> {
    * @param type input data object type
    * @return true the codec can encode value, false otherwise
    */
-  boolean canEncode(Class type);
+  boolean canEncode(Class<?> type);
 
   /**
    * Decode data to a value.
@@ -71,7 +71,7 @@ public interface Codec<T> {
    *
    * @return the encoded value
    */
-  Class<?> type();
+  Class<T> type();
 
   TypeCode getTypeCode();
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/Codecs.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/Codecs.java
@@ -47,6 +47,6 @@ public interface Codecs {
    */
   Value encode(Object value);
 
-  Codec getCodec(Class type);
+  <T> Codec<T> getCodec(Class<T> type);
 
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecs.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/DefaultCodecs.java
@@ -46,13 +46,13 @@ public final class DefaultCodecs implements Codecs {
    */
   public DefaultCodecs() {
     this.codecs = Arrays.asList(
-        new ArrayCodec(this, Boolean[].class, TypeCode.BOOL),
-        new ArrayCodec(this, ByteBuffer[].class, TypeCode.BYTES),
-        new ArrayCodec(this, LocalDate[].class, TypeCode.DATE),
-        new ArrayCodec(this, Double[].class, TypeCode.FLOAT64),
-        new ArrayCodec(this, Long[].class, TypeCode.INT64),
-        new ArrayCodec(this, String[].class, TypeCode.STRING),
-        new ArrayCodec(this, LocalDateTime[].class, TypeCode.TIMESTAMP),
+        new ArrayCodec<>(this, Boolean[].class, TypeCode.BOOL),
+        new ArrayCodec<>(this, ByteBuffer[].class, TypeCode.BYTES),
+        new ArrayCodec<>(this, LocalDate[].class, TypeCode.DATE),
+        new ArrayCodec<>(this, Double[].class, TypeCode.FLOAT64),
+        new ArrayCodec<>(this, Long[].class, TypeCode.INT64),
+        new ArrayCodec<>(this, String[].class, TypeCode.STRING),
+        new ArrayCodec<>(this, LocalDateTime[].class, TypeCode.TIMESTAMP),
         new SpannerCodec<>(Boolean.class, TypeCode.BOOL,
             v -> Value.newBuilder().setBoolValue(v).build()),
         new SpannerCodec<>(ByteBuffer.class, TypeCode.BYTES,
@@ -123,7 +123,7 @@ public final class DefaultCodecs implements Codecs {
     if (value == null) {
       return NULL_VALUE;
     }
-    Codec codec = getCodec(value.getClass());
+    Codec<?> codec = getCodec(value.getClass());
     return codec.encode(value);
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/SpannerCodec.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/codecs/SpannerCodec.java
@@ -76,7 +76,7 @@ class SpannerCodec<T> implements Codec<T> {
   }
 
   @Override
-  public Class<?> type() {
+  public Class<T> type() {
     return this.type;
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/statement/TypedNull.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/statement/TypedNull.java
@@ -21,13 +21,13 @@ package com.google.cloud.spanner.r2dbc.statement;
  */
 public class TypedNull {
 
-  private final Class type;
+  private final Class<?> type;
 
-  public TypedNull(Class type) {
+  public TypedNull(Class<?> type) {
     this.type = type;
   }
 
-  public Class getType() {
+  public Class<?> getType() {
     return this.type;
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/util/ObservableReactiveUtil.java
@@ -40,7 +40,7 @@ public class ObservableReactiveUtil {
    */
   public static <ResponseT> Mono<ResponseT> unaryCall(
       Consumer<StreamObserver<ResponseT>> remoteCall) {
-    return Mono.create(sink -> remoteCall.accept(new UnaryStreamObserver(sink)));
+    return Mono.create(sink -> remoteCall.accept(new UnaryStreamObserver<>(sink)));
   }
 
   /**
@@ -56,7 +56,7 @@ public class ObservableReactiveUtil {
       Consumer<StreamObserver<ResponseT>> remoteCall) {
 
     return Flux.create(sink -> {
-      StreamingObserver observer = new StreamingObserver(sink);
+      StreamingObserver<RequestT, ResponseT> observer = new StreamingObserver<>(sink);
       remoteCall.accept(observer);
       sink.onRequest(demand -> observer.request(demand));
     });
@@ -110,9 +110,9 @@ public class ObservableReactiveUtil {
 
     private boolean terminalEventReceived;
 
-    private final MonoSink sink;
+    private final MonoSink<ResponseT> sink;
 
-    public UnaryStreamObserver(MonoSink sink) {
+    public UnaryStreamObserver(MonoSink<ResponseT> sink) {
       this.sink = sink;
     }
 


### PR DESCRIPTION
I am leaving some binder generic smells alone for now; it's going to be part of advanced parameter binding that's been merged in the SPI anyway.