### PR TITLE
Rename driver 

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -46,7 +46,11 @@ import java.util.Set;
 public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvider {
 
   /** R2DBC driver name for Google Cloud Spanner. */
-  public static final String DRIVER_NAME = "spanner";
+  public static final String DRIVER_NAME = "cloudspanner";
+
+  /** {@code DRIVER_NAME} should be used instead. */
+  @Deprecated
+  public static final String SHORT_DRIVER_NAME = "spanner";
 
   /** Option name for GCP Project. */
   public static final Option<String> PROJECT = Option.valueOf("project");
@@ -131,7 +135,7 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
     Assert.requireNonNull(connectionFactoryOptions, "connectionFactoryOptions must not be null");
     String driver = connectionFactoryOptions.getValue(DRIVER);
 
-    return DRIVER_NAME.equals(driver);
+    return DRIVER_NAME.equals(driver) || SHORT_DRIVER_NAME.equals(driver);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -48,7 +48,11 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   /** R2DBC driver name for Google Cloud Spanner. */
   public static final String DRIVER_NAME = "cloudspanner";
 
-  /** {@code DRIVER_NAME} should be used instead. */
+  /**
+   * Abbreviated name standing for Cloud Spanner.
+   *
+   * @deprecated {@code DRIVER_NAME} should be used instead.
+   */
   @Deprecated
   public static final String SHORT_DRIVER_NAME = "spanner";
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -26,6 +26,7 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PA
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.PROJECT;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.READONLY;
 import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.URL;
+import static com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider.USE_PLAIN_TEXT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +52,7 @@ import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
+import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
@@ -72,6 +74,7 @@ class SpannerConnectionFactoryProviderTest {
           .option(INSTANCE, "an-instance")
           .option(DATABASE, "db")
           .option(GOOGLE_CREDENTIALS, mock(GoogleCredentials.class))
+          .option(USE_PLAIN_TEXT, true) // prevent looking for default credentials
           .build();
 
   ConnectionFactoryOptions.Builder optionsBuilder;
@@ -110,6 +113,45 @@ class SpannerConnectionFactoryProviderTest {
         this.spannerConnectionFactoryProvider.create(SPANNER_OPTIONS);
     assertThat(spannerConnectionFactory).isNotNull();
     assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+  }
+
+  @Test
+  void testCreateFactoryWithOldDriverNameWillReturnCorrectFactory() {
+    ConnectionFactory spannerConnectionFactory =
+        ConnectionFactories.get("r2dbc:spanner://spanner.googleapis.com:443/projects/"
+            + "myproject/instances/myinstance/databases/mydatabase?usePlainText=true");
+    assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+  }
+
+  @Test
+  void testCreateFactoryWithDriverNameWillReturnCorrectFactory() {
+    ConnectionFactory spannerConnectionFactory =
+        ConnectionFactories.get("r2dbc:cloudspanner://spanner.googleapis.com:443/projects/"
+            + "myproject/instances/myinstance/databases/mydatabase?usePlainText=true");
+    assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+  }
+
+  @Test
+  void testCreateFactoryV2WithOldDriverNameWillReturnCorrectFactory() {
+    ConnectionFactory spannerConnectionFactory =
+        ConnectionFactories.get(
+            "r2dbc:spanner://spanner.googleapis.com:443/projects/"
+                + "myproject/instances/myinstance/databases/mydatabase"
+                + "?client-implementation=client-library&usePlainText=true");
+    assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+  }
+
+  @Test
+  void testCreateFactoryV2WithDriverNameWillReturnCorrectFactory() {
+    ConnectionFactory spannerConnectionFactory =
+        ConnectionFactories.get("r2dbc:cloudspanner://spanner.googleapis.com:443/projects/"
+            + "myproject/instances/myinstance/databases/mydatabase"
+            + "?client-implementation=client-library&usePlainText=true");
+    assertThat(spannerConnectionFactory).isNotNull();
+    assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -120,8 +120,9 @@ class SpannerConnectionFactoryProviderTest {
     ConnectionFactory spannerConnectionFactory =
         ConnectionFactories.get("r2dbc:spanner://spanner.googleapis.com:443/projects/"
             + "myproject/instances/myinstance/databases/mydatabase?usePlainText=true");
-    assertThat(spannerConnectionFactory).isNotNull();
-    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+    assertThat(spannerConnectionFactory)
+        .isNotNull()
+        .isInstanceOf(SpannerConnectionFactory.class);
   }
 
   @Test
@@ -129,8 +130,9 @@ class SpannerConnectionFactoryProviderTest {
     ConnectionFactory spannerConnectionFactory =
         ConnectionFactories.get("r2dbc:cloudspanner://spanner.googleapis.com:443/projects/"
             + "myproject/instances/myinstance/databases/mydatabase?usePlainText=true");
-    assertThat(spannerConnectionFactory).isNotNull();
-    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+    assertThat(spannerConnectionFactory)
+        .isNotNull()
+        .isInstanceOf(SpannerConnectionFactory.class);
   }
 
   @Test
@@ -140,8 +142,9 @@ class SpannerConnectionFactoryProviderTest {
             "r2dbc:spanner://spanner.googleapis.com:443/projects/"
                 + "myproject/instances/myinstance/databases/mydatabase"
                 + "?client-implementation=client-library&usePlainText=true");
-    assertThat(spannerConnectionFactory).isNotNull();
-    assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+    assertThat(spannerConnectionFactory)
+        .isNotNull()
+        .isInstanceOf(SpannerClientLibraryConnectionFactory.class);
   }
 
   @Test
@@ -150,8 +153,9 @@ class SpannerConnectionFactoryProviderTest {
         ConnectionFactories.get("r2dbc:cloudspanner://spanner.googleapis.com:443/projects/"
             + "myproject/instances/myinstance/databases/mydatabase"
             + "?client-implementation=client-library&usePlainText=true");
-    assertThat(spannerConnectionFactory).isNotNull();
-    assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+    assertThat(spannerConnectionFactory)
+        .isNotNull()
+        .isInstanceOf(SpannerClientLibraryConnectionFactory.class);
   }
 
   @Test
@@ -166,8 +170,9 @@ class SpannerConnectionFactoryProviderTest {
 
     ConnectionFactory spannerConnectionFactory =
         this.spannerConnectionFactoryProvider.create(optionsWithUrl);
-    assertThat(spannerConnectionFactory).isNotNull();
-    assertThat(spannerConnectionFactory).isInstanceOf(SpannerConnectionFactory.class);
+    assertThat(spannerConnectionFactory)
+        .isNotNull()
+        .isInstanceOf(SpannerConnectionFactory.class);
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDmlReactiveStreamVerification.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDmlReactiveStreamVerification.java
@@ -68,7 +68,7 @@ class SpannerDmlReactiveStreamVerification extends
   }
 
   public SpannerDmlReactiveStreamVerification() {
-    super(new TestEnvironment());
+    super(new TestEnvironment(200));
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerSelectReactiveStreamVerification.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerSelectReactiveStreamVerification.java
@@ -66,7 +66,7 @@ class SpannerSelectReactiveStreamVerification extends
   }
 
   public SpannerSelectReactiveStreamVerification() {
-    super(new TestEnvironment());
+    super(new TestEnvironment(200));
   }
 
   @Override


### PR DESCRIPTION
Long-standing request for consistency with JDBC driver and official product name.

We'll keep supporting the old name for a few versions.

The changes in reactive streams tests are an attempt to remove occasional flakes in CI.