### PR TITLE
Map DML result into R2DBC result to avoid disconnected publisher

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -79,6 +79,7 @@ public class SpringDataR2dbcApp {
         .option(DRIVER, DRIVER_NAME)
         .option(INSTANCE, SPANNER_INSTANCE)
         .option(DATABASE, SPANNER_DATABASE)
+        .option(Option.valueOf("client-implementation"), "client-library")
         .build());
 
     return connectionFactory;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -48,8 +48,8 @@ class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryState
   protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
         .runDmlStatement(statement)
-        .transform(numRowsUpdatedMono -> Mono.just(
-            new SpannerClientLibraryResult(Flux.empty(), numRowsUpdatedMono.map(this::longToInt))));
+        .map(numRowsUpdated ->
+            new SpannerClientLibraryResult(Flux.empty(), longToInt(numRowsUpdated)));
   }
 
   @Override
@@ -59,13 +59,13 @@ class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryState
         .flatMapIterable(
             numRowsArray -> LongStream.of(numRowsArray).boxed().collect(Collectors.toList()))
         .map(numRows ->
-                      new SpannerClientLibraryResult(Flux.empty(), Mono.just(longToInt(numRows)))
+                      new SpannerClientLibraryResult(Flux.empty(), longToInt(numRows))
         );
   }
 
   private int longToInt(Long numRows) {
     if (numRows > Integer.MAX_VALUE) {
-      LOGGER.warn("Number of updated rows exceeds maximum integer value; actual rows updated = %s; "
+      LOGGER.warn("Number of updated rows exceeds maximum integer value; actual rows updated = {}; "
           + "returning max int value", numRows);
       return Integer.MAX_VALUE;
     }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
@@ -28,19 +28,19 @@ class SpannerClientLibraryResult implements Result {
 
   private final Flux<SpannerClientLibraryRow> resultRows;
 
-  private final Mono<Integer> rowsUpdated;
+  private final int numRowsUpdated;
 
   private RowMetadata rowMetadata;
 
   public SpannerClientLibraryResult(
-      Flux<SpannerClientLibraryRow> resultRows, Mono<Integer> rowsUpdated) {
+      Flux<SpannerClientLibraryRow> resultRows, int numRowsUpdated) {
     this.resultRows = resultRows;
-    this.rowsUpdated = rowsUpdated;
+    this.numRowsUpdated = numRowsUpdated;
   }
 
   @Override
   public Publisher<Integer> getRowsUpdated() {
-    return this.rowsUpdated;
+    return Mono.just(this.numRowsUpdated);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -41,7 +41,7 @@ class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatemen
   protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
         .runSelectStatement(statement)
-        .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, Mono.empty()))).single();
+        .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, 0))).single();
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -204,7 +204,7 @@ class AbstractSpannerClientLibraryStatementTest {
           .runDmlStatement(statement)
           .map(
               numRows ->
-                  new SpannerClientLibraryResult(Flux.empty(), Mono.just(numRows.intValue())));
+                  new SpannerClientLibraryResult(Flux.empty(), numRows.intValue()));
     }
 
     @Override
@@ -219,7 +219,7 @@ class AbstractSpannerClientLibraryStatementTest {
                           .map(
                               rowCount ->
                                   new SpannerClientLibraryResult(
-                                      Flux.empty(), Mono.just(rowCount.intValue())))));
+                                      Flux.empty(), rowCount.intValue()))));
     }
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
@@ -44,7 +44,8 @@ class SpannerClientLibraryDmlStatementTest {
         new SpannerClientLibraryDmlStatement(this.mockAdapter, "irrelevant sql");
 
     StepVerifier.create(
-            Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated()))
+            Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated())
+    )
         .expectNext(0)
         .verifyComplete();
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
@@ -56,7 +56,7 @@ class SpannerClientLibraryStatementTest {
 
     StepVerifier.create(
         Flux.from(statement.execute()).flatMap(result -> result.getRowsUpdated()))
-        // SELECT statements never have updated row counts.
+        .expectNext(0)
         .verifyComplete();
 
     StepVerifier.create(

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
@@ -50,7 +50,7 @@ class SpannerResultTest {
   @Test
   void getRowsUpdatedTest() {
     StepVerifier.create(
-        ((Mono) new SpannerClientLibraryResult(this.resultSet, Mono.just(2)).getRowsUpdated()))
+        ((Mono) new SpannerClientLibraryResult(this.resultSet, 2).getRowsUpdated()))
         .expectNext(2)
         .verifyComplete();
   }
@@ -70,7 +70,7 @@ class SpannerResultTest {
   @Test
   void mapTest() {
 
-    Publisher<String> result = new SpannerClientLibraryResult(this.resultSet, Mono.just(0))
+    Publisher<String> result = new SpannerClientLibraryResult(this.resultSet, 0)
         .map((row, metadata) ->
             row.get(1, Boolean.class)
                 + "-"


### PR DESCRIPTION
V2 DML statement used to assume that `Result.getRowsUpdated()`  would always be called to trigger the reactive pipeline. However, the spec says either `getRowsUpdated()` or `map()` will be called, and Spring Data used the latter. This caused DML queries to never actually run when invoked through Spring Data.

There is a slight behavior change for SELECT statements -- they used to return an empty publisher as a result of `Result.getRowsUpdated()`, but now return a constant `0`. I think this is a change for the better, since semantically it's correct that 0 rows were updated for a SELECT.

Fixes #346.