### PR TITLE
fix: Context loss after applying com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryStatement

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -44,7 +44,9 @@ class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatemen
         .transform(
             rows ->
                 Mono.deferContextual(
-                    c -> Mono.just(new SpannerClientLibraryResult(rows.contextWrite(c), 0))))
+                    contextView ->
+                        Mono.just(
+                            new SpannerClientLibraryResult(rows.contextWrite(contextView), 0))))
         .single();
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatement.java
@@ -41,7 +41,11 @@ class SpannerClientLibraryStatement extends AbstractSpannerClientLibraryStatemen
   protected Mono<SpannerClientLibraryResult> executeSingle(Statement statement) {
     return this.clientLibraryAdapter
         .runSelectStatement(statement)
-        .transform(rows -> Mono.just(new SpannerClientLibraryResult(rows, 0))).single();
+        .transform(
+            rows ->
+                Mono.deferContextual(
+                    c -> Mono.just(new SpannerClientLibraryResult(rows.contextWrite(c), 0))))
+        .single();
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementContextLossTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementContextLossTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import reactor.core.publisher.Hooks;
+
+class SpannerClientLibraryStatementContextLossTest extends SpannerClientLibraryStatementTest {
+
+  @BeforeAll
+  static void enableContextLossTracking() {
+    Hooks.enableContextLossTracking();
+  }
+
+  @AfterAll
+  static void disableContextLossTracking() {
+    Hooks.disableContextLossTracking();
+  }
+}


### PR DESCRIPTION
fixes #685
Thanks @filipenfst for reporting the bug and proposing the fix. 

**Bug**: 
without the changes in [SpannerClientLibraryStatement](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/pull/690/files#diff-8dc52019a2c3f21d622ff67a164701491c23275986a72dce82c805f32550edc9), the `SpannerClientLibraryStatementTest` would fail with context loss if context loss tracking is enabled. This [unit test](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/blob/3e0c14ab8f9f8d6a4745198ac031e17648e03e62/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementContextLossTest.java) can be used to reproduce the error. 
```
Context loss after applying com.google.cloud.spanner.r2dbc.v2.SpannerClientLibraryStatement$$Lambda$451/0x0000000801285948@6331250e)
```
**Fix**: 
retain contextView in `SpannerClientLibraryStatement#executeSingle` method transform.