### PR TITLE
Preparing next snapshot version 1.2.0-SNAPSHOT

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-r2dbc-sample/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-spanner-r2dbc-samples</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Google Cloud Spanner R2DBC Sample via direct SPI</name>

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -14,7 +14,7 @@
 
   <artifactId>cloud-spanner-spring-data-r2dbc-sample</artifactId>
   <groupId>com.google.cloud</groupId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
 
   <properties>
     <sonar.skip>true</sonar.skip>

--- a/cloud-spanner-r2dbc-samples/pom.xml
+++ b/cloud-spanner-r2dbc-samples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-spanner-r2dbc-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cloud-spanner-r2dbc-samples</artifactId>

--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>cloud-spanner-r2dbc-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <name>Google Cloud Spanner R2DBC Driver</name>

--- a/cloud-spanner-spring-data-r2dbc/pom.xml
+++ b/cloud-spanner-spring-data-r2dbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>cloud-spanner-r2dbc-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>cloud-spanner-r2dbc-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
 
   <name>Google Cloud Spanner R2DBC Parent Project</name>
   <description>Reactive R2DBC driver implementation for Cloud Spanner.</description>


### PR DESCRIPTION
We merge this once we confirm new release 1.1.0 is available in Maven Central https://repo1.maven.org/maven2/com/google/cloud/cloud-spanner-r2dbc/