### PR TITLE
Cleanup tests properly to avoid session leaks

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
@@ -12,7 +12,7 @@
     <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <name>Google Cloud Spanner R2DBC via direct SPI</name>
+  <name>Google Cloud Spanner R2DBC Sample via direct SPI</name>
 
   <properties>
     <apache-commons-io.version>2.6</apache-commons-io.version>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
@@ -47,14 +47,6 @@
       <version>${apache-commons-io.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- facilitate project ID discovery in integration tests -->
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
@@ -59,7 +59,7 @@ public class BookExampleApp {
   }
 
   public void cleanup() {
-    this.connection.close();
+    Mono.from(this.connection.close()).block();
   }
 
   /**

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
@@ -66,7 +66,7 @@ public class BookExampleApp {
    * Creates a table named BOOKS.
    */
   public void createTable() {
-    Mono.from(connection.createStatement("CREATE TABLE BOOKS ("
+    Mono.from(this.connection.createStatement("CREATE TABLE BOOKS ("
             + "  ID STRING(20) NOT NULL,"
             + "  TITLE STRING(MAX) NOT NULL"
             + ") PRIMARY KEY (ID)").execute())
@@ -78,7 +78,7 @@ public class BookExampleApp {
    * Saves two books.
    */
   public void saveBooks() {
-    Statement statement = connection.createStatement(
+    Statement statement = this.connection.createStatement(
         "INSERT BOOKS "
             + "(ID, TITLE)"
             + " VALUES "
@@ -91,8 +91,8 @@ public class BookExampleApp {
 
     Flux.concat(this.connection.beginTransaction(),
         Flux.from(statement.execute()).flatMapSequential(r -> Mono.from(r.getRowsUpdated())).then(),
-        connection.commitTransaction()
-    ).doOnNext(x -> System.out.println("Insert books transaction committed."))
+        this.connection.commitTransaction()
+    ).doOnComplete(() -> System.out.println("Insert books transaction committed."))
         .blockLast();
   }
 
@@ -100,7 +100,7 @@ public class BookExampleApp {
    * Finds books in the table named BOOKS.
    */
   public void retrieveBooks() {
-    Flux.from(connection.createStatement("SELECT * FROM books").execute())
+    Flux.from(this.connection.createStatement("SELECT * FROM books").execute())
         .flatMap(spannerResult -> spannerResult.map(
             (r, meta) -> "Retrieved book: " + r.get("ID", String.class) + " " + r
                 .get("TITLE", String.class)

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/BookExampleApp.java
@@ -21,10 +21,12 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.IN
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
+import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
+import io.r2dbc.spi.Statement;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -34,6 +36,8 @@ import reactor.core.publisher.Mono;
 public class BookExampleApp {
 
   private final ConnectionFactory connectionFactory;
+
+  private final Connection connection;
 
   /**
    * Constructor.
@@ -50,14 +54,19 @@ public class BookExampleApp {
         .option(INSTANCE, sampleInstance)
         .option(DATABASE, sampleDatabase)
         .build());
+
+    this.connection = Mono.from(this.connectionFactory.create()).block();
+  }
+
+  public void cleanup() {
+    this.connection.close();
   }
 
   /**
    * Creates a table named BOOKS.
    */
   public void createTable() {
-    Mono.from(this.connectionFactory.create())
-        .delayUntil(c -> c.createStatement("CREATE TABLE BOOKS ("
+    Mono.from(connection.createStatement("CREATE TABLE BOOKS ("
             + "  ID STRING(20) NOT NULL,"
             + "  TITLE STRING(MAX) NOT NULL"
             + ") PRIMARY KEY (ID)").execute())
@@ -69,37 +78,29 @@ public class BookExampleApp {
    * Saves two books.
    */
   public void saveBooks() {
-    Mono.from(this.connectionFactory.create())
-        .delayUntil(c -> c.beginTransaction())
-        .delayUntil(c ->
-            Mono.fromRunnable(() ->
-                Flux.from(c.createStatement(
-                    "INSERT BOOKS "
-                        + "(ID, TITLE)"
-                        + " VALUES "
-                        + "(@id, @title)")
-                    .bind("id", "book1")
-                    .bind("title", "Book One")
-                    .add()
-                    .bind("id", "book2")
-                    .bind("title", "Book Two")
-                    .execute())
-                    .flatMapSequential(r -> Mono.from(r.getRowsUpdated()))
-                    .collectList().block()
-            )
-        )
-        .delayUntil(c -> c.commitTransaction())
-        .doOnNext(x -> System.out.println("Insert books transaction committed."))
-        .block();
+    Statement statement = connection.createStatement(
+        "INSERT BOOKS "
+            + "(ID, TITLE)"
+            + " VALUES "
+            + "(@id, @title)")
+        .bind("id", "book1")
+        .bind("title", "Book One")
+        .add()
+        .bind("id", "book2")
+        .bind("title", "Book Two");
+
+    Flux.concat(this.connection.beginTransaction(),
+        Flux.from(statement.execute()).flatMapSequential(r -> Mono.from(r.getRowsUpdated())).then(),
+        connection.commitTransaction()
+    ).doOnNext(x -> System.out.println("Insert books transaction committed."))
+        .blockLast();
   }
 
   /**
    * Finds books in the table named BOOKS.
    */
   public void retrieveBooks() {
-    Mono.from(this.connectionFactory.create())
-        .flatMapMany(connection -> connection
-            .createStatement("SELECT * FROM books").execute())
+    Flux.from(connection.createStatement("SELECT * FROM books").execute())
         .flatMap(spannerResult -> spannerResult.map(
             (r, meta) -> "Retrieved book: " + r.get("ID", String.class) + " " + r
                 .get("TITLE", String.class)
@@ -114,8 +115,7 @@ public class BookExampleApp {
    */
   public void dropTableIfPresent() {
     try {
-      Mono.from(this.connectionFactory.create())
-          .delayUntil(c -> c.createStatement("DROP TABLE BOOKS").execute())
+      Mono.from(this.connection.createStatement("DROP TABLE BOOKS").execute())
           .doOnNext(x -> System.out.println("Table drop completed."))
           .block();
     } catch (Exception e) {

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/SampleApplication.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/main/java/com/example/SampleApplication.java
@@ -52,6 +52,7 @@ public class SampleApplication {
     bookExampleApp.createTable();
     bookExampleApp.saveBooks();
     bookExampleApp.retrieveBooks();
+    bookExampleApp.cleanup();
   }
 
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
@@ -18,20 +18,9 @@ package com.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.spanner.Spanner;
-import com.google.cloud.spanner.r2dbc.client.GrpcClient;
-import com.google.cloud.spanner.r2dbc.util.ObservableReactiveUtil;
-import com.google.spanner.v1.DatabaseName;
-import com.google.spanner.v1.ListSessionsRequest;
-import com.google.spanner.v1.ListSessionsResponse;
-import com.google.spanner.v1.Session;
-import com.google.spanner.v1.SpannerGrpc.SpannerStub;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/src/test/java/com/example/BookExampleAppIT.java
@@ -18,9 +18,20 @@ package com.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.r2dbc.client.GrpcClient;
+import com.google.cloud.spanner.r2dbc.util.ObservableReactiveUtil;
+import com.google.spanner.v1.DatabaseName;
+import com.google.spanner.v1.ListSessionsRequest;
+import com.google.spanner.v1.ListSessionsResponse;
+import com.google.spanner.v1.Session;
+import com.google.spanner.v1.SpannerGrpc.SpannerStub;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -60,6 +71,7 @@ class BookExampleAppIT {
     bookExampleApp.createTable();
     bookExampleApp.saveBooks();
     bookExampleApp.retrieveBooks();
+    bookExampleApp.cleanup();
 
     assertThat(baos.toString()).contains("Table creation completed.");
     assertThat(baos.toString()).contains("Insert books transaction committed.");

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -141,5 +141,4 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
   public Publisher<Void> close() {
     return this.clientLibraryAdapter.close();
   }
-
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -141,4 +141,5 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
   public Publisher<Void> close() {
     return this.clientLibraryAdapter.close();
   }
+
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -63,7 +63,6 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory,
    */
   @Override
   public Publisher<Void> close() {
-    // TODO: check if it would still be blocking in Cloud Spanner Connection API
     return Mono.fromRunnable(() -> this.spannerClient.close());
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.util.Assert;
+import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -29,7 +30,7 @@ import reactor.core.publisher.Mono;
  * The factory is for a specific project/instance/database + credentials.
  *
  */
-public class SpannerClientLibraryConnectionFactory implements ConnectionFactory {
+public class SpannerClientLibraryConnectionFactory implements ConnectionFactory, Closeable {
 
   private SpannerConnectionConfiguration config;
 
@@ -54,5 +55,16 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory 
   @Override
   public ConnectionFactoryMetadata getMetadata() {
     return null;
+  }
+
+  /**
+   * This method is blocking, to be called at the end of the application lifecycle.
+   * @return
+   */
+  @Override
+  public Publisher<Void> close() {
+    // TODO: check if it would still be blocking in Cloud Spanner Connection API
+    this.spannerClient.close();
+    return Mono.empty();
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -64,7 +64,6 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory,
   @Override
   public Publisher<Void> close() {
     // TODO: check if it would still be blocking in Cloud Spanner Connection API
-    this.spannerClient.close();
-    return Mono.empty();
+    return Mono.fromRunnable(() -> this.spannerClient.close());
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIT.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.r2dbc.api.SpannerConnection;
 import com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryConnectionFactory;
+import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,6 +127,11 @@ class ClientLibraryBasedIT {
         conn.createStatement("DELETE FROM BOOKS WHERE true").execute())
         .flatMap(rs -> Mono.from(rs.getRowsUpdated()))
         .block();
+  }
+
+  @AfterAll
+  static void cleanUpEnvironment() {
+  //  ((Closeable) connectionFactory).close();
   }
 
   @Test
@@ -672,6 +679,7 @@ class ClientLibraryBasedIT {
 
     StepVerifier.create(urlBasedConnectionFactory.create())
         .expectNextMatches(cf -> cf instanceof SpannerClientLibraryConnectionFactory);
+    ((Closeable) urlBasedConnectionFactory).close();
   }
 
   private Publisher<Long> getFirstNumber(Result result) {
@@ -699,4 +707,5 @@ class ClientLibraryBasedIT {
         .as("Expected rows inserted")
         .verifyComplete();
   }
+
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
@@ -34,12 +34,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * This class does not follow test naming conventions intentionally.
  * It is intended for one-off use troubleshooting and cleaning up sessions.
+ * Note that during normal operation, no leftover sessions should be present. If leftover sessions
+ * are detected, it's due to a bug and should be fixed.
  */
+@Disabled
 public class SessionCleanupUtils {
 
   static GrpcClient client;
@@ -54,6 +58,7 @@ public class SessionCleanupUtils {
   @Test
   void deleteAllSessions() throws Exception {
     List<String> activeSessions = getSessionNames();
+    System.out.println("Deleting " + activeSessions.size() + " sessions");
     int i = 0;
     for (String name : activeSessions) {
       if (i % 50 == 0) {
@@ -81,15 +86,19 @@ public class SessionCleanupUtils {
           });
     }
 
+    Thread.sleep(1000);
+
   }
 
+  /** In stable state, there should be no stray sessions.
+   * Exceptions:
+   * - you are running in a CI environment and there are other tests running.
+   * - you want to verify session state after a test. In this case, make another method
+   *   verifying the correct number of sessions (exactly 1, greater than 10 etc.)
+   */
   @Test
-  // can be used as a test or as a helper verifier method.
-  void verifyAtMostOneLeftoverSession() throws Exception {
+  void verifyNoLeftoverSessions() throws Exception {
     List<String> activeSessions = getSessionNames();
-
-    // only the current session should be present, or none
-    //assertThat(activeSessions).hasSizeLessThan(2);
     assertThat(activeSessions).isEmpty();
   }
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.spanner.r2dbc.client.GrpcClient;
+import com.google.cloud.spanner.r2dbc.util.ObservableReactiveUtil;
+import com.google.protobuf.Empty;
+import com.google.spanner.v1.DatabaseName;
+import com.google.spanner.v1.DeleteSessionRequest;
+import com.google.spanner.v1.ListSessionsRequest;
+import com.google.spanner.v1.ListSessionsResponse;
+import com.google.spanner.v1.Session;
+import com.google.spanner.v1.SpannerGrpc.SpannerStub;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class does not follow test naming conventions intentionally.
+ * It is intended for one-off use troubleshooting and cleaning up sessions.
+ */
+public class SessionCleanupUtils {
+
+  static GrpcClient client;
+  static SpannerStub spannerStub;
+
+  @BeforeAll
+  static void setUpEnvironment() throws Exception {
+    client = new GrpcClient(GoogleCredentials.getApplicationDefault());
+    spannerStub = client.getSpanner();
+  }
+
+  @Test
+  void deleteAllSessions() throws Exception {
+    List<String> activeSessions = getSessionNames();
+    int i = 0;
+    for (String name : activeSessions) {
+      if (i % 50 == 0) {
+        // occasionally give all calls time to finish.
+        Thread.sleep(200);
+      }
+      i++;
+      spannerStub.deleteSession(
+          DeleteSessionRequest.newBuilder().setName(name).build(),
+          new StreamObserver<Empty>() {
+            @Override
+            public void onNext(Empty empty) {
+
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+
+            }
+
+            @Override
+            public void onCompleted() {
+              System.out.println("Deleted session " + name);
+            }
+          });
+    }
+
+  }
+
+  @Test
+  // can be used as a test or as a helper verifier method.
+  void verifyAtMostOneLeftoverSession() throws Exception {
+    List<String> activeSessions = getSessionNames();
+
+    // only the current session should be present, or none
+    //assertThat(activeSessions).hasSizeLessThan(2);
+    assertThat(activeSessions).isEmpty();
+  }
+
+  private List<String> getSessionNames() throws Exception {
+    String databaseName = DatabaseName.format(ServiceOptions.getDefaultProjectId(),
+        DatabaseProperties.INSTANCE, DatabaseProperties.DATABASE);
+
+    String nextPageToken = null;
+    List<String> sessionNames = new ArrayList<>();
+
+    do {
+      ListSessionsRequest.Builder requestBuilder =
+          ListSessionsRequest.newBuilder().setDatabase(databaseName);
+
+      if (nextPageToken != null) {
+        requestBuilder.setPageToken(nextPageToken);
+      }
+
+      ListSessionsResponse listSessionsResponse =
+          ObservableReactiveUtil.<ListSessionsResponse>unaryCall(
+              obs -> spannerStub.listSessions(requestBuilder.build(), obs))
+              .block();
+
+      nextPageToken = listSessionsResponse.getNextPageToken();
+      sessionNames.addAll(
+          listSessionsResponse.getSessionsList().stream()
+              .map(Session::getName)
+              .collect(Collectors.toList()));
+    } while (nextPageToken != null && !"".equals(nextPageToken));
+
+
+    return sessionNames;
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner.r2dbc.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.spanner.r2dbc.client.GrpcClient;
@@ -96,7 +94,11 @@ class SessionCleanupUtils {
    */
   static void verifyNoLeftoverSessions() throws Exception {
     List<String> activeSessions = getSessionNames();
-    assertThat(activeSessions).isEmpty();
+    if (activeSessions.isEmpty()) {
+      System.out.println("No leftover sessions, yay!");
+    } else {
+      throw new IllegalStateException("Expected no sessions, but found " + activeSessions.size());
+    }
   }
 
   private static List<String> getSessionNames() throws Exception {

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SessionCleanupUtils.java
@@ -33,30 +33,28 @@ import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 /**
- * This class does not follow test naming conventions intentionally.
- * It is intended for one-off use troubleshooting and cleaning up sessions.
+ * Driver class for one-off use troubleshooting and cleaning up of Cloud Spanner sessions.
  * Note that during normal operation, no leftover sessions should be present. If leftover sessions
  * are detected, it's due to a bug and should be fixed.
  */
-@Disabled
-public class SessionCleanupUtils {
+class SessionCleanupUtils {
 
   static GrpcClient client;
   static SpannerStub spannerStub;
 
-  @BeforeAll
-  static void setUpEnvironment() throws Exception {
+  public static void main(String[] args) throws Exception {
     client = new GrpcClient(GoogleCredentials.getApplicationDefault());
     spannerStub = client.getSpanner();
+
+    // Uncomment if necessary to clear already-accumulated sessions.
+    //deleteAllSessions();
+
+    verifyNoLeftoverSessions();
   }
 
-  @Test
-  void deleteAllSessions() throws Exception {
+  static void deleteAllSessions() throws Exception {
     List<String> activeSessions = getSessionNames();
     System.out.println("Deleting " + activeSessions.size() + " sessions");
     int i = 0;
@@ -96,13 +94,12 @@ public class SessionCleanupUtils {
    * - you want to verify session state after a test. In this case, make another method
    *   verifying the correct number of sessions (exactly 1, greater than 10 etc.)
    */
-  @Test
-  void verifyNoLeftoverSessions() throws Exception {
+  static void verifyNoLeftoverSessions() throws Exception {
     List<String> activeSessions = getSessionNames();
     assertThat(activeSessions).isEmpty();
   }
 
-  private List<String> getSessionNames() throws Exception {
+  private static List<String> getSessionNames() throws Exception {
     String databaseName = DatabaseName.format(ServiceOptions.getDefaultProjectId(),
         DatabaseProperties.INSTANCE, DatabaseProperties.DATABASE);
 


### PR DESCRIPTION
Noticed during fixit that we were running out of available server side sessions. 

Spanner client library-based ConnectionFactory now implements R2DBC `Closeable`, as discussed in #284. Closing that out requires a small bit of documentation that I will do separately.

Fixes #310.