### PR TITLE
Bump libraries-bom from 26.1.1 to 26.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
 
-    <google-cloud-bom.version>26.1.1</google-cloud-bom.version>
+    <google-cloud-bom.version>26.1.2</google-cloud-bom.version>
 
     <r2dbc.version>0.9.0.RELEASE</r2dbc.version>
     <reactor.version>2020.0.23</reactor.version>


### PR DESCRIPTION
Upgrades libraries-bom back to 26.1.2 (revert of GoogleCloudPlatform/cloud-spanner-r2dbc#583), as the observed integration test failure was a flake unrelated to the dependabot upgrade, and has been successfully re-run.