### PR TITLE
Switch main branch to, well, main!

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -2,7 +2,7 @@ name: SonarCloud Analysis
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -2,7 +2,7 @@ name: Unit Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An implementation of the [R2DBC](https://r2dbc.io/) driver for [Cloud Spanner](https://cloud.google.com/spanner/) is being developed in this repository.
 
-A [Spring Data R2DBC dialect for Cloud Spanner](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-spring-data-r2dbc) dialect is available, as well.
+A [Spring Data R2DBC dialect for Cloud Spanner](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/main/cloud-spanner-spring-data-r2dbc) dialect is available, as well.
 
 ## Setup Instructions
 

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -5,7 +5,7 @@ All scripts can be found in the `.kokoro` directory.
 
 ## Snapshots
 
-A commit to the `master` branch will automatically trigger the `prod:cloud-java-frameworks/cloud-spanner-r2dbc/continuous` job that will publish snapshots to https://oss.sonatype.org/content/repositories/snapshots/com/google/cloud/cloud-spanner-r2dbc/)[Sonatype Snapshots repository].
+A commit to the `main` branch will automatically trigger the `prod:cloud-java-frameworks/cloud-spanner-r2dbc/continuous` job that will publish snapshots to https://oss.sonatype.org/content/repositories/snapshots/com/google/cloud/cloud-spanner-r2dbc/)[Sonatype Snapshots repository].
 
 ## Releases
 

--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -14,7 +14,7 @@
 
   <name>Google Cloud Spanner R2DBC Driver</name>
   <description>Reactive R2DBC driver implementation for Cloud Spanner.</description>
-  <url>https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc</url>
+  <url>https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/main/cloud-spanner-r2dbc</url>
 
   <dependencies>
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/util/SpannerExceptionUtil.java
@@ -106,7 +106,7 @@ public class SpannerExceptionUtil {
    * Returns whether an exception thrown should be retried.
    *
    * <p>Derived from google-cloud-java/SpannerExceptionFactory.java:
-   * https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
+   * https://github.com/googleapis/java-spanner/blob/master/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerExceptionFactory.java
    */
   private static boolean isRetryable(StatusRuntimeException statusRuntimeException) {
     if (statusRuntimeException.getStatus().getCode() == Status.Code.INTERNAL

--- a/cloud-spanner-spring-data-r2dbc/README.md
+++ b/cloud-spanner-spring-data-r2dbc/README.md
@@ -44,4 +44,4 @@ See the [Spring Data R2DBC documentation](https://docs.spring.io/spring-data/r2d
 
 ## Sample Application
 
-We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/master/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample) which demonstrates using the Spring Data R2DBC framework with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).
+We provide a [sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/main/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample) which demonstrates using the Spring Data R2DBC framework with Cloud Spanner in [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html).


### PR DESCRIPTION
The link to Cloud Spanner client library changed just because it was for an outdated repo; no branch switch there yet.