### PR TITLE
Bind arrays and lists to Spanner native arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,13 @@ Cloud Spanner R2DBC Driver supports the following types:
 |`STRING`        |`java.lang.String`   |
 |`JSON`          |`com.google.cloud.spanner.r2dbc.v2.JsonWrapper`   |
 |`TIMESTAMP`     |`java.time.LocalDateTime` |
-|`ARRAY`         |Array-Variant of the corresponding Java type (e.g. `Long[]` for `ARRAY<INT64>`) `ARRAY<JSON>` is not supported.|
+|`ARRAY`         |Arrays or `Iterable` collections with hint. `ARRAY<JSON>` is not supported.|
 
-Null values mapping is supported in both directions. 
+Null values mapping is supported in both directions.
+See [Cloud Spanner documentation](https://cloud.google.com/spanner/docs/data-types) to learn more about Spanner types.
+
+
+### JSON Mapping
 
 `JSON` Spanner type is supported through `JsonWrapper.class`. This is a wrapper class around String representation of the Json value. Below are the basic usages wrapping and un-wrapping string: 
 ```java
@@ -184,7 +188,20 @@ Null values mapping is supported in both directions.
 
 If using Spring Data, default converters to/from `Map` are ready to use out-of-box for key or value type of `String`, `Boolean` and `Double`. Custom converters can be used to allow Json conversion directly to/from collections or user-defined types. Examples of using `Map` and custom class `Review` for Json field are provided in the [Spring Data sample application](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/tree/main/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample)
 
-See [Cloud Spanner documentation](https://cloud.google.com/spanner/docs/data-types) to learn more about Spanner types.
+### Array Mapping
+
+Cloud Spanner arrays can be mapped to/from either primitive Java arrays or `Iterable` collections of wrapper types. For example, a column of type `ARRAY<INT64>` can be represented as `long[]` or `List<Long>`.
+
+However, binding `Iterable` parameters requires a `SpannerType` hint for the specific `com.google.cloud.spanner.Type` to use.
+
+```
+  List value = ...;
+  SpannerType typeHint = SpannerType.of( Type.array(Type.string()) );
+  statement.bind("columnName", Parameters.in(typeHint, value));
+```
+This is not a concern when using Spring Data, as collections will automatically be converted to typed arrays by the framework.
+
+NOTE: Using `long` and `double` arrays is more efficient than using `int` and `float`, as the latter need to get converted for every element.
 
 ## Connections
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/Book.java
@@ -16,6 +16,8 @@
 
 package com.example;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
@@ -41,6 +43,9 @@ public class Book {
   @Column("REVIEWS")
   private Review review;
 
+  @Column("CATEGORIES")
+  private List<String> categories;
+
   public Book(String title, Map<String, String> extraDetails, Review review) {
     this.id = UUID.randomUUID().toString();
     this.title = title;
@@ -65,12 +70,21 @@ public class Book {
     return review;
   }
 
+  public List<String> getCategories() {
+    return categories;
+  }
+
+  public void setCategories(List<String> categories) {
+    this.categories = categories;
+  }
+
   @Override
   public String toString() {
     return "Book{" +
             "id='" + id + '\'' +
             ", title='" + title + '\'' +
-            ", extraDetails=" +(extraDetails == null ? "" : extraDetails.toString()) +
+            ", extraDetails=" + (extraDetails == null ? "" : extraDetails.toString()) +
+            ", categories=" + (categories == null ? "" : categories) +
             '}';
   }
 }

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/SpringDataR2dbcApp.java
@@ -76,6 +76,7 @@ public class SpringDataR2dbcApp {
                   + "  TITLE STRING(MAX) NOT NULL,"
                   + "  EXTRADETAILS JSON,"
                   + "  REVIEWS JSON,"
+                  + "  CATEGORIES ARRAY<STRING(64)>"
                   + ") PRIMARY KEY (ID)")
           .fetch()
           .rowsUpdated()

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/java/com/example/WebController.java
@@ -58,21 +58,12 @@ public class WebController {
   }
 
   @PostMapping("/add")
-  public Mono<Void> addBook(@RequestBody String bookTitle) {
-    return r2dbcEntityTemplate.insert(Book.class)
-        .using(new Book(bookTitle, null, null))
+  public Mono<Void> addBook(@RequestBody Book book) {
+    return r2dbcEntityTemplate
+        .insert(Book.class)
+        .using(book)
         .log()
         .then();
-  }
-
-  @PostMapping(value = "/add-book-with-json",
-          consumes = MediaType.APPLICATION_JSON_VALUE)
-  public Mono<Void> addBookJson(@RequestBody Book book) {
-    return r2dbcEntityTemplate
-            .insert(Book.class)
-            .using(book)
-            .log()
-            .then();
   }
 
   /**

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/main/resources/static/index.html
@@ -6,17 +6,12 @@
     function appendOutput(extraText, books) {
       const el = document.getElementById('result');
       el.value += extraText;
+      const replacer = (key,value) => {
+          return value ? value : undefined;
+      }
       if (books) {
         for (let book of books) {
-          if (!book.extraDetails && !book.review) {
-            el.value += (book.title + "(" + book.id + "); \n");
-          } else if (book.extraDetails) {
-            el.value += (book.title + "(" + book.id + ")" +
-            "; rating: " + book.extraDetails.rating + "; is series: " + book.extraDetails.series +"\n");
-          } else if (book.review) {
-            el.value += (book.title + "(" + book.id + ")" +
-            "; reviewer: " + book.review.reviewerId + "; review: " + book.review.reviewerContent +"\n");
-          }
+          el.value += JSON.stringify(book, replacer, 2) + "\n";
         }
       }
       el.value +=  "\n\n";
@@ -33,16 +28,36 @@
     }
 
     function addBook() {
-      const newTitle = document.getElementById('newBookTitle').value;
-      if (!newTitle) {
+      const book = {};
+      book.title = document.getElementById('newBookTitle').value;
+
+      if (!book.title) {
         appendOutput("Please provide non-empty title");
         return false;
+      }
+
+      const reviewer = document.getElementById('reviewer').value;
+      const review = document.getElementById('review').value;
+      if (reviewer || review) {
+        book.review = { reviewerId: reviewer, reviewerContent: review };
+      }
+
+      const rating = document.getElementById('rating').value;
+      const series = document.getElementById('series').value;
+      if (rating || series) {
+        book.extraDetails = { rating: rating, series: series};
+      }
+
+      const categoriesString = document.getElementById('categories').value;
+      console.log("categories = " + categoriesString);
+      if (categoriesString) {
+        book.categories = categoriesString.split(",");
       }
 
       fetch('/add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json'},
-        body: newTitle
+        body: JSON.stringify(book)
       }).then(response => {
          if (response.ok) {
            appendOutput("Added book.");
@@ -53,76 +68,6 @@
 
       return false;
     }
-
-    function addBookJson() {
-      const newTitle = document.getElementById('newBookTitle').value;
-      const rating = document.getElementById('rating').value;
-      const series = document.getElementById('series').value;
-      if (!newTitle) {
-        appendOutput("Please provide non-empty title");
-        return false;
-      }
-      if (!rating) {
-        appendOutput("Please provide non-empty rating");
-        return false;
-      }
-      if (!series) {
-        appendOutput("Please provide non-empty series");
-        return false;
-      }
-      const bodyContent =  "{\"title\":\"" + newTitle + "\",\"extraDetails\":"
-      + "{\"rating\":\"" + rating + "\",\"series\":\"" + series + "\"},\"review\":null}";
-      fetch('/add-book-with-json', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json'},
-        body: bodyContent
-      }).then(response => {
-         if (response.ok) {
-           appendOutput("Added book.");
-         } else {
-           appendOutput("Failed to add book.");
-         }
-       });
-
-
-      return false;
-    }
-
-
-    function addJsonCustomClass() {
-      const newTitle = document.getElementById('newBookTitle').value;
-      const reviewer = document.getElementById('reviewer').value;
-      const review = document.getElementById('review').value;
-      if (!newTitle) {
-        appendOutput("Please provide non-empty title");
-        return false;
-      }
-      if (!reviewer) {
-        appendOutput("Please provide non-empty reviewer");
-        return false;
-      }
-      if (!review) {
-        appendOutput("Please provide non-empty review");
-        return false;
-      }
-      const bodyContent =  "{\"title\":\"" + newTitle + "\",\"extraDetails\":null,"
-      + "\"review\":{\"reviewerId\":\"" + reviewer + "\",\"reviewerContent\":\"" + review + "\"}}";
-      fetch('/add-book-with-json', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json'},
-        body: bodyContent
-      }).then(response => {
-         if (response.ok) {
-           appendOutput("Added book.");
-         } else {
-           appendOutput("Failed to add book.");
-         }
-       });
-
-
-      return false;
-    }
-
 
     function findBookById() {
       const id = document.getElementById('bookId').value;
@@ -144,8 +89,16 @@
   </script>
 
   <style>
-    div.buttonLink {
+    div.buttonLink, div.section {
       margin-bottom: 1em;
+    }
+    div.buttonLink {
+      border: 1px solid grey;
+      background-color: lightgrey;
+      display: block;
+    }
+    h3 {
+      font-style: italic;
     }
   </style>
 </head>
@@ -159,21 +112,31 @@
     <a href="/" onClick="return listBooks();">List Books</a>
   </div>
 
-  <div class="buttonLink">
-    New Book Title: <input id="newBookTitle" name="newBookTitle"/> <a class="buttonLink" href="/"
-                                                                      onClick="return addBook();">Add Book With No Extra
-    Details</a>
+  <hr/>
+
+  <h3>Required Field</h3>
+  <div class="section">
+    New Book Title: <input id="newBookTitle" name="newBookTitle"/>
   </div>
 
-  <div class="buttonLink">
+  <h3>Extra details (Map entity field turning into JSON Spanner column)</h3>
+  <div class="section">
     Rating: <input id="rating" name="rating"/> Is series: <input id="series" name="series"/>
-    <a class="buttonLink" href="/" onClick="return addBookJson();">Add Book With Extra Details</a>
   </div>
 
-  <div class="buttonLink">
+  <h3>Review (custom Review object entity field turning into JSON Spanner column)</h3>
+  <div class="section">
     Reviewer: <input id="reviewer" name="rating"/> Review: <input id="review" name="series"/>
-    <a class="buttonLink" href="/" onClick="return addJsonCustomClass();">Add Book With Review</a>
   </div>
+
+  <h3>Comma-separated categories (List entity field turning into ARRAY<STRING> Spanner column)</h3>
+  <div class="section">
+    Categories: <input id="categories" name="categories"/>
+  </div>
+
+  <a class="buttonLink" href="/" onClick="return addBook();">Add Book</a>
+
+  <hr/>
 
   <div class="buttonLink">
     Search for: <input id="bookId" name="bookId"/> <a class="buttonLink" href="/" onClick="return findBookById();">Find

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
@@ -2,6 +2,8 @@ package com.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.ServiceOptions;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -29,20 +31,29 @@ class SpringDataR2dbcAppIntegrationTest {
   @Autowired
   private WebTestClient webTestClient;
 
+  @Autowired
+  private ObjectMapper objectMapper;
+
   @AfterEach
   void deleteRecords() {
     this.webTestClient.get().uri("delete-all").exchange().expectStatus().is2xxSuccessful();
   }
 
   @Test
-  void testBasicWebEndpoints() {
+  void testBasicWebEndpoints() throws JsonProcessingException {
 
     // initially empty table
     this.webTestClient.get().uri("/list").exchange()
         .expectBody(Book[].class).isEqualTo(new Book[0]);
 
-    this.webTestClient.post().uri("/add").body(Mono.just("Call of the wild"), String.class)
-        .exchange().expectStatus().is2xxSuccessful();
+    Book newBook = new Book("Call of the wild", null, null);
+    this.webTestClient.post()
+        .uri("/add")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Mono.just(objectMapper.writeValueAsString(newBook)), String.class)
+        .exchange()
+        .expectStatus()
+        .is2xxSuccessful();
 
     AtomicReference<String> id = new AtomicReference<>();
     this.webTestClient.get().uri("/list").exchange()
@@ -64,7 +75,7 @@ class SpringDataR2dbcAppIntegrationTest {
   void testJsonWebEndpoints() {
     this.webTestClient
         .post()
-        .uri("/add-book-with-json")
+        .uri("/add-book")
         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .body(
             Mono.just(
@@ -77,7 +88,7 @@ class SpringDataR2dbcAppIntegrationTest {
 
     this.webTestClient
         .post()
-        .uri("/add-book-with-json")
+        .uri("/add-book")
         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .body(
             Mono.just(

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/src/test/java/com/example/SpringDataR2dbcAppIntegrationTest.java
@@ -75,7 +75,7 @@ class SpringDataR2dbcAppIntegrationTest {
   void testJsonWebEndpoints() {
     this.webTestClient
         .post()
-        .uri("/add-book")
+        .uri("/add")
         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .body(
             Mono.just(
@@ -88,7 +88,7 @@ class SpringDataR2dbcAppIntegrationTest {
 
     this.webTestClient
         .post()
-        .uri("/add-book")
+        .uri("/add")
         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .body(
             Mono.just(

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerType.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerType.java
@@ -26,7 +26,7 @@ import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
 import com.google.cloud.spanner.ValueBinder;
 import java.math.BigDecimal;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 /**
@@ -51,9 +51,8 @@ public abstract class SpannerType implements io.r2dbc.spi.Type {
    *
    * @param binder a {@link ValueBinder} from a call to {@code Statement.Builder.bind(String)}
    * @param value {@link Iterable} value to bind
-   * @param <T> a typed {@link Iterable}
    */
-  public <T extends Iterable> void bindIterable(ValueBinder<Statement.Builder> binder, T value) {
+  public void bindIterable(ValueBinder<Statement.Builder> binder, Iterable<?> value) {
     if (!this.isArray()) {
       throw new BindingFailureException("Iterable cannot be bound to a non-array Spanner type.");
     }
@@ -93,7 +92,7 @@ public abstract class SpannerType implements io.r2dbc.spi.Type {
   }
 
   private static Map<Code, Class<?>> buildTypeMap() {
-    Map<Code, Class<?>> map = new HashMap<>();
+    Map<Code, Class<?>> map = new EnumMap<>(Code.class);
     map.put(Code.BOOL, Boolean.class);
     map.put(Code.BYTES, ByteArray.class);
     map.put(Code.DATE, Date.class);
@@ -109,7 +108,7 @@ public abstract class SpannerType implements io.r2dbc.spi.Type {
   }
 
   private static Map<Code, IterableStatementBinder> buildArrayBinderMap() {
-    Map<Code, IterableStatementBinder> map = new HashMap<>();
+    Map<Code, IterableStatementBinder> map = new EnumMap<>(Code.class);
     map.put(Code.BOOL, (b, i) -> b.toBoolArray((Iterable<Boolean>) i));
     map.put(Code.INT64, (b, i) -> b.toInt64Array((Iterable<Long>) i));
     map.put(Code.NUMERIC, (b, i) -> b.toNumericArray((Iterable<BigDecimal>) i));

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerType.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerType.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc;
+
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Type.Code;
+import com.google.cloud.spanner.ValueBinder;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An R2DBC {@link io.r2dbc.spi.Type}-compatible wrapper around Cloud Spanner's {@Type}.
+ */
+public abstract class SpannerType implements io.r2dbc.spi.Type {
+
+  private Type type;
+
+  private static final Map<Code, Class<?>> SPANNER_TO_JAVA_TYPES = buildTypeMap();
+  private static final Map<Code, IterableStatementBinder> ARRAY_BINDERS = buildArrayBinderMap();
+
+  private SpannerType(Type type) {
+    this.type = type;
+  }
+
+  public abstract boolean isArray();
+
+  /**
+   * Adds type-specific binding of provided value to statement.
+   * Fails if the value or type are not compatiblie with Spanner arrays.
+   *
+   * @param binder a {@link ValueBinder} from a call to {@code Statement.Builder.bind(String)}
+   * @param value {@link Iterable} value to bind
+   * @param <T> a typed {@link Iterable}
+   */
+  public <T extends Iterable> void bindIterable(ValueBinder<Statement.Builder> binder, T value) {
+    if (!this.isArray()) {
+      throw new BindingFailureException("Iterable cannot be bound to a non-array Spanner type.");
+    }
+
+    IterableStatementBinder typedBinder =
+        ARRAY_BINDERS.get(this.type.getArrayElementType().getCode());
+    if (typedBinder == null) {
+      throw new BindingFailureException("Array binder not found for type " + this.type);
+    }
+    typedBinder.bind(binder, value);
+
+  }
+
+  /**
+   * Returns a `{@link SpannerType} corresponding to the provided Spanner client library type.
+   *
+   * @param type client library {@link Type}
+   * @return `{@link SpannerType} wrapper for the provided client library type
+   */
+  public static SpannerType of(Type type) {
+    return new SpannerType(type) {
+      @Override
+      public Class<?> getJavaType() {
+        return SPANNER_TO_JAVA_TYPES.get(type.getCode());
+      }
+
+      @Override
+      public String getName() {
+        return type.toString();
+      }
+
+      @Override
+      public boolean isArray() {
+        return type.getCode() == Code.ARRAY;
+      }
+    };
+  }
+
+  private static Map<Code, Class<?>> buildTypeMap() {
+    Map<Code, Class<?>> map = new HashMap<>();
+    map.put(Code.BOOL, Boolean.class);
+    map.put(Code.BYTES, ByteArray.class);
+    map.put(Code.DATE, Date.class);
+    map.put(Code.FLOAT64, Double.class);
+    map.put(Code.NUMERIC, BigDecimal.class);
+    map.put(Code.INT64, Long.class);
+    map.put(Code.STRING, String.class);
+    map.put(Code.STRUCT, Struct.class);
+    map.put(Code.TIMESTAMP, Timestamp.class);
+    map.put(Code.ARRAY, Iterable.class);
+
+    return map;
+  }
+
+  private static Map<Code, IterableStatementBinder> buildArrayBinderMap() {
+    Map<Code, IterableStatementBinder> map = new HashMap<>();
+    map.put(Code.BOOL, (b, i) -> b.toBoolArray((Iterable<Boolean>) i));
+    map.put(Code.INT64, (b, i) -> b.toInt64Array((Iterable<Long>) i));
+    map.put(Code.NUMERIC, (b, i) -> b.toNumericArray((Iterable<BigDecimal>) i));
+    map.put(Code.FLOAT64, (b, i) -> b.toFloat64Array((Iterable<Double>) i));
+    map.put(Code.STRING, (b, i) -> b.toStringArray((Iterable<String>) i));
+    map.put(Code.BYTES, (b, i) -> b.toBytesArray((Iterable<ByteArray>) i));
+    map.put(Code.TIMESTAMP, (b, i) -> b.toTimestampArray((Iterable<Timestamp>) i));
+    map.put(Code.DATE, (b, i) -> b.toDateArray((Iterable<Date>) i));
+    // no JSON, ARRAY, STRUCT for now
+
+    return map;
+  }
+
+  // More readable equivalent to BiConsumer<ValueBinder<Statement.Builder>, Iterable<?>>
+  @FunctionalInterface
+  private interface IterableStatementBinder {
+    void bind(ValueBinder<Statement.Builder> binder, Iterable<?> value);
+  }
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
@@ -36,9 +36,10 @@ class ArrayToIterableBinder<T> implements ClientLibraryTypeBinder<T[]> {
 
   private Class<T[]> type;
 
-  private BiConsumer<ValueBinder, Iterable<T>> bindingConsumer;
+  private BiConsumer<ValueBinder<Statement.Builder>, Iterable<T>> bindingConsumer;
 
-  ArrayToIterableBinder(Class<T[]> type, BiConsumer<ValueBinder, Iterable<T>> bindingConsumer) {
+  ArrayToIterableBinder(Class<T[]> type,
+      BiConsumer<ValueBinder<Statement.Builder>, Iterable<T>> bindingConsumer) {
     this.type = type;
     this.bindingConsumer = bindingConsumer;
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
@@ -32,7 +32,7 @@ import java.util.function.BiConsumer;
  *
  * @param <T> Array element type
  */
-class ArrayToIterableBinder<T> implements ClientLibraryTypeBinder<T[]> {
+class ArrayToIterableBinder<T> implements ClientLibraryTypeBinder {
 
   private Class<T[]> type;
 
@@ -45,18 +45,18 @@ class ArrayToIterableBinder<T> implements ClientLibraryTypeBinder<T[]> {
   }
 
   @Override
-  public boolean canBind(Class<T[]> type, SpannerType unusedSpannerType) {
+  public boolean canBind(Class<?> type, SpannerType unusedSpannerType) {
     Assert.requireNonNull(type, "type to encode must not be null");
 
     return this.type.equals(type);
   }
 
   @Override
-  public void bind(Statement.Builder builder, String name, T[] value, SpannerType unusedType) {
+  public void bind(Statement.Builder builder, String name, Object value, SpannerType unusedType) {
     if (value == null) {
       this.bindingConsumer.accept(builder.bind(name), null);
     } else {
-      this.bindingConsumer.accept(builder.bind(name), Arrays.asList(value));
+      this.bindingConsumer.accept(builder.bind(name), Arrays.asList((T[]) value));
     }
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.ValueBinder;
+import com.google.cloud.spanner.r2dbc.SpannerType;
+import com.google.cloud.spanner.r2dbc.util.Assert;
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+
+/**
+ * Binds object arrays to client library {@link ValueBinder} API that requires iterable collections.
+ *
+ * <p>Also useful for binding arrays of primitives that are too short to be natively supported in
+ *     Spanner since these have to use the {@link Iterable}-accepting variants of binding methods.
+ *     Only a single array type can be bound by an instance of this class.
+ *
+ * @param <T> Array element type
+ */
+class ArrayToIterableBinder<T> implements ClientLibraryTypeBinder<T[]> {
+
+  private Class<T[]> type;
+
+  private BiConsumer<ValueBinder, Iterable<T>> bindingConsumer;
+
+  ArrayToIterableBinder(Class<T[]> type, BiConsumer<ValueBinder, Iterable<T>> bindingConsumer) {
+    this.type = type;
+    this.bindingConsumer = bindingConsumer;
+  }
+
+  @Override
+  public boolean canBind(Class<T[]> type, SpannerType unusedSpannerType) {
+    Assert.requireNonNull(type, "type to encode must not be null");
+
+    return this.type.equals(type);
+  }
+
+  @Override
+  public void bind(Statement.Builder builder, String name, T[] value, SpannerType unusedType) {
+    if (value == null) {
+      this.bindingConsumer.accept(builder.bind(name), null);
+    } else {
+      this.bindingConsumer.accept(builder.bind(name), Arrays.asList(value));
+    }
+  }
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
@@ -39,37 +39,37 @@ class ClientLibraryBinder {
   private static List<ClientLibraryTypeBinder> buildBinders() {
     List<ClientLibraryTypeBinder> binders = new ArrayList<>();
     binders.add(
-        new ClientLibraryTypeBinderImpl<>(Integer.class,
+        new SingleTypeBinder<>(Integer.class,
             (binder, val) -> binder.to(longFromInteger(val))));
-    binders.add(new ClientLibraryTypeBinderImpl<>(Long.class, (binder, val) -> binder.to(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(Double.class, (binder, val) -> binder.to(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(Boolean.class, (binder, val) -> binder.to(val)));
+    binders.add(new SingleTypeBinder<>(Long.class, (binder, val) -> binder.to(val)));
+    binders.add(new SingleTypeBinder<>(Double.class, (binder, val) -> binder.to(val)));
+    binders.add(new SingleTypeBinder<>(Boolean.class, (binder, val) -> binder.to(val)));
     binders.add(
-        new ClientLibraryTypeBinderImpl<>(ByteArray.class, (binder, val) -> binder.to(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(Date.class, (binder, val) -> binder.to(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(String.class, (binder, val) -> binder.to(val)));
+        new SingleTypeBinder<>(ByteArray.class, (binder, val) -> binder.to(val)));
+    binders.add(new SingleTypeBinder<>(Date.class, (binder, val) -> binder.to(val)));
+    binders.add(new SingleTypeBinder<>(String.class, (binder, val) -> binder.to(val)));
     binders.add(
-        new ClientLibraryTypeBinderImpl<>(Timestamp.class, (binder, val) -> binder.to(val)));
+        new SingleTypeBinder<>(Timestamp.class, (binder, val) -> binder.to(val)));
     binders.add(
-        new ClientLibraryTypeBinderImpl<>(BigDecimal.class, (binder, val) -> binder.to(val)));
+        new SingleTypeBinder<>(BigDecimal.class, (binder, val) -> binder.to(val)));
 
     binders.add(
-        new ClientLibraryTypeBinderImpl<>(
+        new SingleTypeBinder<>(
             JsonWrapper.class,
             (binder, val) -> binder.to(val == null ? Value.json(null) : val.getJsonVal())));
 
     // Primitive arrays
-    binders.add(new ClientLibraryTypeBinderImpl<>(
+    binders.add(new SingleTypeBinder<>(
         boolean[].class, (binder, val) -> binder.toBoolArray(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(
+    binders.add(new SingleTypeBinder<>(
         long[].class, (binder, val) -> binder.toInt64Array(val)));
-    binders.add(new ClientLibraryTypeBinderImpl<>(
+    binders.add(new SingleTypeBinder<>(
         double[].class, (binder, val) -> binder.toFloat64Array(val)));
 
     // Primitive arrays that have to expand element size to 64 bits to match Spanner types.
-    binders.add(new ClientLibraryTypeBinderImpl<>(
+    binders.add(new SingleTypeBinder<>(
         int[].class, (binder, val) -> binder.toInt64Array(Arrays.asList(val))));
-    binders.add(new ClientLibraryTypeBinderImpl<>(
+    binders.add(new SingleTypeBinder<>(
         float[].class, (binder, val) -> binder.toFloat64Array(Arrays.asList(val))));
 
     // Object arrays

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryBinder.java
@@ -29,7 +29,6 @@ import io.r2dbc.spi.Parameter;
 import io.r2dbc.spi.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -68,9 +67,9 @@ class ClientLibraryBinder {
 
     // Primitive arrays that have to expand element size to 64 bits to match Spanner types.
     binders.add(new SingleTypeBinder<>(
-        int[].class, (binder, val) -> binder.toInt64Array(Arrays.asList(val))));
+        int[].class, (binder, val) -> binder.toInt64Array(toLongArray(val))));
     binders.add(new SingleTypeBinder<>(
-        float[].class, (binder, val) -> binder.toFloat64Array(Arrays.asList(val))));
+        float[].class, (binder, val) -> binder.toFloat64Array(toDoubleArray(val))));
 
     // Object arrays
     binders.add(new ArrayToIterableBinder<>(Boolean[].class,
@@ -92,6 +91,28 @@ class ClientLibraryBinder {
     binders.add(new IterableBinder());
 
     return binders;
+  }
+
+  private static long[] toLongArray(int[] input) {
+    if (input == null) {
+      return new long[0];
+    }
+    long[] output = new long[input.length];
+    for (int i = 0; i < input.length; i++) {
+      output[i] = input[i];
+    }
+    return output;
+  }
+
+  private static double[] toDoubleArray(float[] input) {
+    if (input == null) {
+      return new double[0];
+    }
+    double[] output = new double[input.length];
+    for (int i = 0; i < input.length; i++) {
+      output[i] = input[i];
+    }
+    return output;
   }
 
   static void bind(Statement.Builder builder, String name, Object value) {

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryDecoder.java
@@ -35,13 +35,17 @@ class ClientLibraryDecoder {
   private static final Map<Type, BiFunction<Struct, Integer, Object>> arrayDecodersMap =
       createArrayDecoders();
 
-  // Only 3 primitive array types are supported by client library.
   // Struct type is the same for arrays and lists, so array getters have to live in a separate map.
   private static Map<Type, BiFunction<Struct, Integer, Object>> createArrayDecoders() {
     Map<Type, BiFunction<Struct, Integer, Object>> decoders = new HashMap<>();
     decoders.put(Type.array(Type.int64()), AbstractStructReader::getLongArray);
     decoders.put(Type.array(Type.float64()), AbstractStructReader::getDoubleArray);
     decoders.put(Type.array(Type.bool()), AbstractStructReader::getBooleanArray);
+
+    // Only 3 primitive array types are supported by client library; the rest have to be converted.
+    decoders.put(
+        Type.array(Type.string()),
+        (struct, index) -> struct.getStringList(index).toArray(new String[0]));
     return decoders;
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement.Builder;
+import com.google.cloud.spanner.r2dbc.SpannerType;
 
 interface ClientLibraryTypeBinder<T> {
 
@@ -24,10 +25,11 @@ interface ClientLibraryTypeBinder<T> {
    * Indicates if the binder can bind a value of a given type.
    *
    * @param type input data object type
+   * @param spannerType optional {@link SpannerType} hint.
    *
    * @return true if the codec can encode value, false otherwise
    */
-  boolean canBind(Class<T> type);
+  boolean canBind(Class<T> type, SpannerType spannerType);
 
   /**
    * Bind a value.
@@ -36,5 +38,5 @@ interface ClientLibraryTypeBinder<T> {
    * @param name parameter name
    * @param value the value to bind
    */
-  void bind(Builder builder, String name, T value);
+  void bind(Builder builder, String name, T value, SpannerType spannerType);
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinder.java
@@ -19,7 +19,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 import com.google.cloud.spanner.Statement.Builder;
 import com.google.cloud.spanner.r2dbc.SpannerType;
 
-interface ClientLibraryTypeBinder<T> {
+interface ClientLibraryTypeBinder {
 
   /**
    * Indicates if the binder can bind a value of a given type.
@@ -29,7 +29,7 @@ interface ClientLibraryTypeBinder<T> {
    *
    * @return true if the codec can encode value, false otherwise
    */
-  boolean canBind(Class<T> type, SpannerType spannerType);
+  boolean canBind(Class<?> type, SpannerType spannerType);
 
   /**
    * Bind a value.
@@ -38,5 +38,5 @@ interface ClientLibraryTypeBinder<T> {
    * @param name parameter name
    * @param value the value to bind
    */
-  void bind(Builder builder, String name, T value, SpannerType spannerType);
+  void bind(Builder builder, String name, Object value, SpannerType spannerType);
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinderImpl.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBinderImpl.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.Statement.Builder;
 import com.google.cloud.spanner.ValueBinder;
+import com.google.cloud.spanner.r2dbc.SpannerType;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import java.util.function.BiConsumer;
 
@@ -34,14 +35,14 @@ class ClientLibraryTypeBinderImpl<T> implements ClientLibraryTypeBinder<T> {
   }
 
   @Override
-  public boolean canBind(Class<T> type) {
+  public boolean canBind(Class<T> type, SpannerType unusedSpannerType) {
     Assert.requireNonNull(type, "type to encode must not be null");
 
     return this.type.isAssignableFrom(type);
   }
 
   @Override
-  public void bind(Builder builder, String name, T value) {
+  public void bind(Builder builder, String name, T value, SpannerType unusedSpannerType) {
     this.bindingConsumer.accept(builder.bind(name), value);
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.r2dbc.BindingFailureException;
+import com.google.cloud.spanner.r2dbc.SpannerType;
+
+/**
+ * Binds {@link Iterable} values to statement parameters, using Spanner type information as a hint.
+ *
+ * @param <T> a typed {@link Iterable}
+ */
+class IterableBinder<T extends Iterable<?>> implements ClientLibraryTypeBinder<T> {
+
+  @Override
+  public boolean canBind(Class<T> type, SpannerType spannerType) {
+    // Handling all iterables regardless of SpannerType will allow more useful error messages.
+    return Iterable.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public void bind(Statement.Builder builder, String name, T value, SpannerType spannerType) {
+    if (spannerType == null) {
+      throw new BindingFailureException(
+          "When binding collections, Parameters.in(SpannerType.of(Type.array(...))) must be used.");
+    }
+    spannerType.bindIterable(builder.bind(name), value);
+  }
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
@@ -23,21 +23,21 @@ import com.google.cloud.spanner.r2dbc.SpannerType;
 /**
  * Binds {@link Iterable} values to statement parameters, using Spanner type information as a hint.
  */
-class IterableBinder implements ClientLibraryTypeBinder<Iterable<?>> {
+class IterableBinder implements ClientLibraryTypeBinder {
 
   @Override
-  public boolean canBind(Class<Iterable<?>> type, SpannerType spannerType) {
+  public boolean canBind(Class<?> type, SpannerType spannerType) {
     // Handling all iterables regardless of SpannerType will allow more useful error messages.
     return Iterable.class.isAssignableFrom(type);
   }
 
   @Override
   public void bind(
-      Statement.Builder builder, String name, Iterable<?> value, SpannerType spannerType) {
+      Statement.Builder builder, String name, Object value, SpannerType spannerType) {
     if (spannerType == null) {
       throw new BindingFailureException(
           "When binding collections, Parameters.in(SpannerType.of(Type.array(...))) must be used.");
     }
-    spannerType.bindIterable(builder.bind(name), value);
+    spannerType.bindIterable(builder.bind(name), (Iterable<?>) value);
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/IterableBinder.java
@@ -22,19 +22,18 @@ import com.google.cloud.spanner.r2dbc.SpannerType;
 
 /**
  * Binds {@link Iterable} values to statement parameters, using Spanner type information as a hint.
- *
- * @param <T> a typed {@link Iterable}
  */
-class IterableBinder<T extends Iterable<?>> implements ClientLibraryTypeBinder<T> {
+class IterableBinder implements ClientLibraryTypeBinder<Iterable<?>> {
 
   @Override
-  public boolean canBind(Class<T> type, SpannerType spannerType) {
+  public boolean canBind(Class<Iterable<?>> type, SpannerType spannerType) {
     // Handling all iterables regardless of SpannerType will allow more useful error messages.
     return Iterable.class.isAssignableFrom(type);
   }
 
   @Override
-  public void bind(Statement.Builder builder, String name, T value, SpannerType spannerType) {
+  public void bind(
+      Statement.Builder builder, String name, Iterable<?> value, SpannerType spannerType) {
     if (spannerType == null) {
       throw new BindingFailureException(
           "When binding collections, Parameters.in(SpannerType.of(Type.array(...))) must be used.");

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Statement.Builder;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.cloud.spanner.r2dbc.SpannerType;
@@ -26,10 +27,10 @@ class SingleTypeBinder<T> implements ClientLibraryTypeBinder {
 
   private Class<T> type;
 
-  private BiConsumer<ValueBinder, T> bindingConsumer;
+  private BiConsumer<ValueBinder<Statement.Builder>, T> bindingConsumer;
 
   public SingleTypeBinder(
-      Class<T> type, BiConsumer<ValueBinder, T> bindingConsumer) {
+      Class<T> type, BiConsumer<ValueBinder<Statement.Builder>, T> bindingConsumer) {
     this.type = type;
     this.bindingConsumer = bindingConsumer;
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
@@ -22,7 +22,7 @@ import com.google.cloud.spanner.r2dbc.SpannerType;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import java.util.function.BiConsumer;
 
-class SingleTypeBinder<T> implements ClientLibraryTypeBinder<T> {
+class SingleTypeBinder<T> implements ClientLibraryTypeBinder {
 
   private Class<T> type;
 
@@ -35,14 +35,14 @@ class SingleTypeBinder<T> implements ClientLibraryTypeBinder<T> {
   }
 
   @Override
-  public boolean canBind(Class<T> type, SpannerType unusedSpannerType) {
+  public boolean canBind(Class<?> type, SpannerType unusedSpannerType) {
     Assert.requireNonNull(type, "type to encode must not be null");
 
     return this.type.isAssignableFrom(type);
   }
 
   @Override
-  public void bind(Builder builder, String name, T value, SpannerType unusedSpannerType) {
-    this.bindingConsumer.accept(builder.bind(name), value);
+  public void bind(Builder builder, String name, Object value, SpannerType unusedSpannerType) {
+    this.bindingConsumer.accept(builder.bind(name), (T) value);
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SingleTypeBinder.java
@@ -22,13 +22,13 @@ import com.google.cloud.spanner.r2dbc.SpannerType;
 import com.google.cloud.spanner.r2dbc.util.Assert;
 import java.util.function.BiConsumer;
 
-class ClientLibraryTypeBinderImpl<T> implements ClientLibraryTypeBinder<T> {
+class SingleTypeBinder<T> implements ClientLibraryTypeBinder<T> {
 
   private Class<T> type;
 
   private BiConsumer<ValueBinder, T> bindingConsumer;
 
-  public ClientLibraryTypeBinderImpl(
+  public SingleTypeBinder(
       Class<T> type, BiConsumer<ValueBinder, T> bindingConsumer) {
     this.type = type;
     this.bindingConsumer = bindingConsumer;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerTypeTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerTypeTest.java
@@ -174,7 +174,8 @@ class SpannerTypeTest {
 
     SpannerType spannerType = SpannerType.of(Type.array(Type.struct()));
 
-    assertThatThrownBy(() -> spannerType.bindIterable(this.mockBinder, new ArrayList<>()))
+    List<String> valueList = new ArrayList<>();
+    assertThatThrownBy(() -> spannerType.bindIterable(this.mockBinder, valueList))
         .isInstanceOf(BindingFailureException.class)
         .hasMessage("Array binder not found for type ARRAY<STRUCT<>>");
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerTypeTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerTypeTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.ValueBinder;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+class SpannerTypeTest {
+
+  ValueBinder<Statement.Builder> mockBinder;
+
+  @BeforeEach
+  void setUp() {
+    this.mockBinder = mock(ValueBinder.class);
+  }
+
+  @Test
+  void isArrayOnlyReturnsTrueForArrayTypes() {
+    assertTrue(SpannerType.of(Type.array(Type.string())).isArray());
+    assertTrue(SpannerType.of(Type.array(Type.json())).isArray());
+    assertTrue(SpannerType.of(Type.array(Type.array(Type.date()))).isArray());
+
+    assertFalse(SpannerType.of(Type.date()).isArray());
+    assertFalse(SpannerType.of(Type.float64()).isArray());
+    assertFalse(SpannerType.of(Type.int64()).isArray());
+    assertFalse(SpannerType.of(Type.json()).isArray());
+    assertFalse(SpannerType.of(Type.numeric()).isArray());
+    assertFalse(SpannerType.of(Type.string()).isArray());
+    assertFalse(SpannerType.of(Type.struct()).isArray());
+    assertFalse(SpannerType.of(Type.timestamp()).isArray());
+  }
+
+  @Test
+  void getNameReturnsSpannerTypeName() {
+
+    assertEquals("ARRAY<STRING>", SpannerType.of(Type.array(Type.string())).getName());
+    assertEquals("ARRAY<INT64>", SpannerType.of(Type.array(Type.int64())).getName());
+
+    assertEquals("DATE", SpannerType.of(Type.date()).getName());
+    assertEquals("FLOAT64", SpannerType.of(Type.float64()).getName());
+    assertEquals("INT64", SpannerType.of(Type.int64()).getName());
+    assertEquals("JSON", SpannerType.of(Type.json()).getName());
+    assertEquals("NUMERIC", SpannerType.of(Type.numeric()).getName());
+    assertEquals("STRING", SpannerType.of(Type.string()).getName());
+    assertEquals("STRUCT<>", SpannerType.of(Type.struct()).getName());
+    assertEquals("TIMESTAMP", SpannerType.of(Type.timestamp()).getName());
+  }
+
+  @Test
+  void getJavaTypeReturnsCorrectType() {
+
+    assertEquals(Iterable.class, SpannerType.of(Type.array(Type.string())).getJavaType());
+    assertEquals(Iterable.class, SpannerType.of(Type.array(Type.int64())).getJavaType());
+
+    assertEquals(Date.class, SpannerType.of(Type.date()).getJavaType());
+    assertEquals(Double.class, SpannerType.of(Type.float64()).getJavaType());
+    assertEquals(Long.class, SpannerType.of(Type.int64()).getJavaType());
+    assertEquals(BigDecimal.class, SpannerType.of(Type.numeric()).getJavaType());
+    assertEquals(String.class, SpannerType.of(Type.string()).getJavaType());
+    assertEquals(Timestamp.class, SpannerType.of(Type.timestamp()).getJavaType());
+    assertEquals(Struct.class, SpannerType.of(Type.struct()).getJavaType());
+
+    assertNull(SpannerType.of(Type.json()).getJavaType());
+  }
+
+  @Test
+  void bindIterableWorksForBooleanArray() {
+    List<Boolean> valueList = Arrays.asList(true, false, false);
+    SpannerType.of(Type.array(Type.bool())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toBoolArray(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForLongArray() {
+    List<Long> valueList = Arrays.asList(12L, 24L, 36L);
+    SpannerType.of(Type.array(Type.int64())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toInt64Array(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForNumericArray() {
+    List<BigDecimal> valueList = Arrays.asList(BigDecimal.TEN, BigDecimal.ONE);
+    SpannerType.of(Type.array(Type.numeric())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toNumericArray(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForDoubleArray() {
+    List<Double> valueList = Arrays.asList(3.14, 2.71);
+    SpannerType.of(Type.array(Type.float64())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toFloat64Array(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForStringArray() {
+    List<String> valueList = Arrays.asList("thing1", "thing2");
+    SpannerType.of(Type.array(Type.string())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toStringArray(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForBytesArray() {
+    List<ByteArray> valueList = Arrays.asList(ByteArray.copyFrom("thing1"));
+    SpannerType.of(Type.array(Type.bytes())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toBytesArray(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForTimestampArray() {
+    List<Timestamp> valueList = Arrays.asList(Timestamp.now());
+    SpannerType.of(Type.array(Type.timestamp())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toTimestampArray(valueList);
+  }
+
+  @Test
+  void bindIterableWorksForDateArray() {
+    List<Date> valueList = Arrays.asList(Date.fromYearMonthDay(2022, 02, 02));
+    SpannerType.of(Type.array(Type.date())).bindIterable(this.mockBinder, valueList);
+    verify(this.mockBinder).toDateArray(valueList);
+  }
+
+  @Test
+  void bindIterableFailsForNonArrayTypes() {
+    ValueBinder<Statement.Builder> mockBinder = mock(ValueBinder.class);
+
+    SpannerType spannerType = SpannerType.of(Type.string());
+    List<String> valueList = Arrays.asList("thing1", "thing2");
+
+    assertThatThrownBy(() -> spannerType.bindIterable(this.mockBinder, valueList))
+        .isInstanceOf(BindingFailureException.class)
+        .hasMessage("Iterable cannot be bound to a non-array Spanner type.");
+
+    verifyNoInteractions(this.mockBinder);
+  }
+
+  @Test
+  void bindIterableFailsForUnsupportedTypes() {
+    ValueBinder<Statement.Builder> mockBinder = mock(ValueBinder.class);
+
+    SpannerType spannerType = SpannerType.of(Type.array(Type.struct()));
+
+    assertThatThrownBy(() -> spannerType.bindIterable(this.mockBinder, new ArrayList<>()))
+        .isInstanceOf(BindingFailureException.class)
+        .hasMessage("Array binder not found for type ARRAY<STRUCT<>>");
+
+    verifyNoInteractions(this.mockBinder);
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/Book.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/Book.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.spanner.r2dbc.it;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -35,6 +37,8 @@ public class Book {
 
   private final String[] editions;
 
+  private final List<String> awards;
+
   private final Boolean fiction;
 
   private final LocalDate published;
@@ -42,6 +46,8 @@ public class Book {
   private final Double wordsPerSentence;
 
   private final Integer category;
+
+  private final BigDecimal price;
 
   /**
    * Constructor.
@@ -51,23 +57,26 @@ public class Book {
    * @param author author
    * @param synopsis text
    * @param editions edition array
+   * @awards awards awards list
    * @param fiction boolean
    * @param published local date
    * @param wordsPerSentence double
    * @param category integer
    */
   public Book(String id, String title, String author, String synopsis,
-      String[] editions, Boolean fiction, LocalDate published, Double wordsPerSentence,
-      Integer category) {
+      String[] editions, List<String> awards, Boolean fiction, LocalDate published,
+      Double wordsPerSentence, Integer category, BigDecimal price) {
     this.id = id;
     this.title = title;
     this.author = author;
     this.synopsis = synopsis;
     this.editions = editions;
+    this.awards = awards;
     this.fiction = fiction;
     this.published = published;
     this.wordsPerSentence = wordsPerSentence;
     this.category = category;
+    this.price = price;
   }
 
   public String getId() {
@@ -90,6 +99,10 @@ public class Book {
     return this.editions;
   }
 
+  public List<String> getAwards() {
+    return this.awards;
+  }
+
   public Boolean getFiction() {
     return this.fiction;
   }
@@ -104,6 +117,10 @@ public class Book {
 
   public Integer getCategory() {
     return this.category;
+  }
+
+  public BigDecimal getPrice() {
+    return this.price;
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/TestDatabaseHelper.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/TestDatabaseHelper.java
@@ -99,6 +99,7 @@ class TestDatabaseHelper {
                 + "  AUTHOR STRING(256),"
                 + "  SYNOPSIS STRING(MAX),"
                 + "  EDITIONS ARRAY<STRING(MAX)>,"
+                + "  AWARDS ARRAY<STRING(MAX)>,"
                 + "  FICTION BOOL,"
                 + "  PUBLISHED DATE,"
                 + "  WORDS_PER_SENTENCE FLOAT64,"

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ArrayToIterableBinderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.spanner.Statement;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ArrayToIterableBinderTest {
+
+  @Test
+  void canBindSameArrayClassOnly() {
+
+    ArrayToIterableBinder binder =
+        new ArrayToIterableBinder(CharSequence[].class, (builder, value) -> {});
+
+
+    assertTrue(binder.canBind(CharSequence[].class, null));
+    assertFalse(binder.canBind(CharSequence.class, null));
+    assertFalse(binder.canBind(String[].class, null));
+    assertFalse(binder.canBind(Object[].class, null));
+  }
+
+  @Test
+  void bindWithNullValue() {
+    Statement.Builder mockBuilder = mock(Statement.Builder.class);
+
+    ArrayToIterableBinder binder =
+        new ArrayToIterableBinder(String[].class, (builder, value) -> {
+          assertThat(value).isNull();
+        });
+
+    binder.bind(mockBuilder, "nullColumn", null, null);
+  }
+
+  @Test
+  void bindWithRealValueTurnsArrayIntoList() {
+    Statement.Builder mockBuilder = mock(Statement.Builder.class);
+
+    ArrayToIterableBinder binder =
+        new ArrayToIterableBinder(String[].class, (builder, value) -> {
+          assertThat(value).isInstanceOf(List.class);
+          assertThat((List) value).containsExactly("apples", "oranges");
+        });
+
+    binder.bind(mockBuilder, "nullColumn", new String[] { "apples", "oranges" }, null);
+  }
+
+
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.r2dbc.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.withPrecision;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -150,6 +151,55 @@ class ClientLibraryTypeBindersTest {
     ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", 123);
     verify(this.valueBinder).to((Long) 123L);
     verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void integerArrayBindsAsLongArray() {
+    int[] arrayValue = new int[] { 1, 2, 3 };
+
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", arrayValue);
+
+    ArgumentCaptor<long[]> captor = ArgumentCaptor.forClass(long[].class);
+    verify(this.valueBinder).toInt64Array(captor.capture());
+    long[] actual = captor.getValue();
+    assertThat(actual).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void nullIntegerArrayBindsAsLong() {
+
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(int[].class));
+
+    ArgumentCaptor<long[]> captor = ArgumentCaptor.forClass(long[].class);
+    verify(this.nullBinder).toInt64Array(captor.capture());
+    long[] actual = captor.getValue();
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void floatArrayBindsAsDoubleArray() {
+    float[] arrayValue = new float[] { 11.1f, 12.2f, 13.3f };
+
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", arrayValue);
+
+    ArgumentCaptor<double[]> captor = ArgumentCaptor.forClass(double[].class);
+    verify(this.valueBinder).toFloat64Array(captor.capture());
+    double[] actual = captor.getValue();
+    assertThat(actual).containsExactly(
+        new double[] {11.1, 12.2, 13.3},
+        withPrecision(0.01)
+    );
+  }
+
+  @Test
+  void nullFloatArrayBindsAsDouble() {
+
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(float[].class));
+
+    ArgumentCaptor<double[]> captor = ArgumentCaptor.forClass(double[].class);
+    verify(this.nullBinder).toFloat64Array(captor.capture());
+    double[] actual = captor.getValue();
+    assertThat(actual).isEmpty();
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -65,7 +65,7 @@ class ClientLibraryTypeBindersTest {
 
     TypedNull randNull = new TypedNull(Random.class);
     assertThatThrownBy(
-        () -> ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", randNull))
+        () -> ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", randNull))
           .isInstanceOf(BindingFailureException.class)
           .hasMessageContaining("Can't find a binder for type: class java.util.Random");
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/ClientLibraryTypeBindersTest.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -30,115 +30,124 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.ValueBinder;
 import com.google.cloud.spanner.r2dbc.BindingFailureException;
 import com.google.cloud.spanner.r2dbc.statement.TypedNull;
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.R2dbcType;
 import java.math.BigDecimal;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class ClientLibraryTypeBindersTest {
   ValueBinder valueBinder;
+
+  ValueBinder nullBinder;
 
   Builder statementBuilder;
 
   @BeforeEach
   public void setUp() {
     this.valueBinder = Mockito.mock(ValueBinder.class);
+    this.nullBinder = Mockito.mock(ValueBinder.class);
+
     this.statementBuilder = Mockito.mock(Builder.class);
-    when(this.statementBuilder.bind(anyString())).thenReturn(this.valueBinder);
+    when(this.statementBuilder.bind("valueColumn")).thenReturn(this.valueBinder);
+    when(this.statementBuilder.bind("nullColumn")).thenReturn(this.nullBinder);
   }
 
   @Test
   void unsupportedTypeThrowsException() {
     Random rand = new Random();
-    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", rand))
+    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", rand))
         .isInstanceOf(BindingFailureException.class)
         .hasMessageContaining("Can't find a binder for type: class java.util.Random");
 
     TypedNull randNull = new TypedNull(Random.class);
-    assertThatThrownBy(() -> ClientLibraryBinder.bind(this.statementBuilder, "a", randNull))
-        .isInstanceOf(BindingFailureException.class)
-        .hasMessageContaining("Can't find a binder for type: class java.util.Random");
+    assertThatThrownBy(
+        () -> ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", randNull))
+          .isInstanceOf(BindingFailureException.class)
+          .hasMessageContaining("Can't find a binder for type: class java.util.Random");
   }
 
   @Test
   void longBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", 1L);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Long.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", 1L);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Long.class));
     verify(this.valueBinder).to((Long) 1L);
-    verify(this.valueBinder).to((Long) null);
+    verify(this.nullBinder).to((Long) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void doubleBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", 2.0);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Double.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", 2.0);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Double.class));
     verify(this.valueBinder).to((Double) 2.0);
-    verify(this.valueBinder).to((Double) null);
+    verify(this.nullBinder).to((Double) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void booleanBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", true);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Boolean.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", true);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Boolean.class));
     verify(this.valueBinder).to((Boolean) true);
-    verify(this.valueBinder).to((Boolean) null);
+    verify(this.nullBinder).to((Boolean) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void byteArrayBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", ByteArray.copyFrom("abc"));
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(ByteArray.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", ByteArray.copyFrom("abc"));
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(ByteArray.class));
     verify(this.valueBinder).to(ByteArray.copyFrom("abc"));
-    verify(this.valueBinder).to((ByteArray) null);
+    verify(this.nullBinder).to((ByteArray) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void dateBinderTest() {
     Date date = Date.fromYearMonthDay(1992, 12, 31);
-    ClientLibraryBinder.bind(this.statementBuilder, "a", date);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Date.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", date);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Date.class));
     verify(this.valueBinder).to(date);
-    verify(this.valueBinder).to((Date) null);
+    verify(this.nullBinder).to((Date) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void stringBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", "abc");
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(String.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", "abc");
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(String.class));
     verify(this.valueBinder).to("abc");
-    verify(this.valueBinder).to((String) null);
+    verify(this.nullBinder).to((String) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void timestampBinderTest() {
     Timestamp ts = Timestamp.ofTimeMicroseconds(123456);
-    ClientLibraryBinder.bind(this.statementBuilder, "a", ts);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Timestamp.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", ts);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Timestamp.class));
     verify(this.valueBinder).to(ts);
-    verify(this.valueBinder).to((Timestamp) null);
+    verify(this.nullBinder).to((Timestamp) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void bigDecimalBinderTest() {
-    ClientLibraryBinder.bind(this.statementBuilder, "a", BigDecimal.TEN);
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(BigDecimal.class));
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", BigDecimal.TEN);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(BigDecimal.class));
     verify(this.valueBinder).to(BigDecimal.TEN);
-    verify(this.valueBinder).to((BigDecimal) null);
+    verify(this.nullBinder).to((BigDecimal) null);
     verifyNoMoreInteractions(this.valueBinder);
   }
 
   @Test
   void integerBindsAsLong() {
 
-    ClientLibraryBinder.bind(this.statementBuilder, "a", 123);
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", 123);
     verify(this.valueBinder).to((Long) 123L);
     verifyNoMoreInteractions(this.valueBinder);
   }
@@ -146,8 +155,8 @@ class ClientLibraryTypeBindersTest {
   @Test
   void integerNullBindsAsLong() {
 
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(Integer.class));
-    verify(this.valueBinder).to((Long) null);
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(Integer.class));
+    verify(this.nullBinder).to((Long) null);
     verifyNoMoreInteractions(this.valueBinder);
 
   }
@@ -155,10 +164,33 @@ class ClientLibraryTypeBindersTest {
   @Test
   void jsonBinderTest() {
     ClientLibraryBinder.bind(
-        this.statementBuilder, "a", JsonWrapper.of("{\"rating\":9,\"open\":true}"));
-    ClientLibraryBinder.bind(this.statementBuilder, "b", new TypedNull(JsonWrapper.class));
+        this.statementBuilder, "valueColumn", JsonWrapper.of("{\"rating\":9,\"open\":true}"));
+    ClientLibraryBinder.bind(this.statementBuilder, "nullColumn", new TypedNull(JsonWrapper.class));
     verify(this.valueBinder).to(Value.json("{\"rating\":9,\"open\":true}"));
-    verify(this.valueBinder).to(Value.json(null));
+    verify(this.nullBinder).to(Value.json(null));
     verifyNoMoreInteractions(this.valueBinder);
+  }
+
+  @Test
+  void stringArrayBinderTest() {
+    String[] value = new String[] { "Apples", "Oranges" };
+
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn", value);
+    ClientLibraryBinder.bind(
+        this.statementBuilder, "nullColumn", new TypedNull(String[].class));
+
+    ArgumentCaptor<Iterable<String>> captor = ArgumentCaptor.forClass(Iterable.class);
+    verify(this.valueBinder).toStringArray(captor.capture());
+    assertThat(captor.getValue()).containsExactly("Apples", "Oranges");
+
+    verify(this.nullBinder).toStringArray(null);
+  }
+
+  @Test
+  void bindingWithParameter() {
+    String text = "something there is that doesn't love a wall";
+    ClientLibraryBinder.bind(this.statementBuilder, "valueColumn",
+        Parameters.in(R2dbcType.VARCHAR, text));
+    verify(this.valueBinder).to(text);
   }
 }

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerArrayColumns.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerArrayColumns.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022-2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.springdata;
+
+import org.springframework.data.relational.core.dialect.ArrayColumns;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+class SpannerArrayColumns implements ArrayColumns {
+
+  @Override
+  public boolean isSupported() {
+    return true;
+  }
+
+  @Override
+  public Class<?> getArrayType(Class<?> userType) {
+    Assert.notNull(userType, "Array component type must not be null");
+
+    return ClassUtils.resolvePrimitiveIfNecessary(userType);
+  }
+}

--- a/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
+++ b/cloud-spanner-spring-data-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/springdata/SpannerR2dbcDialect.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
 import org.springframework.data.relational.core.dialect.AbstractDialect;
+import org.springframework.data.relational.core.dialect.ArrayColumns;
 import org.springframework.data.relational.core.dialect.LimitClause;
 import org.springframework.data.relational.core.dialect.LockClause;
 import org.springframework.data.relational.core.sql.LockOptions;
@@ -102,6 +103,11 @@ public class SpannerR2dbcDialect extends AbstractDialect implements R2dbcDialect
   @Override
   public Collection<Object> getConverters() {
     return Arrays.asList(new JsonToMapConverter<>(this.gson), new MapToJsonConverter<>(this.gson));
+  }
+
+  @Override
+  public ArrayColumns getArraySupport() {
+    return new SpannerArrayColumns();
   }
 
 }


### PR DESCRIPTION
This PR adds three additional types of parameter binding:
1) primitive arrays. These were straightforward to match, knowing the incoming object type, and are implemented with existing `ClientLibraryTypeBinderImpl`.
2) wrapper type arrays or primitive arrays where type conversion is needed. These need to be converted from an array to a list to use the list-accepting overloads of client library value binder. I've implemented a helper class `ArrayToIterableBinder` to avoid duplicating list creation boilerplate.
3) Iterable/Collection. This was harder, since the client library has typed binding methods, but parameterized types aren't real ("reified") in Java. This is, however, possible with R2DBC SPI 0.9 `Parameter.in()` binding. It's implemented with one binder for all `Iterable` needs -- `IterableBinder`, which uses some hardcoded type maps in `SpannerType`. I've updated `ClientLibraryTypeBinder` to accept `SpannerType` hints, but for now only the `IterableBinder` uses these values. We may have use for the additional type hinting in the future, though, so we might as well give the binders all useful information up front.

The funny thing is that (3) is not necessary to bind collections with Spring Data, because all collections get converted to arrays internally, so by the time the value gets to the driver, it's already an easily digestible array.  `SpannerArrayColumns` and `SpannerR2dbcDialect` changes are needed to trigger this logic in Spring Data.

In a semi-related change, I've simplified the front-end to send and retrieve a whole Book object, because adding another field with another button would be too complicated for users.

Fixes #481.