### PR TITLE
Bump spring-boot-starter-parent to 2.6.8 instead of 2.7.0

### DIFF
--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.7</version>
+    <version>2.6.8</version>
     <relativePath/>
   </parent>
 

--- a/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
+++ b/cloud-spanner-r2dbc-samples/cloud-spanner-spring-data-r2dbc-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.6.7</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Reverts #544, and set spring-boot-starter-parent to 2.6.8.
2.7.0 needs to be a manual update with #541, integration test fails with same error as #539