### PR TITLE
feat: upgrade to R2DBC SPI [do not merge]

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResult.java
@@ -31,18 +31,18 @@ class SpannerClientLibraryResult implements Result {
 
   private final Flux<SpannerClientLibraryRow> resultRows;
 
-  private final int numRowsUpdated;
+  private final long numRowsUpdated;
 
   private RowMetadata rowMetadata;
 
   public SpannerClientLibraryResult(
-      Flux<SpannerClientLibraryRow> resultRows, int numRowsUpdated) {
+      Flux<SpannerClientLibraryRow> resultRows, long numRowsUpdated) {
     this.resultRows = Assert.requireNonNull(resultRows, "A non-null flux of rows is required.");
     this.numRowsUpdated = numRowsUpdated;
   }
 
   @Override
-  public Publisher<Integer> getRowsUpdated() {
+  public Publisher<Long> getRowsUpdated() {
     return Mono.just(this.numRowsUpdated);
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadata.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryRowMetadata.java
@@ -81,7 +81,6 @@ class SpannerClientLibraryRowMetadata implements RowMetadata {
     return this.columnMetadatas;
   }
 
-  @Override
   public Collection<String> getColumnNames() {
     return this.columnNames;
   }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryBasedIntegrationTest.java
@@ -144,7 +144,7 @@ class ClientLibraryBasedIntegrationTest {
                 .bind("price", new BigDecimal("123.99"))
                 .execute())
             .flatMapMany(rs -> rs.getRowsUpdated())
-    ).expectNext(1).verifyComplete();
+    ).expectNext(1L).verifyComplete();
 
     StepVerifier.create(
         Mono.from(conn.createStatement("SELECT AUTHOR, PRICE FROM BOOKS LIMIT 1").execute())
@@ -195,7 +195,7 @@ class ClientLibraryBasedIntegrationTest {
                 )
                 .execute())
             .flatMapMany(rs -> rs.getRowsUpdated())
-    ).expectNext(1).verifyComplete();
+    ).expectNext(1L).verifyComplete();
 
     StepVerifier.create(
         Mono.from(conn.createStatement("SELECT count(*) FROM BOOKS").execute())
@@ -244,7 +244,7 @@ class ClientLibraryBasedIntegrationTest {
                         .bind("extra", JsonWrapper.of("{\"b\":9,\"a\":true}"))
                         .execute())
                 .flatMapMany(rs -> rs.getRowsUpdated()))
-        .expectNext(1)
+        .expectNext(1L)
         .verifyComplete();
 
     StepVerifier.create(
@@ -467,7 +467,7 @@ class ClientLibraryBasedIntegrationTest {
                 ).flatMap(r -> r.getRowsUpdated())
             ))
 
-    ).expectNext(1, 1, 1).verifyComplete();
+    ).expectNext(1L, 1L, 1L).verifyComplete();
 
     StepVerifier.create(
         Mono.from(connectionFactory.create()).flatMapMany(
@@ -511,7 +511,7 @@ class ClientLibraryBasedIntegrationTest {
                 ).flatMap(r -> r.getRowsUpdated())
             ))
 
-    ).expectNext(1, 1, 1).verifyComplete();
+    ).expectNext(1L, 1L, 1L).verifyComplete();
 
     StepVerifier.create(
         Mono.from(connectionFactory.create()).flatMapMany(
@@ -553,7 +553,7 @@ class ClientLibraryBasedIntegrationTest {
                     .execute()
             )
                 .flatMap(rs -> rs.getRowsUpdated()))
-    ).expectNext(1, 1, 1).as("Row insert count matches").verifyComplete();
+    ).expectNext(1L, 1L, 1L).as("Row insert count matches").verifyComplete();
 
     StepVerifier.create(
         Mono.from(connectionFactory.create())
@@ -767,7 +767,7 @@ class ClientLibraryBasedIntegrationTest {
               .add("UPDATE BOOKS SET CATEGORY=17 WHERE CATEGORY=29")
               .execute()
           ).flatMap(r -> r.getRowsUpdated())
-    ).expectNext(1, 1, 2)
+    ).expectNext(1L, 1L, 2L)
         .verifyComplete();
 
     verifyIds(uuid1, uuid2);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryDdlIntegrationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/ClientLibraryDdlIntegrationTest.java
@@ -79,7 +79,7 @@ class ClientLibraryDdlIntegrationTest {
             .execute())
             .log("Table" + tableName + " created")
             .flatMap(res -> Mono.from(res.getRowsUpdated()))
