### PR TITLE
chore: replace deprecated github action commands.

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - uses: actions/cache@v3
         id: mvn-cache
         with:

--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -13,27 +13,30 @@ jobs:
   integrationTests:
     if: github.repository == 'GoogleCloudPlatform/cloud-spanner-r2dbc'
     runs-on: ubuntu-20.04
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     strategy:
       fail-fast: true
     steps:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: mvn-cache
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.date }}
       - name: Set Up Authentication
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.CLOUD_SPANNER_R2DBC_CI_SA_KEY }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: latest
           project_id: cloud-spanner-r2dbc-ci
@@ -96,7 +99,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Integration Test Logs - ${{ matrix.it}}
           path: |

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -21,13 +21,14 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: mvn-cache
         with:
           path: ~/.m2/repository
@@ -80,7 +81,7 @@ jobs:
       - name: Archive logs
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit Test Logs - Java ${{ matrix.java }}
           path: |

--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
1. Github action shows warning:
``The `set-output` command is deprecated and will be disabled soon. ``
sample [log](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/actions/runs/5157962559)
This change follows the upgrade guide and upgrades to using Environment Files

2. This pr also addresses `Node.js 12 actions are deprecated` warning on unit test and integration tests.
Github action announcement:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

    - For 'google-github-actions/auth@v1' and 'google-github-actions/setup-gcloud@v1', follow example [here](https://github.com/google-github-actions/setup-gcloud#service-account-key-json)

Note: turnstyle is not updated:
[`softprops/turnstyle@v1`](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/blob/7b3dad17218dd5c4f9b89e0c0052df2c0e8d8ef2/.github/workflows/integrationTests.yaml#L70) is not being maintained since Dec 2020. Most of it functionality is available through the [`concurrency`](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/) in Github Actions, but it lacks ability to queue. It either only want latest code deployed or the latest commit.
https://github.com/softprops/turnstyle/issues/43
https://github.com/orgs/community/discussions/5435
TODO:

- [x] create issue to replace usage of un-mantained `softprops/turnstyle@v1` #694
