### PR TITLE
build: activate the release profile with property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,19 @@
       <modules>
         <module>cloud-spanner-r2dbc</module>
         <module>cloud-spanner-spring-data-r2dbc</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>non-release</id>
+      <activation>
+        <property>
+          <name>!performRelease</name>
+        </property>
+      </activation>
+      <modules>
+        <module>cloud-spanner-r2dbc</module>
+        <module>cloud-spanner-spring-data-r2dbc</module>
         <module>cloud-spanner-r2dbc-samples</module>
       </modules>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -336,19 +336,6 @@
       <modules>
         <module>cloud-spanner-r2dbc</module>
         <module>cloud-spanner-spring-data-r2dbc</module>
-      </modules>
-    </profile>
-
-    <profile>
-      <id>non-release</id>
-      <activation>
-        <property>
-          <name>!performRelease</name>
-        </property>
-      </activation>
-      <modules>
-        <module>cloud-spanner-r2dbc</module>
-        <module>cloud-spanner-spring-data-r2dbc</module>
         <module>cloud-spanner-r2dbc-samples</module>
       </modules>
     </profile>
@@ -392,6 +379,11 @@
 
     <profile>
       <id>release</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+        </property>
+      </activation>
       <modules>
         <module>cloud-spanner-r2dbc</module>
         <module>cloud-spanner-spring-data-r2dbc</module>


### PR DESCRIPTION
The shared release script uses `-DperformRelease` rather than setting a profile `-prelease` explicitly. The latter fails unless the profile is defined. This change activates the `release` profile (which correctly sets the modules and enables GPG signing) via the `performRelease` property.