### PR TITLE
Use the new authentication way

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -28,12 +28,16 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
+      - name: Set Up Authentication
+        id: auth
+        uses: google-github-actions/auth@v0.4.0
+        with:
+          credentials_json: ${{ secrets.CLOUD_SPANNER_R2DBC_CI_SA_KEY }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.2.1
         with:
           version: latest
           project_id: cloud-spanner-r2dbc-ci
-          service_account_key: ${{ secrets.CLOUD_SPANNER_R2DBC_CI_SA_KEY }}
           export_default_credentials: true
       - name: Maven go offline
         id: mvn-offline

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -29,7 +29,6 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Set Up Authentication
-        id: auth
         uses: google-github-actions/auth@v0.4.0
         with:
           credentials_json: ${{ secrets.CLOUD_SPANNER_R2DBC_CI_SA_KEY }}


### PR DESCRIPTION
Gcloud separated the auth step into a different action. Workload federation is recommended, but _(insert long story, available on demand)_ I am sticking with the path of least resistance and using the same JSON credential.