-    ).expectNext(0).as("DDL execution returns zero affected rows")
+    ).expectNext(0L).as("DDL execution returns zero affected rows")
         .verifyComplete();
 
     StepVerifier.create(

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDmlReactiveStreamVerification.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerDmlReactiveStreamVerification.java
@@ -36,7 +36,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 class SpannerDmlReactiveStreamVerification extends
-    PublisherVerification<Integer> {
+    PublisherVerification<Long> {
 
   private static ConnectionFactory connectionFactory;
 
@@ -71,7 +71,7 @@ class SpannerDmlReactiveStreamVerification extends
   }
 
   @Override
-  public Publisher<Integer> createPublisher(long l) {
+  public Publisher<Long> createPublisher(long l) {
     return Mono.from(connectionFactory.create())
         .flatMapMany(conn ->
             Flux.from(conn.createStatement(
@@ -82,7 +82,7 @@ class SpannerDmlReactiveStreamVerification extends
   }
 
   @Override
-  public Publisher<Integer> createFailedPublisher() {
+  public Publisher<Long> createFailedPublisher() {
     return Mono.from(connectionFactory.create())
         .flatMapMany(conn -> conn.createStatement("UPDATE BOOKS SET bad syntax ").execute())
         .flatMap(rs -> rs.getRowsUpdated());

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerQueryUtil.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/it/SpannerQueryUtil.java
@@ -43,10 +43,10 @@ class SpannerQueryUtil {
   /**
    * Executes a DML query and returns the rows updated.
    */
-  static int executeDmlQuery(Connection connection, String sql) {
+  static long executeDmlQuery(Connection connection, String sql) {
 
     Mono.from(connection.beginTransaction()).block();
-    int rowsUpdated = Mono.from(connection.createStatement(sql).execute())
+    long rowsUpdated = Mono.from(connection.createStatement(sql).execute())
         .flatMap(result -> Mono.from(result.getRowsUpdated()))
         .block();
     Mono.from(connection.commitTransaction()).block();

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/AbstractSpannerClientLibraryStatementTest.java
@@ -61,7 +61,7 @@ class AbstractSpannerClientLibraryStatementTest {
     FakeStatement statement = new FakeStatement(this.mockAdapter, query);
 
     StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
-        .expectNext(19)
+        .expectNext(19L)
         .verifyComplete();
 
     ArgumentCaptor<Statement> capturedStatement = ArgumentCaptor.forClass(Statement.class);
@@ -82,7 +82,7 @@ class AbstractSpannerClientLibraryStatementTest {
     statement.bind("three", "333");
 
     StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
-        .expectNext(19)
+        .expectNext(19L)
         .verifyComplete();
 
     ArgumentCaptor<Statement> capturedStatement = ArgumentCaptor.forClass(Statement.class);
@@ -108,7 +108,7 @@ class AbstractSpannerClientLibraryStatementTest {
     statement.add();
 
     StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
-        .expectNext(7, 11, 13)
+        .expectNext(7L, 11L, 13L)
         .verifyComplete();
 
     ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);
@@ -139,7 +139,7 @@ class AbstractSpannerClientLibraryStatementTest {
     statement.bind("three", "B333");
 
     StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
-        .expectNext(7, 11, 13)
+        .expectNext(7L, 11L, 13L)
         .verifyComplete();
 
     ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);
@@ -175,7 +175,7 @@ class AbstractSpannerClientLibraryStatementTest {
     statement.add();
 
     StepVerifier.create(Flux.from(statement.execute()).flatMap(r -> r.getRowsUpdated()))
-        .expectNext(7, 11, 13)
+        .expectNext(7L, 11L, 13L)
         .verifyComplete();
 
     ArgumentCaptor<List<Statement>> params = ArgumentCaptor.forClass(List.class);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -283,7 +283,7 @@ class DatabaseClientReactiveAdapterTest {
       this.adapter.runBatchDml(
           ImmutableList.of(Statement.of("UPDATE something"), Statement.of("UPDATE something else")))
         .flatMap(result -> result.getRowsUpdated())
-    ).expectNext(42, 81)
+    ).expectNext(42L, 81L)
         .verifyComplete();
   }
 
@@ -299,7 +299,7 @@ class DatabaseClientReactiveAdapterTest {
         this.adapter.runBatchDml(
             ImmutableList.of(Statement.of("UPDATE something")))
             .flatMap(result -> result.getRowsUpdated())
-    ).expectNext(Integer.MAX_VALUE)
+    ).expectNext(Long.valueOf(Integer.MAX_VALUE))
         .verifyComplete();
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatchTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerBatchTest.java
@@ -78,7 +78,7 @@ class SpannerBatchTest {
             batch.add("UPDATE tbl SET col1=val1")
                 .add("UPDATE tbl SET col2=val2").execute()
         ).flatMap(r -> r.getRowsUpdated())
-    ).expectNext(35, 47)
+    ).expectNext(35L, 47L)
         .verifyComplete();
 
     ArgumentCaptor<List<Statement>> argCaptor = ArgumentCaptor.forClass(List.class);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -71,7 +71,7 @@ class SpannerClientLibraryConnectionTest {
         Flux.from(
             batch.add("UPDATE tbl SET col1=val1").execute()
         ).flatMap(r -> r.getRowsUpdated())
-    ).expectNext(35)
+    ).expectNext(35L)
     .verifyComplete();
 
     ArgumentCaptor<List<Statement>> argCaptor = ArgumentCaptor.forClass(List.class);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDdlStatementTest.java
@@ -59,7 +59,7 @@ class SpannerClientLibraryDdlStatementTest {
 
     StepVerifier.create(
         statement.execute().flatMap((Result r) -> Mono.from(r.getRowsUpdated()))
-    ).expectNext(0)
+    ).expectNext(0L)
         .verifyComplete();
   }
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryDmlStatementTest.java
@@ -48,7 +48,7 @@ class SpannerClientLibraryDmlStatementTest {
     StepVerifier.create(
             Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated())
     )
-        .expectNext(0)
+        .expectNext(0L)
         .verifyComplete();
   }
 
@@ -68,7 +68,7 @@ class SpannerClientLibraryDmlStatementTest {
 
     StepVerifier.create(
             Flux.from(dmlStatement.execute()).flatMap(result -> result.getRowsUpdated()))
-        .expectNext(2, 5)
+        .expectNext(2L, 5L)
         .verifyComplete();
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryResultTest.java
@@ -41,7 +41,7 @@ class SpannerClientLibraryResultTest {
   void getRowsUpdatedReturnsCorrectNumber() {
     SpannerClientLibraryResult result = new SpannerClientLibraryResult(Flux.empty(), 42);
     StepVerifier.create(result.getRowsUpdated())
-        .expectNext(42)
+        .expectNext(42L)
         .verifyComplete();
   }
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryStatementTest.java
@@ -56,7 +56,7 @@ class SpannerClientLibraryStatementTest {
 
     StepVerifier.create(
         Flux.from(statement.execute()).flatMap(result -> result.getRowsUpdated()))
-        .expectNext(0)
+        .expectNext(0L)
         .verifyComplete();
 
     StepVerifier.create(

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerResultTest.java
@@ -50,7 +50,7 @@ class SpannerResultTest {
   void getRowsUpdatedTest() {
     StepVerifier.create(
         ((Mono) new SpannerClientLibraryResult(this.resultSet, 2).getRowsUpdated()))
-        .expectNext(2)
+        .expectNext(2L)
         .verifyComplete();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
     <google-cloud-bom.version>26.16.0</google-cloud-bom.version>
 
-    <r2dbc.version>0.9.0.RELEASE</r2dbc.version>
+    <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
     <reactor.version>2022.0.7</reactor.version>
 
     <mockito.version>4.9.0</mockito.version>


### PR DESCRIPTION
Attempt to upgrade to R2DBC SPI 1.0 #487

This is a draft PR intent to estimate upgrade effort.

- [x] Fixed compiling errors
- [x] Fixed unit test errors
- [ ] integration test errors caused by return type change `Integer` -> `Long`

error log
```
[ERROR] Failures: 
[ERROR]   ClientLibraryBasedIntegrationTest.insertMultipleBoundParameterSetsInTransaction expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.selectQueryReturnsUpdatedDataDuringAndAfterTransactionCommit expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.selectQueryReturnsUpdatedDataDuringTransactionButNotAfterTransactionRollback expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testStaleRead expectation "row inserted" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testStrongReadFromSubclassedConnection expectation "row inserted" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testTransactionFollowedByStandaloneStatementCommitted expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testTransactionMultipleStatementsCommitted expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testTransactionRolledBack expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[ERROR]   ClientLibraryBasedIntegrationTest.testTransactionSingleStatementCommitted expectation "expectNext(1)" failed (expected value: 1; actual value: 1)
[INFO] 
[ERROR] Tests run: 60, Failures: 9, Errors: 0, Skipped: 34

```