### PR TITLE
feat: Implementing Connection#beginTransaction(TransactionDefinition) to support @Transactional annotation

### DIFF
--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -183,7 +183,7 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
 
   private Mono<Void> validateIsolation(IsolationLevel isolationLevel) {
     boolean valid = isolationLevel == null || isolationLevel == SERIALIZABLE;
-    return valid ? Mono.empty(): Mono.error(new UnsupportedOperationException(
+    return valid ? Mono.empty() : Mono.error(new UnsupportedOperationException(
         String.format("'%s' isolation level not supported", isolationLevel.asSql())));
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -186,6 +186,7 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
     }
     return isolationLevel == SERIALIZABLE ? Mono.empty()
         : Mono.error(new UnsupportedOperationException(
-            String.format("'%s' isolation level not supported", isolationLevel.asSql())));
+            String.format("Unsupported '%s' isolation level, Only SERIALIZABLE is supported.",
+                isolationLevel.asSql())));
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -24,6 +24,7 @@ import static io.r2dbc.spi.IsolationLevel.REPEATABLE_READ;
 import static io.r2dbc.spi.TransactionDefinition.ISOLATION_LEVEL;
 import static io.r2dbc.spi.TransactionDefinition.READ_ONLY;
 import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
 
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.api.SpannerConnection;
@@ -37,13 +38,12 @@ import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 class SpannerClientLibraryConnection implements Connection, SpannerConnection {
-  private final static List<IsolationLevel> UNSUPPORTED_ISOLATION_LEVELS = Arrays.asList(READ_COMMITTED,
+  private static final List<IsolationLevel> UNSUPPORTED_ISOLATION_LEVELS = asList(READ_COMMITTED,
       READ_UNCOMMITTED,
       REPEATABLE_READ);
 
@@ -192,7 +192,7 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
     boolean invalid = UNSUPPORTED_ISOLATION_LEVELS.contains(isolationLevel);
     if (invalid) {
       return Mono.error(new UnsupportedOperationException(
-          String.format("%s isolation level not supported", isolationLevel)));
+          String.format("'%s' isolation level not supported", isolationLevel.asSql())));
     }
     return Mono.empty();
   }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -39,8 +39,6 @@ import io.r2dbc.spi.ValidationDepth;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -70,9 +68,9 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
           if (isReadOnly) {
             TimestampBound timestampBound = firstNonNull(definition.getAttribute(TIMESTAMP_BOUND),
                 TimestampBound.strong());
-            return clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
+            return this.clientLibraryAdapter.beginReadonlyTransaction(timestampBound);
           }
