### PR TITLE
chore: skip nexus-staging-maven-plugin for central portal migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,17 +226,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.13</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.1</version>
@@ -331,11 +320,6 @@
         </executions>
 
       </plugin>
-
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
@@ -344,6 +328,56 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <property>
+          <!-- Only when we use the release-gcp-artifact-registry profile,
+          which comes with artifact-registry-url property, this profile is
+          turned off. -->
+          <name>!artifact-registry-url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>sonatype-nexus-staging</serverId>
+              <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <properties>
+        <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
 
     <profile>
       <id>default</id>


### PR DESCRIPTION
Verified with ` mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer`:
```
[INFO] Installing /usr/local/google/home/mpeddada/IdeaProjects/cloud-spanner-r2dbc/cloud-spanner-r2dbc/pom.xml to /usr/local/google/home/mpeddada/.m2/repository/com/google/cloud/cloud-spanner-r2dbc/1.4.1/cloud-spanner-r2dbc-1.4.1.pom
[INFO] 
[INFO] --- maven-deploy-plugin:3.1.1:deploy (default-deploy) @ cloud-spanner-r2dbc ---
[INFO] Using alternate deployment repository local::default::file:/tmp/maven-staging-dir.rK6dRI
[WARNING] Using legacy syntax for alternative repository. Use "local::file:/tmp/maven-staging-dir.rK6dRI" instead.
Uploading to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/1.4.1/cloud-spanner-r2dbc-1.4.1.pom
Uploaded to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/1.4.1/cloud-spanner-r2dbc-1.4.1.pom (4.5 kB at 497 kB/s)
Uploading to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/1.4.1/cloud-spanner-r2dbc-1.4.1.jar
Uploaded to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/1.4.1/cloud-spanner-r2dbc-1.4.1.jar (83 kB at 10 MB/s)
Downloading from local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/maven-metadata.xml
Downloaded from local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/maven-metadata.xml (315 B at 29 kB/s)
Uploading to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/maven-metadata.xml
Uploaded to local: file:/tmp/maven-staging-dir.rK6dRI/com/google/cloud/cloud-spanner-r2dbc/maven-metadata.xml (315 B at 315 kB/s)

```