### PR TITLE
build: update integration tests to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   integrationTests:
     if: github.repository == 'GoogleCloudPlatform/cloud-spanner-r2dbc'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/ shows that ubuntu-20.x was taken down since April 15, which is the date the jobs started failing due to missing runner:

<img width="1289" height="609" alt="image" src="https://github.com/user-attachments/assets/570ae72b-e907-40cf-b827-ddfcb589e43e" />
