### PR TITLE
chore: re-enable SpannerClientLibraryTestKit tests

### DIFF
--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerClientLibraryTestKit.java
@@ -58,7 +58,6 @@ import reactor.test.StepVerifier;
 /**
  * R2DBC TCK test implementation.
  */
-@Disabled ("Until missing SPI v0.9 functionality is implemented")
 public class SpannerClientLibraryTestKit implements TestKit<String> {
 
   private static final String DISABLE_UNSUPPORTED_FUNCTIONALITY =


### PR DESCRIPTION
Attempting to re-enable these tests according to https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/488