### PR TITLE
Implemented batching for DML

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatch.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatch.java
@@ -25,6 +25,7 @@ import io.r2dbc.spi.Result;
 import java.util.ArrayList;
 import java.util.List;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 class SpannerBatch implements Batch {
 
@@ -37,9 +38,9 @@ class SpannerBatch implements Batch {
 
   @Override
   public Batch add(String sql) {
-    Assert.requireNonNull(sql, "SQL must not be null");
+    Assert.requireNonNull(sql, "SQL must not be null.");
     if (StatementParser.getStatementType(sql) != StatementType.DML) {
-      throw new IllegalArgumentException("Only DML statements are supported in batches");
+      throw new IllegalArgumentException("Only DML statements are supported in batches.");
     }
     this.statements.add(Statement.of(sql));
     return this;
@@ -47,6 +48,9 @@ class SpannerBatch implements Batch {
 
   @Override
   public Publisher<? extends Result> execute() {
+    if (this.statements.isEmpty()) {
+      return Mono.error(new IllegalStateException("Batch is empty."));
+    }
     return this.clientLibraryAdapter.runBatchDml(this.statements);
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatch.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatch.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019-2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.r2dbc.statement.StatementParser;
+import com.google.cloud.spanner.r2dbc.statement.StatementType;
+import com.google.cloud.spanner.r2dbc.util.Assert;
+import io.r2dbc.spi.Batch;
+import io.r2dbc.spi.Result;
+import java.util.ArrayList;
+import java.util.List;
+import org.reactivestreams.Publisher;
+
+class SpannerBatch implements Batch {
+
+  private DatabaseClientReactiveAdapter clientLibraryAdapter;
+  private List<Statement> statements = new ArrayList<>();
+
+  SpannerBatch(DatabaseClientReactiveAdapter clientLibraryAdapter) {
+    this.clientLibraryAdapter = clientLibraryAdapter;
+  }
+
+  @Override
+  public Batch add(String sql) {
+    Assert.requireNonNull(sql, "SQL must not be null");
+    if (StatementParser.getStatementType(sql) != StatementType.DML) {
+      throw new IllegalArgumentException("Only DML statements are supported in batches");
+    }
+    this.statements.add(Statement.of(sql));
+    return this;
+  }
+
+  @Override
+  public Publisher<? extends Result> execute() {
+    return this.clientLibraryAdapter.runBatchDml(this.statements);
+  }
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -64,7 +64,7 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
 
   @Override
   public Batch createBatch() {
-    throw new UnsupportedOperationException();
+    return new SpannerBatch(this.clientLibraryAdapter);
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -18,8 +18,6 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -46,30 +44,12 @@ class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryState
 
   @Override
   protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
-    return this.clientLibraryAdapter
-        .runDmlStatement(statement)
-        .map(numRowsUpdated ->
-            new SpannerClientLibraryResult(Flux.empty(), longToInt(numRowsUpdated)));
+    return this.clientLibraryAdapter.runDmlStatement(statement);
   }
 
   @Override
   protected Flux<SpannerClientLibraryResult> executeMultiple(List<Statement> statements) {
-    return this.clientLibraryAdapter
-        .runBatchDml(statements)
-        .flatMapIterable(
-            numRowsArray -> LongStream.of(numRowsArray).boxed().collect(Collectors.toList()))
-        .map(numRows ->
-                      new SpannerClientLibraryResult(Flux.empty(), longToInt(numRows))
-        );
-  }
-
-  private int longToInt(Long numRows) {
-    if (numRows > Integer.MAX_VALUE) {
-      LOGGER.warn("Number of updated rows exceeds maximum integer value; actual rows updated = {}; "
-          + "returning max int value", numRows);
-      return Integer.MAX_VALUE;
-    }
-    return numRows.intValue();
+    return this.clientLibraryAdapter.runBatchDml(statements);
   }
 
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatement.java
@@ -18,8 +18,6 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -27,9 +25,6 @@ import reactor.core.publisher.Mono;
  * Cloud Spanner implementation of R2DBC SPI for DML statements.
  */
 class SpannerClientLibraryDmlStatement extends AbstractSpannerClientLibraryStatement {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(SpannerClientLibraryDmlStatement.class);
 
   /**
    * Creates a ready-to-run Cloud Spanner DML statement.

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -280,15 +280,12 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   @Test
   public void batch() {
     // Only DML statements are accepted by ExecuteBatchDml endpoint
-
     Flux.usingWhen(getConnectionFactory().create(),
         connection -> Flux.from(connection
-
             .createBatch()
             .add(expand(TestStatement.INSERT_VALUE200))
-            .add(expand(TestStatement.INSERT_VALUE100)) // updatd from SELECT
+            .add(expand(TestStatement.INSERT_VALUE100)) // updated from SELECT
             .execute())
-
             .flatMap(Result::getRowsUpdated),
         Connection::close)
         .then()

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -277,12 +277,23 @@ public class SpannerClientLibraryTestKit implements TestKit<String> {
   }
 
   @Override
-  @Disabled (DISABLE_UNSUPPORTED_FUNCTIONALITY)
   @Test
   public void batch() {
-    /*
-    batch DML support is not supported currently.
-     */
+    // Only DML statements are accepted by ExecuteBatchDml endpoint
+
+    Flux.usingWhen(getConnectionFactory().create(),
+        connection -> Flux.from(connection
+
+            .createBatch()
+            .add(expand(TestStatement.INSERT_VALUE200))
+            .add(expand(TestStatement.INSERT_VALUE100)) // updatd from SELECT
+            .execute())
+
+            .flatMap(Result::getRowsUpdated),
+        Connection::close)
+        .then()
+        .as(StepVerifier::create)
+        .verifyComplete();
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatchTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 Google LLC
+ * Copyright 2021-2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,65 +17,75 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Statement;
-import com.google.cloud.spanner.TimestampBound;
 import io.r2dbc.spi.Batch;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-class SpannerClientLibraryConnectionTest {
+class SpannerBatchTest {
 
   DatabaseClientReactiveAdapter mockAdapter;
 
-  SpannerClientLibraryConnection connection;
-
-  /** Sets up mocks. */
   @BeforeEach
-  public void setUpMocks() {
+  void setUpMocks() {
     this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
-    this.connection = new SpannerClientLibraryConnection(this.mockAdapter);
   }
 
   @Test
-  void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
-
-    when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
-
-    StepVerifier.create(this.connection.beginReadonlyTransaction())
-        .verifyComplete();
-
-    verify(this.mockAdapter).beginReadonlyTransaction(TimestampBound.strong());
+  void emptyBatchFails() {
+    Batch batch = new SpannerBatch(this.mockAdapter);
+    StepVerifier.create(
+        Flux.from(batch.execute())
+    ).verifyErrorMessage("Batch is empty.");
   }
 
   @Test
-  void batchUsesCorrectAdapter() {
-    Batch batch = this.connection.createBatch();
+  void addNullFails() {
+    Batch batch = new SpannerBatch(this.mockAdapter);
+    assertThatThrownBy(() -> batch.add(null))
+        .hasMessage("SQL must not be null.");
+  }
+
+  @Test
+  void nonDmlDisallowedInBatch() {
+    Batch batch = new SpannerBatch(this.mockAdapter);
+    assertThatThrownBy(() -> batch.add("SELECT * FROM tbl"))
+        .hasMessage("Only DML statements are supported in batches.");
+    assertThatThrownBy(() -> batch.add("CREATE TABLE blah"))
+        .hasMessage("Only DML statements are supported in batches.");
+  }
+
+  @Test
+  void batchPassesCorrectQueriesToAdapter() {
+    Batch batch = new SpannerBatch(this.mockAdapter);
     when(this.mockAdapter.runBatchDml(anyList()))
         .thenReturn(Flux.just(
-            new SpannerClientLibraryResult(Flux.empty(), 35)
+            new SpannerClientLibraryResult(Flux.empty(), 35),
+            new SpannerClientLibraryResult(Flux.empty(), 47)
         ));
     StepVerifier.create(
         Flux.from(
-            batch.add("UPDATE tbl SET col1=val1").execute()
+            batch.add("UPDATE tbl SET col1=val1")
+                .add("UPDATE tbl SET col2=val2").execute()
         ).flatMap(r -> r.getRowsUpdated())
-    ).expectNext(35)
-    .verifyComplete();
+    ).expectNext(35, 47)
+        .verifyComplete();
 
     ArgumentCaptor<List<Statement>> argCaptor = ArgumentCaptor.forClass(List.class);
     verify(this.mockAdapter).runBatchDml(argCaptor.capture());
     List<Statement> args = argCaptor.getValue();
-    assertThat(args).hasSize(1);
+    assertThat(args).hasSize(2);
     assertThat(args.get(0).getSql()).isEqualTo("UPDATE tbl SET col1=val1");
+    assertThat(args.get(1).getSql()).isEqualTo("UPDATE tbl SET col2=val2");
   }
 }


### PR DESCRIPTION
This PR brings batch support to the same level that we had in v1 -- supporting batches of DML only.

R2DBC batches were meant for interspersed DML and SELECT. However, Cloud Spanner's `executeBatchDml` endpoint [only allows DML statements in the batch](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteBatchDmlRequest).

As part of implementation, the mapping from a `Mono<long[]>` to an R2DBC `Result` moved from the statement implementation to the `DatabaseClientReactiveAdapter`. It's an adapter from futures to R2DBC primitives... let it adapt fully instead of going halfway to an intermediate `Mono<long[]>`

Fixes #409 