### PR TITLE
Revert "Bump libraries-bom from 26.1.1 to 26.1.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
 
-    <google-cloud-bom.version>26.1.2</google-cloud-bom.version>
+    <google-cloud-bom.version>26.1.1</google-cloud-bom.version>
 
     <r2dbc.version>0.9.0.RELEASE</r2dbc.version>
     <reactor.version>2020.0.23</reactor.version>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-spanner-r2dbc#581.

This upgrade seems to have encountered a number of integration test failures, e.g.:
```
Error:  Tests run: 76, Failures: 15, Errors: 0, Skipped: 39, Time elapsed: 98.084 s <<< FAILURE! - in TestSuite
Error:  com.google.cloud.spanner.r2dbc.it.SpannerSelectReactiveStreamVerification.optional_spec104_mustSignalOnErrorWhenFails  Time elapsed: 0.217 s  <<< FAILURE!
java.lang.RuntimeException: Publisher threw exception (Error-state Publisher FluxFlatMap did not call `onError` on new Subscriber within 200 ms) instead of signalling error via onError!
	at org.reactivestreams.tck.PublisherVerification.optional_spec104_mustSignalOnErrorWhenFails(PublisherVerification.java:384)
```