-          return clientLibraryAdapter.beginTransaction();
+          return this.clientLibraryAdapter.beginTransaction();
         }));
   }
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnection.java
@@ -43,6 +43,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 class SpannerClientLibraryConnection implements Connection, SpannerConnection {
+
   private static final List<IsolationLevel> UNSUPPORTED_ISOLATION_LEVELS = asList(READ_COMMITTED,
       READ_UNCOMMITTED,
       REPEATABLE_READ);
@@ -189,7 +190,8 @@ class SpannerClientLibraryConnection implements Connection, SpannerConnection {
   }
 
   private Mono<Void> validateIsolation(IsolationLevel isolationLevel) {
-    boolean invalid = UNSUPPORTED_ISOLATION_LEVELS.contains(isolationLevel);
+    boolean invalid =
+        isolationLevel != null && UNSUPPORTED_ISOLATION_LEVELS.contains(isolationLevel);
     if (invalid) {
       return Mono.error(new UnsupportedOperationException(
           String.format("'%s' isolation level not supported", isolationLevel.asSql())));

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
@@ -23,6 +23,6 @@ import io.r2dbc.spi.Option;
  * Spanner Constants.
  */
 public class SpannerConstants {
-  public static Option<TimestampBound> TIMESTAMP_BOUND = Option.valueOf("timestampBound");
+  public static final Option<TimestampBound> TIMESTAMP_BOUND = Option.valueOf("timestampBound");
 
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spanner.r2dbc.v2;
 
 import com.google.cloud.spanner.TimestampBound;
-import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Option;
 
+/**
+ * Spanner Constants.
+ */
 public class SpannerConstants {
   public static Option<TimestampBound> TIMESTAMP_BOUND = Option.valueOf("timestampBound");
 

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerConstants.java
@@ -1,0 +1,10 @@
+package com.google.cloud.spanner.r2dbc.v2;
+
+import com.google.cloud.spanner.TimestampBound;
+import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.Option;
+
+public class SpannerConstants {
+  public static Option<TimestampBound> TIMESTAMP_BOUND = Option.valueOf("timestampBound");
+
+}

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.spanner.r2dbc.util;
+package com.google.cloud.spanner.r2dbc.v2;
 
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.TransactionDefinition;
@@ -22,13 +22,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * An implementation of {@link TransactionDefinition} for test purposes.
+ * An implementation of {@link TransactionDefinition} for Spanner Database.
  */
-public class TestTransactionDefinition implements TransactionDefinition {
+public class SpannerTransactionDefinition implements TransactionDefinition {
 
   private final Map<Option<?>, Object> internalMap;
 
-  TestTransactionDefinition(Map<Option<?>, Object> internalMap) {
+  SpannerTransactionDefinition(Map<Option<?>, Object> internalMap) {
     this.internalMap = internalMap;
   }
 
@@ -39,7 +39,7 @@ public class TestTransactionDefinition implements TransactionDefinition {
 
 
   /**
-   * A builder class for {@link TestTransactionDefinition}.
+   * A builder class for {@link SpannerTransactionDefinition}.
    */
   public static class Builder {
     private final Map<Option<?>, Object> internalMap;
@@ -53,8 +53,8 @@ public class TestTransactionDefinition implements TransactionDefinition {
       return this;
     }
 
-    public TestTransactionDefinition build() {
-      return new TestTransactionDefinition(this.internalMap);
+    public SpannerTransactionDefinition build() {
+      return new SpannerTransactionDefinition(this.internalMap);
     }
   }
 }

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.spanner.r2dbc.v2;
 
+import static com.google.cloud.spanner.r2dbc.v2.SpannerConstants.TIMESTAMP_BOUND;
+import static java.lang.Boolean.FALSE;
+
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.TransactionDefinition;
 import java.util.HashMap;
@@ -29,7 +32,15 @@ public class SpannerTransactionDefinition implements TransactionDefinition {
   private final Map<Option<?>, Object> internalMap;
 
   SpannerTransactionDefinition(Map<Option<?>, Object> internalMap) {
+    validate(internalMap);
     this.internalMap = internalMap;
+  }
+
+  private void validate(Map<Option<?>, Object> internalMap) {
+    if (FALSE.equals(internalMap.get(READ_ONLY)) && internalMap.containsKey(TIMESTAMP_BOUND)) {
+      throw new IllegalArgumentException("TIMESTAMP_BOUND can only be configured for"
+          + " read only transactions.");
+    }
   }
 
   @Override

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinition.java
@@ -17,7 +17,7 @@
 package com.google.cloud.spanner.r2dbc.v2;
 
 import static com.google.cloud.spanner.r2dbc.v2.SpannerConstants.TIMESTAMP_BOUND;
-import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.TransactionDefinition;
@@ -37,7 +37,8 @@ public class SpannerTransactionDefinition implements TransactionDefinition {
   }
 
   private void validate(Map<Option<?>, Object> internalMap) {
-    if (FALSE.equals(internalMap.get(READ_ONLY)) && internalMap.containsKey(TIMESTAMP_BOUND)) {
+    boolean isReadOnlyTransaction = TRUE.equals(internalMap.get(READ_ONLY));
+    if (!isReadOnlyTransaction && internalMap.containsKey(TIMESTAMP_BOUND)) {
       throw new IllegalArgumentException("TIMESTAMP_BOUND can only be configured for"
           + " read only transactions.");
     }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/TestTransactionDefinition.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/TestTransactionDefinition.java
@@ -1,0 +1,38 @@
+package com.google.cloud.spanner.r2dbc.util;
+
+import io.r2dbc.spi.Option;
+import io.r2dbc.spi.TransactionDefinition;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestTransactionDefinition implements TransactionDefinition {
+
+  private final Map<Option<?>, Object> internalMap;
+
+  TestTransactionDefinition(Map<Option<?>, Object> internalMap) {
+    this.internalMap = internalMap;
+  }
+
+  @Override
+  public <T> T getAttribute(Option<T> option) {
+    return (T) this.internalMap.get(option);
+  }
+
+
+  public static class Builder {
+    private final Map<Option<?>, Object> internalMap;
+
+    public Builder() {
+      this.internalMap = new HashMap<>();
+    }
+
+    public <T> Builder with(Option<T> option, T value) {
+      this.internalMap.put(option, value);
+      return this;
+    }
+
+    public TestTransactionDefinition build() {
+      return new TestTransactionDefinition(internalMap);
+    }
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/TestTransactionDefinition.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/util/TestTransactionDefinition.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spanner.r2dbc.util;
 
 import io.r2dbc.spi.Option;
@@ -5,6 +21,9 @@ import io.r2dbc.spi.TransactionDefinition;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * An implementation of {@link TransactionDefinition} for test purposes.
+ */
 public class TestTransactionDefinition implements TransactionDefinition {
 
   private final Map<Option<?>, Object> internalMap;
@@ -19,6 +38,9 @@ public class TestTransactionDefinition implements TransactionDefinition {
   }
 
 
+  /**
+   * A builder class for {@link TestTransactionDefinition}.
+   */
   public static class Builder {
     private final Map<Option<?>, Object> internalMap;
 
@@ -32,7 +54,7 @@ public class TestTransactionDefinition implements TransactionDefinition {
     }
 
     public TestTransactionDefinition build() {
-      return new TestTransactionDefinition(internalMap);
+      return new TestTransactionDefinition(this.internalMap);
     }
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.r2dbc.util.TestTransactionDefinition;
+import com.google.cloud.spanner.r2dbc.v2.SpannerTransactionDefinition;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.TransactionDefinition;
 import java.time.Duration;
@@ -69,7 +69,7 @@ class SpannerClientLibraryConnectionTest {
 
   @Test
   void shouldBeginTransactionInReadOnlyMode() {
-    TestTransactionDefinition readOnlyDefinition = new TestTransactionDefinition.Builder()
+    SpannerTransactionDefinition readOnlyDefinition = new SpannerTransactionDefinition.Builder()
         .with(TransactionDefinition.READ_ONLY, true)
         .build();
 
@@ -83,7 +83,7 @@ class SpannerClientLibraryConnectionTest {
 
   @Test
   void shouldBeginTransactionInReadWriteMode() {
-    TestTransactionDefinition readWriteDefinition = new TestTransactionDefinition.Builder()
+    SpannerTransactionDefinition readWriteDefinition = new SpannerTransactionDefinition.Builder()
         .with(TransactionDefinition.READ_ONLY, false)
         .build();
 
@@ -97,7 +97,7 @@ class SpannerClientLibraryConnectionTest {
 
   @Test
   void shouldBeginTransactionInReadWriteModeByDefault() {
-    TestTransactionDefinition readWriteDefinition = new TestTransactionDefinition.Builder()
+    SpannerTransactionDefinition readWriteDefinition = new SpannerTransactionDefinition.Builder()
         .build();   // absence of attribute indicates read write transaction
 
     when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
@@ -112,7 +112,7 @@ class SpannerClientLibraryConnectionTest {
   void shouldBeginTransactionWithGivenTimestampBound() {
     TimestampBound fiveSecondTimestampBound = TimestampBound.ofExactStaleness(5L, TimeUnit.SECONDS);
 
-    TestTransactionDefinition readWriteDefinition = new TestTransactionDefinition.Builder()
+    SpannerTransactionDefinition readWriteDefinition = new SpannerTransactionDefinition.Builder()
         .with(TransactionDefinition.READ_ONLY, true)
         .with(SpannerConstants.TIMESTAMP_BOUND, fiveSecondTimestampBound)
         .build();
@@ -129,36 +129,36 @@ class SpannerClientLibraryConnectionTest {
   @Test
   void shouldThrowErrorWhenBeginTransactionWithOtherThanDefaultOrSerializable() {
     when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
-    TestTransactionDefinition.Builder builder = new TestTransactionDefinition.Builder();
+    SpannerTransactionDefinition.Builder builder = new SpannerTransactionDefinition.Builder();
 
     // default isolation
-    TestTransactionDefinition defaultIsolation = builder.with(ISOLATION_LEVEL, null)
+    SpannerTransactionDefinition defaultIsolation = builder.with(ISOLATION_LEVEL, null)
         .build();
     StepVerifier.create(this.connection.beginTransaction(defaultIsolation))
         .verifyComplete();
 
     // SERIALIZABLE isolation
-    TestTransactionDefinition serializable = builder.with(ISOLATION_LEVEL, SERIALIZABLE)
+    SpannerTransactionDefinition serializable = builder.with(ISOLATION_LEVEL, SERIALIZABLE)
         .build();
     StepVerifier.create(this.connection.beginTransaction(serializable))
         .verifyComplete();
 
     // READ_COMMITTED isolation
-    TestTransactionDefinition readCommitted = builder.with(ISOLATION_LEVEL, READ_COMMITTED)
+    SpannerTransactionDefinition readCommitted = builder.with(ISOLATION_LEVEL, READ_COMMITTED)
         .build();
     StepVerifier.create(this.connection.beginTransaction(readCommitted))
         .expectError(UnsupportedOperationException.class)
         .verify();
 
     // READ_UNCOMMITTED isolation
-    TestTransactionDefinition readUncommitted = builder.with(ISOLATION_LEVEL, READ_UNCOMMITTED)
+    SpannerTransactionDefinition readUncommitted = builder.with(ISOLATION_LEVEL, READ_UNCOMMITTED)
         .build();
     StepVerifier.create(this.connection.beginTransaction(readUncommitted))
         .expectError(UnsupportedOperationException.class)
         .verify();
 
     // REPEATABLE_READ isolation
-    TestTransactionDefinition repeatableRead = builder.with(ISOLATION_LEVEL, REPEATABLE_READ)
+    SpannerTransactionDefinition repeatableRead = builder.with(ISOLATION_LEVEL, REPEATABLE_READ)
         .build();
     StepVerifier.create(this.connection.beginTransaction(repeatableRead))
         .expectError(UnsupportedOperationException.class)

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -32,7 +32,6 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.r2dbc.util.TestTransactionDefinition;
 import io.r2dbc.spi.Batch;
-import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.TransactionDefinition;
 import java.time.Duration;
 import java.util.List;

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -54,13 +54,13 @@ class SpannerClientLibraryConnectionTest {
   public void setUpMocks() {
     this.mockAdapter = mock(DatabaseClientReactiveAdapter.class);
     this.connection = new SpannerClientLibraryConnection(this.mockAdapter);
+
+    when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
+    when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
   }
 
   @Test
   void beginReadonlyTransactionUsesStrongConsistencyByDefault() {
-
-    when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
-
     StepVerifier.create(this.connection.beginReadonlyTransaction())
         .verifyComplete();
 
@@ -72,8 +72,6 @@ class SpannerClientLibraryConnectionTest {
     SpannerTransactionDefinition readOnlyDefinition = new SpannerTransactionDefinition.Builder()
         .with(TransactionDefinition.READ_ONLY, true)
         .build();
-
-    when(this.mockAdapter.beginReadonlyTransaction(any())).thenReturn(Mono.empty());
 
     StepVerifier.create(this.connection.beginTransaction(readOnlyDefinition))
         .verifyComplete();
@@ -87,8 +85,6 @@ class SpannerClientLibraryConnectionTest {
         .with(TransactionDefinition.READ_ONLY, false)
         .build();
 
-    when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
-
     StepVerifier.create(this.connection.beginTransaction(readWriteDefinition))
         .verifyComplete();
 
@@ -99,8 +95,6 @@ class SpannerClientLibraryConnectionTest {
   void shouldBeginTransactionInReadWriteModeByDefault() {
     SpannerTransactionDefinition readWriteDefinition = new SpannerTransactionDefinition.Builder()
         .build();   // absence of attribute indicates read write transaction
-
-    when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
 
     StepVerifier.create(this.connection.beginTransaction(readWriteDefinition))
         .verifyComplete();
@@ -117,9 +111,6 @@ class SpannerClientLibraryConnectionTest {
         .with(SpannerConstants.TIMESTAMP_BOUND, fiveSecondTimestampBound)
         .build();
 
-    when(this.mockAdapter.beginReadonlyTransaction(fiveSecondTimestampBound))
-        .thenReturn(Mono.empty());
-
     StepVerifier.create(this.connection.beginTransaction(readWriteDefinition))
         .verifyComplete();
 
@@ -128,7 +119,6 @@ class SpannerClientLibraryConnectionTest {
 
   @Test
   void shouldThrowErrorWhenBeginTransactionWithOtherThanDefaultOrSerializable() {
-    when(this.mockAdapter.beginTransaction()).thenReturn(Mono.empty());
     SpannerTransactionDefinition.Builder builder = new SpannerTransactionDefinition.Builder();
 
     // default isolation

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -171,18 +171,21 @@ class SpannerClientLibraryConnectionTest {
         .verifyComplete();
     assertThat(this.connection.getTransactionIsolationLevel()).isEqualTo(SERIALIZABLE);
 
-    StepVerifier.create(this.connection.beginTransaction(READ_COMMITTED))
+    StepVerifier.create(this.connection.setTransactionIsolationLevel(READ_COMMITTED))
         .expectError(UnsupportedOperationException.class)
         .verify();
 
-    StepVerifier.create(this.connection.beginTransaction(READ_UNCOMMITTED))
+    StepVerifier.create(this.connection.setTransactionIsolationLevel(READ_UNCOMMITTED))
         .expectError(UnsupportedOperationException.class)
         .verify();
 
-    StepVerifier.create(this.connection.beginTransaction(REPEATABLE_READ))
+    StepVerifier.create(this.connection.setTransactionIsolationLevel(REPEATABLE_READ))
         .expectError(UnsupportedOperationException.class)
         .verify();
 
+    StepVerifier.create(this.connection.setTransactionIsolationLevel(null))
+        .expectError(IllegalArgumentException.class)
+        .verify();
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.spanner.r2dbc.v2.SpannerTransactionDefinition;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.TransactionDefinition;
 import java.time.Duration;
@@ -106,12 +105,13 @@ class SpannerClientLibraryConnectionTest {
   void shouldBeginTransactionWithGivenTimestampBound() {
     TimestampBound fiveSecondTimestampBound = TimestampBound.ofExactStaleness(5L, TimeUnit.SECONDS);
 
-    SpannerTransactionDefinition readWriteDefinition = new SpannerTransactionDefinition.Builder()
-        .with(TransactionDefinition.READ_ONLY, true)
-        .with(SpannerConstants.TIMESTAMP_BOUND, fiveSecondTimestampBound)
-        .build();
+    SpannerTransactionDefinition staleTransactionDefinition =
+        new SpannerTransactionDefinition.Builder()
+            .with(TransactionDefinition.READ_ONLY, true)
+            .with(SpannerConstants.TIMESTAMP_BOUND, fiveSecondTimestampBound)
+            .build();
 
-    StepVerifier.create(this.connection.beginTransaction(readWriteDefinition))
+    StepVerifier.create(this.connection.beginTransaction(staleTransactionDefinition))
         .verifyComplete();
 
     verify(this.mockAdapter).beginReadonlyTransaction(fiveSecondTimestampBound);

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinitionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinitionTest.java
@@ -30,10 +30,15 @@ class SpannerTransactionDefinitionTest {
 
   @Test
   void shouldThrowExceptionIfTimeStampBoundIsConfiguredWithReadWriteTransaction() {
-    SpannerTransactionDefinition.Builder builder = new SpannerTransactionDefinition.Builder()
+    SpannerTransactionDefinition.Builder builder1 = new SpannerTransactionDefinition.Builder()
         .with(TIMESTAMP_BOUND, TimestampBound.ofExactStaleness(5, TimeUnit.SECONDS))
         .with(READ_ONLY, false);
 
-    assertThrows(IllegalArgumentException.class, builder::build);
+    // absence of READ_ONLY attribute indicates read write transaction
+    SpannerTransactionDefinition.Builder builder2 = new SpannerTransactionDefinition.Builder()
+        .with(TIMESTAMP_BOUND, TimestampBound.ofExactStaleness(5, TimeUnit.SECONDS));
+
+    assertThrows(IllegalArgumentException.class, builder1::build);
+    assertThrows(IllegalArgumentException.class, builder2::build);
   }
 }

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinitionTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerTransactionDefinitionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static com.google.cloud.spanner.r2dbc.v2.SpannerConstants.TIMESTAMP_BOUND;
+import static io.r2dbc.spi.TransactionDefinition.READ_ONLY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.cloud.spanner.TimestampBound;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+
+
+class SpannerTransactionDefinitionTest {
+
+  @Test
+  void shouldThrowExceptionIfTimeStampBoundIsConfiguredWithReadWriteTransaction() {
+    SpannerTransactionDefinition.Builder builder = new SpannerTransactionDefinition.Builder()
+        .with(TIMESTAMP_BOUND, TimestampBound.ofExactStaleness(5, TimeUnit.SECONDS))
+        .with(READ_ONLY, false);
+
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+}


### PR DESCRIPTION
Implemented the following classes and methods to conform to R2DBC SPI which enables supporting `@Transactional` annotation in [Spring Data Dialect](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-spanner-spring-data-r2dbc).

- `Connection#beginTransaction(TransactionDefinition)` method so that it can be used by a `TransactionManager` when `@Transactional` annotation is used. ✅
- `Connection#getTransactionIsolationLevel` returns SERIALIZABLE as it is the closest level to EXTERNAL_CONSISTENCY which spanner supports. ✅
- `Connection#setTransactionIsolationLevel(IsolationLevel)` accepts only `IsolationLevel.SERIALIZABLE` and throw `UnsupportedOperationException` otherwise. ✅
- Introduced `SpannerTransactionDefinition`, an implementation of `TransactionDefinition`(R2DBC spi) to configure the transaction attributes which will be used by `Connection#beginTransaction(TransactionDefinition)` method. ✅

Fixes #238 
