### PR TITLE
Selectively update gax version -- this would fix the currently failing build

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -22,6 +22,14 @@
 
   <dependencyManagement>
     <dependencies>
+
+
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax</artifactId>
+        <version>1.66.0</version>
+      </dependency>
+
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>cloud-spanner-r2dbc</artifactId>


### PR DESCRIPTION
I don't actually want to merge this in, but this is an interesting case of diamond dependencies.

Spanner v6.9.1 uses the latest GAX, which uses a new class: `com.google.api.gax.tracing.BaseApiTracer`. Which is fine!

But every client library depends on `google-cloud-core`, which [hardcodes](https://github.com/googleapis/java-core/blob/master/pom.xml#L154) the GAX version (it's 1.66.0 now, but it was 1.65.1 in the latest released version 1.95.4.
````
\- com.google.cloud:google-cloud-core:jar:1.95.4:compile
    \- com.google.api:gax:jar:1.65.1:compile
````

**So we end up with `gax-grpc:1.66.0` but `gax:1.65.1`**

````
[INFO] 
[INFO] ------< com.google.cloud:cloud-spanner-spring-data-r2dbc-sample >-------
[INFO] Building cloud-spanner-spring-data-r2dbc-sample 0.6.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ cloud-spanner-spring-data-r2dbc-sample ---
[INFO] com.google.cloud:cloud-spanner-spring-data-r2dbc-sample:jar:0.6.0-SNAPSHOT
[INFO] \- com.google.cloud:cloud-spanner-spring-data-r2dbc:jar:0.6.0-SNAPSHOT:compile
[INFO]    \- com.google.cloud:cloud-spanner-r2dbc:jar:0.6.0-SNAPSHOT:compile
[INFO]       \- com.google.cloud:google-cloud-spanner:jar:6.9.1:compile
[INFO]          \- com.google.api:gax-grpc:jar:1.66.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.914 s
[INFO] Finished at: 2021-07-12T23:36:18-04:00
[INFO] ------------------------------------------------------------------------



[INFO] Scanning for projects...
[INFO] 
[INFO] ------< com.google.cloud:cloud-spanner-spring-data-r2dbc-sample >-------
[INFO] Building cloud-spanner-spring-data-r2dbc-sample 0.6.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ cloud-spanner-spring-data-r2dbc-sample ---
[INFO] com.google.cloud:cloud-spanner-spring-data-r2dbc-sample:jar:0.6.0-SNAPSHOT
[INFO] \- com.google.cloud:cloud-spanner-spring-data-r2dbc:jar:0.6.0-SNAPSHOT:compile
[INFO]    \- com.google.cloud:cloud-spanner-r2dbc:jar:0.6.0-SNAPSHOT:compile
[INFO]       \- com.google.cloud:google-cloud-core:jar:1.95.4:compile
[INFO]          \- com.google.api:gax:jar:1.65.1:compile
````




**Full stack trace showing the problem symptoms:**

````
Caused by: java.lang.NoClassDefFoundError: com/google/api/gax/tracing/BaseApiTracer
2021-07-12T21:12:51.6974381Z 	at com.google.api.gax.grpc.GrpcCallContext.getTracer(GrpcCallContext.java:482) ~[gax-grpc-1.66.0.jar:1.66.0]
2021-07-12T21:12:51.6977012Z 	at com.google.api.gax.tracing.TracedOperationCallable.futureCall(TracedOperationCallable.java:73) ~[gax-1.65.1.jar:1.65.1]
2021-07-12T21:12:51.6979500Z 	at com.google.api.gax.rpc.OperationCallable$1.futureCall(OperationCallable.java:150) ~[gax-1.65.1.jar:1.65.1]
2021-07-12T21:12:51.6982139Z 	at com.google.cloud.spanner.spi.v1.GapicSpannerRpc.lambda$updateDatabaseDdl$7(GapicSpannerRpc.java:1135) ~[google-cloud-spanner-6.9.1.jar:6.9.1]
````