### PR TITLE
Change autocommit/readonly value on connection creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The following options are available to be configured for the connection factory:
 | `database`  | Your Spanner Database name | True (if `url` not provided) | |
 | `url`       | A Cloud Spanner R2DBC URL specifying your Spanner database. An alternative to specifying `project`, `instance`, and `database` separately. | False |
 | `google_credentials` | Optional [Google credentials](https://cloud.google.com/docs/authentication/production) override to specify for your Google Cloud account. | False | If not provided, credentials will be [inferred from your runtime environment](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically).
+| `autocommit`  | Whether new connections are created in autocommit mode | False | True |
+| `readonly`  | Whether new connections start with a read-only transaction | False | False |
 | `partial_result_set_fetch_size` | Number of intermediate result sets that are buffered in transit for a read query. | False | 1 |
 | `ddl_operation_timeout` | Duration in seconds to wait for a DDL operation to complete before timing out | False | 600 seconds |
 | `ddl_operation_poll_interval` | Duration in seconds to wait between each polling request for the completion of a DDL operation | False | 5 seconds |

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfiguration.java
@@ -71,6 +71,10 @@ public class SpannerConnectionConfiguration {
 
   private String optimizerVersion;
 
+  private boolean readonly;
+
+  private boolean autocommit;
+
   /**
    * Basic property initializing constructor.
    *
@@ -145,6 +149,14 @@ public class SpannerConnectionConfiguration {
 
   public String getOptimizerVersion() {
     return this.optimizerVersion;
+  }
+
+  public boolean isReadonly() {
+    return this.readonly;
+  }
+
+  public boolean isAutocommit() {
+    return this.autocommit;
   }
 
   @Override
@@ -226,6 +238,10 @@ public class SpannerConnectionConfiguration {
     private boolean usePlainText = false;
 
     private String optimizerVersion;
+
+    private boolean readonly = false;
+
+    private boolean autocommit = true;
 
     /**
      * R2DBC SPI does not provide the full URL to drivers after parsing the connection string.
@@ -317,6 +333,16 @@ public class SpannerConnectionConfiguration {
       return this;
     }
 
+    public Builder setReadonly(boolean readonly) {
+      this.readonly = readonly;
+      return this;
+    }
+
+    public Builder setAutocommit(boolean autocommit) {
+      this.autocommit = autocommit;
+      return this;
+    }
+
     /**
      * Constructs an instance of the {@link SpannerConnectionConfiguration}.
      *
@@ -357,6 +383,8 @@ public class SpannerConnectionConfiguration {
               : Runtime.getRuntime().availableProcessors();
       configuration.usePlainText = this.usePlainText;
       configuration.optimizerVersion = this.optimizerVersion;
+      configuration.readonly = this.readonly;
+      configuration.autocommit = this.autocommit;
 
       return configuration;
     }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner.r2dbc;
 
+import static com.google.cloud.spanner.connection.ConnectionOptions.AUTOCOMMIT_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.READONLY_PROPERTY_NAME;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration.FQDN_PATTERN_PARSE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
@@ -79,6 +81,11 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
    */
   public static final Option<GoogleCredentials> GOOGLE_CREDENTIALS =
       Option.valueOf("google_credentials");
+
+  public static final Option<Boolean> AUTOCOMMIT = Option.valueOf(AUTOCOMMIT_PROPERTY_NAME);
+
+  public static final Option<Boolean> READONLY = Option.valueOf(READONLY_PROPERTY_NAME);
+
 
   /**
    * Option specifying the location of the GCP credentials file. Same as GOOGLE_CREDENTIALS,
@@ -186,7 +193,25 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
       config.setOptimizerVersion(options.getValue(OPTIMIZER_VERSION));
     }
 
+    if (options.hasOption(AUTOCOMMIT)) {
+      config.setAutocommit(getBooleanFlag(options.getValue(AUTOCOMMIT)));
+    }
+
+    if (options.hasOption(READONLY)) {
+      config.setReadonly(getBooleanFlag(options.getValue(READONLY)));
+    }
+
     return config.build();
+  }
+
+  private boolean getBooleanFlag(Object value) {
+    Assert.requireNonNull(value, "Non-null option value expected");
+    if (value instanceof Boolean) {
+      return ((Boolean) value).booleanValue();
+    } else if (value instanceof String) {
+      return Boolean.valueOf((String) value);
+    }
+    throw new IllegalStateException("Flag type expected to be Boolean or String for " + value);
   }
 
   /**

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/api/SpannerConnection.java
@@ -42,4 +42,6 @@ public interface SpannerConnection {
    * @return {@link Mono} signaling readonly transaction is ready for use
    */
   Mono<Void> beginReadonlyTransaction();
+
+  boolean isInReadonlyTransaction();
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapter.java
@@ -310,6 +310,10 @@ class DatabaseClientReactiveAdapter {
     return this.queryOptions;
   }
 
+  boolean isInReadonlyTransaction() {
+    return this.txnManager.isInReadonlyTransaction();
+  }
+
   @VisibleForTesting
   void setTxnManager(DatabaseClientTransactionManager txnManager) {
     this.txnManager = txnManager;

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -17,7 +17,6 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.api.SpannerConnection;
 import com.google.cloud.spanner.r2dbc.statement.StatementParser;
 import com.google.cloud.spanner.r2dbc.statement.StatementType;
@@ -38,10 +37,8 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
    * Cloud Spanner implementation of R2DBC Connection SPI.
    *
    * @param clientLibraryAdapter adapter to Cloud Spanner database client
-   * @param config driver configuration extracted from URL or passed directly to connection factory.
    */
-  public SpannerClientLibraryConnection(DatabaseClientReactiveAdapter clientLibraryAdapter,
-      SpannerConnectionConfiguration config) {
+  public SpannerClientLibraryConnection(DatabaseClientReactiveAdapter clientLibraryAdapter) {
     this.clientLibraryAdapter = clientLibraryAdapter;
   }
 
@@ -141,5 +138,9 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
   @Override
   public Publisher<Void> close() {
     return this.clientLibraryAdapter.close();
+  }
+
+  public boolean isInReadonlyTransaction() {
+    return this.clientLibraryAdapter.isInReadonlyTransaction();
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
@@ -695,6 +695,38 @@ class ClientLibraryBasedIntegrationTest {
 
   }
 
+  @Test
+  void urlConnectionWithExplicitAutocommitOff() {
+    String baseUrl = String.format(
+        "r2dbc:spanner://spanner.googleapis.com:443/projects/%s/instances/%s/databases/%s",
+        ServiceOptions.getDefaultProjectId(),
+        DatabaseProperties.INSTANCE,
+        DatabaseProperties.DATABASE);
+
+    ConnectionFactory cf = ConnectionFactories.get(baseUrl
+        + "?client-implementation=client-library&autocommit=false");
+    StepVerifier.create(
+        Mono.from(cf.create()).map(conn -> conn.isAutoCommit())
+    ).expectNext(false)
+        .verifyComplete();
+  }
+
+  @Test
+  void urlConnectionWithExplicitReadonlyOn() {
+    String baseUrl = String.format(
+        "r2dbc:spanner://spanner.googleapis.com:443/projects/%s/instances/%s/databases/%s",
+        ServiceOptions.getDefaultProjectId(),
+        DatabaseProperties.INSTANCE,
+        DatabaseProperties.DATABASE);
+
+    ConnectionFactory cf = ConnectionFactories.get(baseUrl
+        + "?client-implementation=client-library&readonly=true");
+    StepVerifier.create(
+        Mono.from(cf.create()).map(conn -> ((SpannerConnection) conn).isInReadonlyTransaction())
+    ).expectNext(true)
+        .verifyComplete();
+  }
+
   private Publisher<Long> getFirstNumber(Result result) {
     return result.map((row, meta) -> (Long) row.get(1));
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -73,6 +73,83 @@ class SpannerClientLibraryConnectionFactoryTest {
   }
 
   @Test
+  void createConnectionDefaultsToAutocommitOn() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder.build()
+    );
+    StepVerifier.create(Mono.from(cf.create()).map(conn -> conn.isAutoCommit()))
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  void createConnectionWithAutocommitExplicitlyOn() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder
+            .setAutocommit(true)
+            .build()
+    );
+    StepVerifier.create(Mono.from(cf.create()).map(conn -> conn.isAutoCommit()))
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  void createConnectionWithAutocommitExplicitlyOff() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder
+            .setAutocommit(false)
+            .build()
+    );
+    StepVerifier.create(Mono.from(cf.create()).map(conn -> conn.isAutoCommit()))
+        .expectNext(false)
+        .verifyComplete();
+  }
+
+  @Test
+  void createConnectionDefaultsToReadonlyOff() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder.build()
+    );
+    StepVerifier.create(
+        Mono.from(cf.create())
+            .map(conn -> ((SpannerClientLibraryConnection) conn).isInReadonlyTransaction())
+    )
+        .expectNext(false)
+        .verifyComplete();
+  }
+
+  @Test
+  void createConnectionWithReadonlyExplicitlyOn() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder
+            .setReadonly(true)
+            .build()
+    );
+    StepVerifier.create(
+        Mono.from(cf.create())
+          .map(conn -> ((SpannerClientLibraryConnection) conn).isInReadonlyTransaction())
+    )
+        .expectNext(true)
+        .verifyComplete();
+  }
+
+  @Test
+  void createConnectionWithReadonlyExplicitlyOff() {
+    SpannerClientLibraryConnectionFactory cf = new SpannerClientLibraryConnectionFactory(
+        this.configBuilder
+            .setReadonly(false)
+            .build()
+    );
+    StepVerifier.create(
+        Mono.from(cf.create())
+            .map(conn -> ((SpannerClientLibraryConnection) conn).isInReadonlyTransaction())
+    )
+        .expectNext(false)
+        .verifyComplete();
+  }
+
+  @Test
   void connectionFactoryClosingResultsInSpannerClientClosure() {
     SpannerConnectionConfiguration mockConfig = mock(SpannerConnectionConfiguration.class);
     SpannerOptions mockSpannerOptions = mock(SpannerOptions.class);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -30,7 +29,6 @@ import reactor.test.StepVerifier;
 
 class SpannerClientLibraryConnectionTest {
 
-  SpannerConnectionConfiguration mockConfig;
   DatabaseClientReactiveAdapter mockAdapter;
 
   SpannerClientLibraryConnection connection;
@@ -38,9 +36,8 @@ class SpannerClientLibraryConnectionTest {
   /** Sets up mocks. */
   @BeforeEach
   public void setUpMocks() {
-    this.mockConfig = mock(SpannerConnectionConfiguration.class);
     this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
-    this.connection = new SpannerClientLibraryConnection(this.mockAdapter, this.mockConfig);
+    this.connection = new SpannerClientLibraryConnection(this.mockAdapter);
   }
 
   @Test


### PR DESCRIPTION
Minor but longstanding feature debt for parity with JDBC driver.

Also removes unused `SpannerConnectionConfiguration` parameter in connection.

Fixes #294, #295.
