### PR TITLE
Upgrade to modern Spring Data R2DBC

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -27,13 +27,6 @@
         <artifactId>cloud-spanner-r2dbc</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.springframework.boot.experimental</groupId>
-        <artifactId>spring-boot-bom-r2dbc</artifactId>
-        <version>0.1.0.M3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -45,24 +38,11 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot.experimental</groupId>
-      <artifactId>spring-boot-starter-data-r2dbc</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
 
   </dependencies>
-
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -17,6 +17,7 @@
 package com.example;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 /**
@@ -26,8 +27,10 @@ import org.springframework.data.relational.core.mapping.Table;
 public class Book {
 
   @Id
+  @Column("ID")
   private String id;
 
+  @Column("TITLE")
   private String title;
 
   public Book(String id, String title) {
@@ -41,5 +44,21 @@ public class Book {
 
   public String getTitle() {
     return this.title;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public String toString() {
+    return "Book{" +
+        "id='" + id + '\'' +
+        ", title='" + title + '\'' +
+        '}';
   }
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -46,19 +46,4 @@ public class Book {
     return this.title;
   }
 
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
-  }
-
-  @Override
-  public String toString() {
-    return "Book{" +
-        "id='" + id + '\'' +
-        ", title='" + title + '\'' +
-        '}';
-  }
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -37,11 +37,12 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Hooks;
 
 /**
  * Driver application showing Cloud Spanner R2DBC use with Spring Data.
@@ -62,6 +63,7 @@ public class SpringDataR2dbcApp {
   private DatabaseClient r2dbcClient;
 
   public static void main(String[] args) {
+    Hooks.onOperatorDebug();
     Assert.notNull(INSTANCE, "Please provide spanner.instance property");
     Assert.notNull(DATABASE, "Please provide spanner.database property");
     Assert.notNull(GCP_PROJECT, "Please provide gcp.project property");
@@ -86,11 +88,12 @@ public class SpringDataR2dbcApp {
   public void setUpData() {
     LOGGER.info("Setting up test table BOOK...");
     try {
-      r2dbcClient.execute("CREATE TABLE BOOK ("
+      r2dbcClient.sql("CREATE TABLE BOOK ("
           + "  ID STRING(36) NOT NULL,"
           + "  TITLE STRING(MAX) NOT NULL"
-          + ") PRIMARY KEY (ID)")
-          .fetch().rowsUpdated().block();
+          + ") PRIMARY KEY (ID)"
+      ).fetch().rowsUpdated().block();
+
     } catch (Exception e) {
       LOGGER.info("Failed to set up test table BOOK", e);
       return;
@@ -102,7 +105,7 @@ public class SpringDataR2dbcApp {
   public void tearDownData() {
     LOGGER.info("Deleting test table BOOK...");
     try {
-      r2dbcClient.execute("DROP TABLE BOOK")
+      r2dbcClient.sql("DROP TABLE BOOK")
           .fetch().rowsUpdated().block();
     } catch (Exception e) {
       LOGGER.info("Failed to delete test table BOOK", e);

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
@@ -18,11 +18,10 @@ package com.example;
 
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
@@ -40,24 +39,23 @@ import reactor.core.publisher.Mono;
 public class WebController {
 
   @Autowired
-  private DatabaseClient r2dbcClient;
+  private R2dbcEntityTemplate r2dbcEntityTemplate;
 
   @Autowired
   private BookRepository r2dbcRepository;
 
   @GetMapping("/list")
   public Flux<Book> listBooks() {
-    return r2dbcClient.execute("SELECT id, title FROM BOOK")
-        .as(Book.class)
-        .fetch().all();
+    return r2dbcEntityTemplate
+        .select(Book.class)
+        .all();
   }
 
   @PostMapping("/add")
   public Mono<Void> addBook(@RequestBody String bookTitle) {
-    return r2dbcClient.insert()
-        .into("book")
-        .value("id", UUID.randomUUID().toString())
-        .value("title", bookTitle)
+    return r2dbcEntityTemplate.insert(Book.class)
+        .using(new Book(UUID.randomUUID().toString(), bookTitle))
+        .log()
         .then();
   }
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/application.properties
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.org.springframework.r2dbc=DEBUG

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -207,7 +207,11 @@ class DatabaseClientReactiveAdapter {
    * @return reactive pipeline for running a DML statement
    */
   Mono<Long> runDmlStatement(com.google.cloud.spanner.Statement statement) {
-    return runBatchDmlInternal(ctx -> ctx.executeUpdateAsync(statement));
+    return runBatchDmlInternal(
+        ctx -> {
+          System.out.println("*** Executing update on " + statement.getSql());
+          return ctx.executeUpdateAsync(statement);
+        });
   }
 
   /**

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -207,11 +207,7 @@ class DatabaseClientReactiveAdapter {
    * @return reactive pipeline for running a DML statement
    */
   Mono<Long> runDmlStatement(com.google.cloud.spanner.Statement statement) {
-    return runBatchDmlInternal(
-        ctx -> {
-          System.out.println("*** Executing update on " + statement.getSql());
-          return ctx.executeUpdateAsync(statement);
-        });
+    return runBatchDmlInternal(ctx -> ctx.executeUpdateAsync(statement));
   }
 
   /**

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryMetadata;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.Connection;
@@ -54,7 +55,7 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory,
 
   @Override
   public ConnectionFactoryMetadata getMetadata() {
-    return null;
+    return SpannerConnectionFactoryMetadata.INSTANCE;
   }
 
   /**

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactory.java
@@ -67,7 +67,7 @@ public class SpannerClientLibraryConnectionFactory implements ConnectionFactory,
    * @return A Mono indicating that the blocking call completed
    */
   @Override
