### PR TITLE
fix: rollback could return session to pool twice

### DIFF
--- a/cloud-spanner-r2dbc/pom.xml
+++ b/cloud-spanner-r2dbc/pom.xml
@@ -83,6 +83,20 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Test dependencies for a mock Spanner server -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-spanner</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProvider.java
@@ -22,7 +22,6 @@ import static com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration.FQDN
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.r2dbc.util.Assert;
@@ -68,7 +67,7 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   /**
    * Option specifying the already-instantiated credentials object.
    */
-  public static final Option<GoogleCredentials> GOOGLE_CREDENTIALS =
+  public static final Option<OAuth2Credentials> GOOGLE_CREDENTIALS =
       Option.valueOf("google_credentials");
 
   public static final Option<Boolean> AUTOCOMMIT = Option.valueOf(AUTOCOMMIT_PROPERTY_NAME);
@@ -117,7 +116,8 @@ public class SpannerConnectionFactoryProvider implements ConnectionFactoryProvid
   SpannerConnectionConfiguration createConfiguration(
       ConnectionFactoryOptions options) {
 
-    SpannerConnectionConfiguration.Builder config = new SpannerConnectionConfiguration.Builder();
+    SpannerConnectionConfiguration.Builder config =
+        new SpannerConnectionConfiguration.Builder(options);
 
     // Directly passed URL is supported for backwards compatibility. R2DBC SPI does not provide
     // the original URL when creating connection through ConnectionFactories.get(String).

--- a/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
+++ b/cloud-spanner-r2dbc/src/main/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientTransactionManager.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionManager.TransactionState;
 import com.google.cloud.spanner.r2dbc.TransactionInProgressException;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -108,7 +109,9 @@ class DatabaseClientTransactionManager {
     ApiFuture<Void> returnFuture = ApiFutures.immediateFuture(null);
 
     if (this.transactionManager != null) {
-      returnFuture = this.transactionManager.closeAsync();
+      if (this.transactionManager.getState() != TransactionState.ROLLED_BACK) {
+        returnFuture = this.transactionManager.closeAsync();
+      }
       this.transactionManager = null;
     }
 

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionConfigurationTest.java
@@ -18,21 +18,22 @@ package com.google.cloud.spanner.r2dbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration.Builder;
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /**
  * Test for {@link SpannerConnectionConfiguration}.
  */
 class SpannerConnectionConfigurationTest {
 
-  GoogleCredentials mockCredentials = Mockito.mock(GoogleCredentials.class);
+  GoogleCredentials mockCredentials = mock(GoogleCredentials.class);
 
   SpannerConnectionConfiguration.Builder configurationBuilder;
 
@@ -41,13 +42,15 @@ class SpannerConnectionConfigurationTest {
    */
   @BeforeEach
   public void setUpMockCredentials() {
-    this.configurationBuilder = new SpannerConnectionConfiguration.Builder()
+    this.configurationBuilder = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setCredentials(this.mockCredentials);
   }
 
   @Test
   void missingInstanceNameTriggersException() {
-    Builder builder = new SpannerConnectionConfiguration.Builder()
+    Builder builder = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setProjectId("project1")
         .setDatabaseName("db")
         .setCredentials(NoCredentials.getInstance());
@@ -59,7 +62,8 @@ class SpannerConnectionConfigurationTest {
 
   @Test
   void missingDatabaseNameTriggersException() {
-    Builder builder = new SpannerConnectionConfiguration.Builder()
+    Builder builder = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setProjectId("project1")
         .setInstanceName("an-instance")
         .setCredentials(NoCredentials.getInstance());
@@ -71,7 +75,8 @@ class SpannerConnectionConfigurationTest {
 
   @Test
   void missingProjectIdTriggersException() {
-    Builder builder = new SpannerConnectionConfiguration.Builder()
+    Builder builder = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setInstanceName("an-instance")
         .setDatabaseName("db")
         .setCredentials(NoCredentials.getInstance());

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/SpannerConnectionFactoryProviderTest.java
@@ -48,11 +48,13 @@ import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.StructType.Field;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeCode;
+import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 /**
  * Unit test for {@link SpannerConnectionFactoryProvider}.
@@ -101,6 +103,8 @@ class SpannerConnectionFactoryProviderTest {
         this.spannerConnectionFactoryProvider.create(SPANNER_OPTIONS);
     assertThat(spannerConnectionFactory).isNotNull();
     assertThat(spannerConnectionFactory).isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+
+    Flux.from(((Closeable) spannerConnectionFactory).close()).blockLast();
   }
 
   @Test
@@ -111,6 +115,8 @@ class SpannerConnectionFactoryProviderTest {
     assertThat(spannerConnectionFactory)
         .isNotNull()
         .isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+
+    Flux.from(((Closeable) spannerConnectionFactory).close()).blockLast();
   }
 
   @Test
@@ -121,6 +127,8 @@ class SpannerConnectionFactoryProviderTest {
     assertThat(spannerConnectionFactory)
         .isNotNull()
         .isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+
+    Flux.from(((Closeable) spannerConnectionFactory).close()).blockLast();
   }
 
   @Test
@@ -138,6 +146,8 @@ class SpannerConnectionFactoryProviderTest {
     assertThat(spannerConnectionFactory)
         .isNotNull()
         .isInstanceOf(SpannerClientLibraryConnectionFactory.class);
+
+    Flux.from(((Closeable) spannerConnectionFactory).close()).blockLast();
   }
 
   @Test

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/DatabaseClientReactiveAdapterTest.java
@@ -45,6 +45,7 @@ import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
@@ -74,7 +75,7 @@ class DatabaseClientReactiveAdapterTest {
   @BeforeEach
   void setup() throws Exception {
     this.config =
-        new SpannerConnectionConfiguration.Builder()
+        new SpannerConnectionConfiguration.Builder(mock(ConnectionFactoryOptions.class))
             .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
             .setCredentials(mock(GoogleCredentials.class))
             .build();
@@ -148,7 +149,8 @@ class DatabaseClientReactiveAdapterTest {
 
   @Test
   void unsetQueryOptimizerResultsInDefaultQueryOptions() {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
         .setCredentials(mock(GoogleCredentials.class))
         .build();
@@ -160,7 +162,8 @@ class DatabaseClientReactiveAdapterTest {
 
   @Test
   void queryOptimizerPropagatesToQueryOptions() {
-    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder()
+    SpannerConnectionConfiguration config = new SpannerConnectionConfiguration.Builder(
+        mock(ConnectionFactoryOptions.class))
         .setFullyQualifiedDatabaseName("projects/p/instances/i/databases/d")
         .setCredentials(mock(GoogleCredentials.class))
         .setOptimizerVersion("2")

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/MockServerTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/MockServerTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2021-2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.r2dbc.v2;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryProvider;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.RollbackRequest;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.Type;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.r2dbc.spi.Closeable;
+import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** End-to-end tests that run against an in-memory mock Spanner server. */
+public class MockServerTest {
+
+  private static Server server;
+  private static MockSpannerServiceImpl mockSpanner;
+
+  @BeforeAll
+  static void setupMockSpanner() throws Exception {
+    // Create a mock Spanner service and add a simple query result.
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0);
+    mockSpanner.putStatementResult(
+        StatementResult.query(Statement.of("SELECT 1 AS C"),
+        ResultSet.newBuilder()
+            .setMetadata(ResultSetMetadata
+                .newBuilder()
+                .setRowType(
+                    StructType.newBuilder().addFields(
+                        Field.newBuilder()
+                            .setName("C")
+                            .setType(Type.newBuilder().setCode(TypeCode.INT64).build())
+                            .build()).build())
+            .build())
+            .addRows(
+                ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("1").build())
+                    .build())
+            .build()));
+
+    // Start an in-memory gRPC server and add the Spanner service.
+    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    server = NettyServerBuilder.forAddress(address).addService(mockSpanner).build().start();
+  }
+
+  @AfterAll
+  static void teardownMockSpanner() throws Exception {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @AfterEach
+  void resetMockSpanner() {
+    mockSpanner.reset();
+  }
+
+  ConnectionFactory createConnectionFactory() {
+    ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+        .option(DRIVER, "cloudspanner")
+        .option(SpannerConnectionFactoryProvider.PROJECT, "p")
+        .option(SpannerConnectionFactoryProvider.INSTANCE, "i")
+        .option(ConnectionFactoryOptions.DATABASE, "d")
+        .option(ConnectionFactoryOptions.HOST, "localhost")
+        .option(ConnectionFactoryOptions.PORT, server.getPort())
+        .option(SpannerConnectionFactoryProvider.GOOGLE_CREDENTIALS, NoCredentials.getInstance())
+        .option(SpannerConnectionFactoryProvider.USE_PLAIN_TEXT, true).build();
+    return ConnectionFactories.get(options);
+  }
+
+  @Test
+  void testSimpleQuery() {
+    ConnectionFactory connectionFactory = createConnectionFactory();
+    Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+    Connection connection = Mono.from(connectionPublisher).block();
+
+    List<String> results = Flux.from(connection.createStatement("SELECT 1 AS C").execute())
+        .flatMap(spannerResult -> spannerResult.map(this::describeRow))
+        .collectList().block();
+    assertNotNull(results);
+    assertEquals(1, results.size());
+    String row = results.get(0);
+    assertEquals("{\n" + "\t\"C\": 1,\n" + "}", row);
+
+    Mono.from(((Closeable) connectionFactory).close()).subscribe();
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertFalse(request.hasTransaction());
+  }
+
+  @Test
+  public void testSimpleTransaction() {
+    String sql = "insert into foo (id) values (1)";
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+    ConnectionFactory connectionFactory = createConnectionFactory();
+    Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+    Connection connection = Mono.from(connectionPublisher).block();
+
+    Flux.concat(
+        connection.beginTransaction(),
+        connection.createStatement(sql).execute(),
+        connection.commitTransaction())
+        .blockLast();
+
+    Mono.from(((Closeable) connectionFactory).close()).subscribe();
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.hasTransaction());
+    assertTrue(request.getTransaction().hasBegin());
+    assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testTwoTransactions() {
+    String sql = "insert into foo (id) values (1)";
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+    ConnectionFactory connectionFactory = createConnectionFactory();
+    Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+    Connection connection = Mono.from(connectionPublisher).block();
+
+    Flux.concat(connection.beginTransaction(), connection.createStatement(sql).execute(),
+        connection.commitTransaction(), connection.beginTransaction(),
+        connection.createStatement(sql).execute(), connection.commitTransaction()).blockLast();
+
+    Mono.from(((Closeable) connectionFactory).close()).subscribe();
+
+    assertEquals(2, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    for (ExecuteSqlRequest request : mockSpanner.getRequestsOfType(ExecuteSqlRequest.class)) {
+      assertTrue(request.hasTransaction());
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    }
+    assertEquals(2, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRollbackEmptyTransaction() {
+    String sql = "insert into foo (id) values (1)";
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+    ConnectionFactory connectionFactory = createConnectionFactory();
+    Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+    Connection connection = Mono.from(connectionPublisher).block();
+
+    Flux.concat(connection.beginTransaction(), connection.rollbackTransaction(),
+        connection.beginTransaction(), connection.createStatement(sql).execute(),
+        connection.commitTransaction()).blockLast();
+
+    Mono.from(((Closeable) connectionFactory).close()).subscribe();
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    for (ExecuteSqlRequest request : mockSpanner.getRequestsOfType(ExecuteSqlRequest.class)) {
+      assertTrue(request.hasTransaction());
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    }
+    // Rolling back an empty transaction is a no-op and should not lead to a request on Spanner.
+    assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
+    assertEquals(1, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRollbackTransaction() {
+    String sql = "insert into foo (id) values (1)";
+    mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+    ConnectionFactory connectionFactory = createConnectionFactory();
+    Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
+    Connection connection = Mono.from(connectionPublisher).block();
+
+    Flux.concat(connection.beginTransaction(), connection.createStatement(sql).execute(),
+        connection.rollbackTransaction()).blockLast();
+
+    Mono.from(((Closeable) connectionFactory).close()).subscribe();
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    for (ExecuteSqlRequest request : mockSpanner.getRequestsOfType(ExecuteSqlRequest.class)) {
+      assertTrue(request.hasTransaction());
+      assertTrue(request.getTransaction().hasBegin());
+      assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    }
+    assertEquals(1, mockSpanner.countRequestsOfType(RollbackRequest.class));
+    assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testRollbackEmptyTransactionAndExecuteSqlInParallel() throws Exception {
+    // Redirect log to /dev/null.
+    PrintStream err = System.err;
+    System.setErr(new PrintStream(new OutputStream() {
+      @Override
+      public void write(int b) throws IOException {
+        // do nothing
+      }
+    }));
+    try {
+      String sql = "insert into foo (id) values (1)";
+      mockSpanner.putStatementResult(StatementResult.update(Statement.of(sql), 1L));
+
+      ConnectionFactory connectionFactory = createConnectionFactory();
+      Publisher<? extends Connection> connectionPublisher1 = connectionFactory.create();
+      Connection connection1 = Mono.from(connectionPublisher1).block();
+      Publisher<? extends Connection> connectionPublisher2 = connectionFactory.create();
+      Connection connection2 = Mono.from(connectionPublisher2).block();
+
+      int n = 100;
+      ExecutorService rollbackService = Executors.newSingleThreadExecutor();
+      ExecutorService queryService = Executors.newSingleThreadExecutor();
+      Future<?> rollbackFuture = rollbackService.submit(() -> {
+        repeat(n, () -> {
+          Flux.concat(connection1.beginTransaction(), connection1.rollbackTransaction())
+              .blockLast();
+        });
+      });
+      Future<?> queryFuture = queryService.submit(() -> {
+        repeat(n, () -> {
+          Flux.concat(connection2.createStatement(sql).execute()).blockLast();
+        });
+      });
+      rollbackFuture.get();
+      queryFuture.get();
+
+      Mono.from(((Closeable) connectionFactory).close()).block();
+
+      assertEquals(n, mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
+          .filter(request -> request.getSql().equals(sql)).count());
+      // Rolling back an empty transaction is a no-op and should not lead to a request on Spanner.
+      assertEquals(0, mockSpanner.countRequestsOfType(RollbackRequest.class));
+      // Each of the DML statements should be committed.
+      assertEquals(n, mockSpanner.countRequestsOfType(CommitRequest.class));
+    } finally {
+      System.setErr(err);
+    }
+  }
+
+  String describeRow(Row row, RowMetadata meta) {
+    StringBuilder result = new StringBuilder("{\n");
+    for (ColumnMetadata col : meta.getColumnMetadatas()) {
+      result.append('\t').append('"').append(col.getName()).append('"').append(':').append(' ');
+      result.append(row.get(col.getName())).append(',').append('\n');
+    }
+    result.append('}');
+    return result.toString();
+  }
+
+  static void repeat(int n, Runnable action) {
+    for (int i = 0; i < n; i++) {
+      action.run();
+    }
+  }
+}

--- a/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
+++ b/cloud-spanner-r2dbc/src/test/java/com/google/cloud/spanner/r2dbc/v2/SpannerClientLibraryConnectionFactoryTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionConfiguration;
 import com.google.cloud.spanner.r2dbc.SpannerConnectionFactoryMetadata;
 import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -35,7 +36,7 @@ import reactor.test.StepVerifier;
 class SpannerClientLibraryConnectionFactoryTest {
 
   SpannerConnectionConfiguration.Builder configBuilder =
-      new SpannerConnectionConfiguration.Builder()
+      new SpannerConnectionConfiguration.Builder(mock(ConnectionFactoryOptions.class))
         .setProjectId("test-project")
         .setInstanceName("test-instance")
         .setDatabaseName("test-database")


### PR DESCRIPTION
Transaction rollbacks could cause a session to be added to the session pool twice. This again could cause two transactions to try to use the same session at the same time, which again could lead to unpredictable errors.