-  public Publisher<Void> close() {
+  public Mono<Void> close() {
     return Mono.fromRunnable(() -> this.spannerClient.close());
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryMetadata;
 import io.r2dbc.spi.Connection;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -86,5 +87,15 @@ class SpannerClientLibraryConnectionFactoryTest {
     verify(mockSpanner).close();
     verifyNoMoreInteractions(mockSpanner);
 
+  }
+
+  @Test
+  void testGetMetadata() {
+    SpannerClientLibraryConnectionFactory cf =
+        new SpannerClientLibraryConnectionFactory(this.configBuilder.build());
+
+    assertThat(cf.getMetadata()).isSameAs(SpannerConnectionFactoryMetadata.INSTANCE);
+
+    cf.close().block();
   }
 }

--- a/cloud-spanner-spring-data-r2dbc/pom.xml
+++ b/cloud-spanner-spring-data-r2dbc/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
 
   <properties>
-    <spring-data-r2dbc.version>1.0.0.RELEASE</spring-data-r2dbc.version>
+    <spring-data-r2dbc.version>1.2.6</spring-data-r2dbc.version>
   </properties>
 
   <dependencies>

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProvider.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProvider.java
@@ -1,0 +1,17 @@
+package com.google.cloud.spanner.r2dbc.springdata;
+
+import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryMetadata;
+import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.r2dbc.core.binding.BindMarkersFactory;
+import org.springframework.r2dbc.core.binding.BindMarkersFactoryResolver.BindMarkerFactoryProvider;
+
+public class SpannerBindMarkerFactoryProvider implements BindMarkerFactoryProvider {
+
+  @Override
+  public BindMarkersFactory getBindMarkers(ConnectionFactory connectionFactory) {
+    if (SpannerConnectionFactoryMetadata.INSTANCE.equals(connectionFactory.getMetadata())) {
+      return SpannerR2dbcDialect.NAMED;
+    }
+    return null;
+  }
+}

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProvider.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spanner.r2dbc.springdata;
 
 import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryMetadata;
@@ -5,6 +21,9 @@ import io.r2dbc.spi.ConnectionFactory;
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
 import org.springframework.r2dbc.core.binding.BindMarkersFactoryResolver.BindMarkerFactoryProvider;
 
+/**
+ * Provides the named bind marker strategy for Cloud Spanner.
+ */
 public class SpannerBindMarkerFactoryProvider implements BindMarkerFactoryProvider {
 
   @Override

--- a/cloud-spanner-spring-data-r2dbc/src/main/resources/META-INF/spring.factories
+++ b/cloud-spanner-spring-data-r2dbc/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.data.r2dbc.dialect.DialectResolver$R2dbcDialectProvider=\
 com.google.cloud.spanner.r2dbc.springdata.SpannerR2dbcDialectProvider
+org.springframework.r2dbc.core.binding.BindMarkersFactoryResolver$BindMarkerFactoryProvider=com.google.cloud.spanner.r2dbc.springdata.SpannerBindMarkerFactoryProvider

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProviderTest.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerBindMarkerFactoryProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.springdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionFactory;
+import com.google.cloud.spanner.r2dbc.client.Client;
+import com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryConnectionFactory;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryMetadata;
+import org.junit.jupiter.api.Test;
+import org.springframework.r2dbc.core.binding.BindMarkersFactory;
+
+class SpannerBindMarkerFactoryProviderTest {
+
+  @Test
+  void spannerBindMarkersFoundForV1ConnectionFactory() {
+    SpannerBindMarkerFactoryProvider provider = new SpannerBindMarkerFactoryProvider();
+    SpannerConnectionFactory cf = new SpannerConnectionFactory(
+        mock(Client.class), mock(SpannerConnectionConfiguration.class));
+
+    BindMarkersFactory factory = provider.getBindMarkers(cf);
+    assertThat(factory).isSameAs(SpannerR2dbcDialect.NAMED);
+  }
+
+  @Test
+  void spannerBindMarkersFoundForV2ConnectionFactory() {
+    SpannerBindMarkerFactoryProvider provider = new SpannerBindMarkerFactoryProvider();
+    SpannerConnectionConfiguration mockConfig = mock(SpannerConnectionConfiguration.class);
+    SpannerOptions mockSpannerOptions = mock(SpannerOptions.class);
+    Spanner mockService = mock(Spanner.class);
+
+    when(mockConfig.buildSpannerOptions()).thenReturn(mockSpannerOptions);
+    when(mockSpannerOptions.getService()).thenReturn(mockService);
+
+    SpannerClientLibraryConnectionFactory cf =
+        new SpannerClientLibraryConnectionFactory(mockConfig);
+
+    BindMarkersFactory factory = provider.getBindMarkers(cf);
+    assertThat(factory).isSameAs(SpannerR2dbcDialect.NAMED);
+  }
+
+  @Test
+  void spannerBindMarkersNotFoundForUnknownFactory() {
+    SpannerBindMarkerFactoryProvider provider = new SpannerBindMarkerFactoryProvider();
+    ConnectionFactory cf = mock(ConnectionFactory.class);
+    ConnectionFactoryMetadata mockMetadata = mock(ConnectionFactoryMetadata.class);
+    when(cf.getMetadata()).thenReturn(mockMetadata);
+    when(mockMetadata.getName()).thenReturn("SOME_DATABASE");
+
+    BindMarkersFactory factory = provider.getBindMarkers(cf);
+    assertThat(factory).isNull();
+  }
+
+}

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
@@ -19,9 +19,9 @@ package com.google.cloud.spanner.r2dbc.springdata;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.data.r2dbc.dialect.BindMarkers;
 import org.springframework.data.relational.core.dialect.LimitClause;
 import org.springframework.data.relational.core.dialect.LimitClause.Position;
+import org.springframework.r2dbc.core.binding.BindMarkers;
 
 class SpannerR2dbcDialectTest {
 

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialectTest.java
@@ -17,10 +17,16 @@
 package com.google.cloud.spanner.r2dbc.springdata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.data.relational.core.dialect.LimitClause;
-import org.springframework.data.relational.core.dialect.LimitClause.Position;
+import org.springframework.data.relational.core.dialect.LockClause;
+import org.springframework.data.relational.core.sql.LockMode;
+import org.springframework.data.relational.core.sql.LockOptions;
+import org.springframework.data.relational.core.sql.SQL;
+import org.springframework.data.relational.core.sql.Select;
+import org.springframework.data.relational.core.sql.Table;
 import org.springframework.r2dbc.core.binding.BindMarkers;
 
 class SpannerR2dbcDialectTest {
@@ -31,7 +37,7 @@ class SpannerR2dbcDialectTest {
     assertThat(clause.getOffset(100)).isEqualTo("LIMIT 9223372036854775807 OFFSET 100");
     assertThat(clause.getLimit(42)).isEqualTo("LIMIT 42");
     assertThat(clause.getLimitOffset(42, 100)).isEqualTo("LIMIT 42 OFFSET 100");
-    assertThat(clause.getClausePosition()).isSameAs(Position.AFTER_ORDER_BY);
+    assertThat(clause.getClausePosition()).isSameAs(LimitClause.Position.AFTER_ORDER_BY);
   }
 
   @Test
@@ -41,6 +47,22 @@ class SpannerR2dbcDialectTest {
     assertThat(bindMarkers).isNotNull();
     assertThat(bindMarkers.next().getPlaceholder()).isEqualTo("@val0");
     assertThat(bindMarkers.next().getPlaceholder()).isEqualTo("@val1");
+  }
+
+  @Test
+  void lockStringAlwaysEmpty() {
+    SpannerR2dbcDialect dialect = new SpannerR2dbcDialect();
+    Table table = SQL.table("aTable");
+    Select sql = Select.builder().select(table.column("aColumn"))
+        .from(table)
+        .build();
+    LockOptions lockOptions = new LockOptions(LockMode.PESSIMISTIC_READ, sql.getFrom());
+
+    LockClause lock = dialect.lock();
+
+    assertNotNull(lock);
+    assertThat(lock.getLock(lockOptions)).isEmpty();
+    assertThat(lock.getClausePosition()).isSameAs(LockClause.Position.AFTER_FROM_TABLE);
   }
 
 }

--- a/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/it/entities/President.java
+++ b/cloud-spanner-spring-data-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/springdata/it/entities/President.java
@@ -16,13 +16,17 @@
 
 package com.google.cloud.spanner.r2dbc.springdata.it.entities;
 
+import org.springframework.data.relational.core.mapping.Column;
+
 /**
  * Example entity.
  */
 public class President {
 
+  @Column("NAME")
   private String name;
 
+  @Column("START_YEAR")
   private long startYear;
 
   public President(String name, long startYear) {

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <google-cloud-bom.version>19.2.0</google-cloud-bom.version>
 
     <r2dbc.version>0.8.4.RELEASE</r2dbc.version>
-    <reactor.version>Dysprosium-SR18</reactor.version>
+    <reactor.version>2020.0.5</reactor.version>
 
     <mockito.version>3.8.0</mockito.version>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Spring Data dialect updates:
* Many supporting classes moved from Spring Data into Spring Framework.
* Spring Boot integration is no longer in experimental; it's part of mainstream Boot autoconfiguration.
* The need for `SpannerBindMarkerFactoryProvider` is a bit redundant since the same information can be derived from dialect, which is already getting autodiscovered. But it's documented [here](https://docs.spring.io/spring-framework/docs/current/reference/html/data-access.html#r2dbc-DatabaseClient).

Updated sample:
* Explicitly specifying `@Column` is needed because v1 is case-sensitive. We have fixed it to comply with case-insensitive spec for v2 in #271 , so this should become unnecessary when we migrate to v2.

Necessary but not sufficient step towards #314.